### PR TITLE
Add support for certbot --dry-run

### DIFF
--- a/letsencrypt/DOCS.md
+++ b/letsencrypt/DOCS.md
@@ -135,6 +135,21 @@ dns:
   cloudflare_api_key: 31242lk3j4ljlfdwsjf0
 ```
 
+### Staging Environment
+
+Let's Encrypt includes a number of [rate limits](https://letsencrypt.org/docs/rate-limits/) which you might run into - for example, if you fail validation too many times in a row, or request too many duplicate certificates. If you hit one of these limts, there's no way to reset it - you'll have to wait anywhere from an hour to a week to get things moving again. To help avoid that, Let's Encrypt offers a [staging environment](https://letsencrypt.org/docs/staging-environment/) for testing purposes. You can target this environment by adding an "environment: staging" entry to your yaml; we recommend this when you're getting started, especially if things don't work on your first attempt.
+
+```yaml
+email: your.email@example.com
+domains:
+  - home-assistant.io
+certfile: fullchain.pem
+keyfile: privkey.pem
+challenge: http
+dns: {}
+environment: staging
+```
+
 ### google dns challenge
 
 ```yaml

--- a/letsencrypt/config.json
+++ b/letsencrypt/config.json
@@ -21,6 +21,7 @@
     "certfile": "fullchain.pem",
     "keyfile": "privkey.pem",
     "challenge": "http",
+    "environment": "production",
     "dns": {}
   },
   "schema": {
@@ -29,6 +30,7 @@
     "certfile": "str",
     "keyfile": "str",
     "challenge": "list(dns|http)",
+    "environment": "list(staging|production)",
     "acme_server": "url?",
     "acme_root_ca_cert": "str?",
     "dns": {

--- a/letsencrypt/rootfs/etc/services.d/lets-encrypt/run
+++ b/letsencrypt/rootfs/etc/services.d/lets-encrypt/run
@@ -21,6 +21,7 @@ ACME_ROOT_CA=$(bashio::config 'acme_root_ca_cert')
 CERTBOT_ARGUMENTS+=("--non-interactive" "--keep-until-expiring" "--expand" "--agree-tos")
 CERTBOT_ARGUMENTS+=("--config-dir" "$CERT_DIR" "--work-dir" "$WORK_DIR")
 CERTBOT_ARGUMENTS+=("--preferred-challenges" "$CHALLENGE")
+CERTBOT_ARGUMENTS+=("--email" "$EMAIL")
 
 if [ "${ENVIRONMENT}" == "staging" ]; then
     CERTBOT_ARGUMENTS+=("--dry-run")

--- a/letsencrypt/rootfs/etc/services.d/lets-encrypt/run
+++ b/letsencrypt/rootfs/etc/services.d/lets-encrypt/run
@@ -4,6 +4,7 @@
 # ==============================================================================
 CERT_DIR=/data/letsencrypt
 WORK_DIR=/data/workdir
+CERTBOT_ARGUMENTS=()
 PROVIDER_ARGUMENTS=()
 ACME_CUSTOM_SERVER_ARGUMENTS=()
 
@@ -12,9 +13,21 @@ DOMAINS=$(bashio::config 'domains')
 KEYFILE=$(bashio::config 'keyfile')
 CERTFILE=$(bashio::config 'certfile')
 CHALLENGE=$(bashio::config 'challenge')
+ENVIRONMENT=$(bashio::config 'environment')
 DNS_PROVIDER=$(bashio::config 'dns.provider')
 ACME_SERVER=$(bashio::config 'acme_server')
 ACME_ROOT_CA=$(bashio::config 'acme_root_ca_cert')
+
+CERTBOT_ARGUMENTS+=("--non-interactive" "--keep-until-expiring" "--expand" "--agree-tos")
+CERTBOT_ARGUMENTS+=("--config-dir" "$CERT_DIR" "--work-dir" "$WORK_DIR")
+CERTBOT_ARGUMENTS+=("--preferred-challenges" "$CHALLENGE")
+
+if [ "${ENVIRONMENT}" == "staging" ]; then
+    CERTBOT_ARGUMENTS+=("--dry-run")
+    bashio::log.info "Targeting staging environment"
+else
+    bashio::log.info "Targeting production environment"
+fi
 
 if [ "${CHALLENGE}" == "dns" ]; then
     bashio::log.info "Selected DNS Provider: ${DNS_PROVIDER}"
@@ -115,15 +128,9 @@ echo "$DOMAINS" > /data/domains.gen
 
 # Generate a new certificate if necessary or expand a previous certificate if domains has changed
 if [ "$CHALLENGE" == "dns" ]; then
-    certbot certonly --non-interactive --keep-until-expiring --expand \
-        --email "$EMAIL" --agree-tos \
-        --config-dir "$CERT_DIR" --work-dir "$WORK_DIR" \
-        --preferred-challenges "$CHALLENGE" "${DOMAIN_ARR[@]}" "${PROVIDER_ARGUMENTS[@]}"
+    certbot certonly "${CERTBOT_ARGUMENTS[@]}" "${DOMAIN_ARR[@]}" "${PROVIDER_ARGUMENTS[@]}"
 else
-    certbot certonly --non-interactive --keep-until-expiring --expand \
-        --email "$EMAIL" --agree-tos \
-        --config-dir "$CERT_DIR" --work-dir "$WORK_DIR" \
-        --preferred-challenges "$CHALLENGE" "${DOMAIN_ARR[@]}" "${ACME_CUSTOM_SERVER_ARGUMENTS[@]}" --standalone
+    certbot certonly "${CERTBOT_ARGUMENTS[@]}" "${DOMAIN_ARR[@]}" "${ACME_CUSTOM_SERVER_ARGUMENTS[@]}" --standalone
 fi
 
 # Get the last modified cert directory and copy the cert and private key to store


### PR DESCRIPTION
Added support for (and documented) --dry-run.

Tweaked the final cerbot invocation to refer to a master set of certbot_arguments to reduce duplication on args like --agree-tos, but happy to drop that bit if you liked it more how it was. Will add to change log and increment version number if this looks acceptable.

Still learning my way around git, thanks for your patience :) 