### PR TITLE
SSH: Add git-perl to have git-add--interactive available

### DIFF
--- a/ssh/Dockerfile
+++ b/ssh/Dockerfile
@@ -20,6 +20,7 @@ RUN \
         alsa-plugins-pulse \
         bluez \
         git \
+        git-perl \
         libuv \
         mosquitto-clients \
         nano \


### PR DESCRIPTION
I tend to use `git add -p` and this is only included in git-perl

Also see https://pkgs.alpinelinux.org/contents?branch=edge&name=git-perl&arch=armhf&repo=main
