### PR TITLE
Add note about ACL for anonymous connections

### DIFF
--- a/mosquitto/DOCS.md
+++ b/mosquitto/DOCS.md
@@ -54,7 +54,7 @@ logins:
 
 ### Option: `anonymous`
 
-Allow anonymous connections. If logins are set, the anonymous user can only read data. Since version 4.1 of the add-on, an explicit ACL definition is required for anonymous connections [see these instructions](#access-control-lists-acls).
+Allow anonymous connections. If logins are set, the anonymous user can only read data. An explicit ACL definition is required for anonymous connections [see Access Control Lists (ACLs)](#access-control-lists-acls).
 
 Default value: `false`
 

--- a/mosquitto/DOCS.md
+++ b/mosquitto/DOCS.md
@@ -54,7 +54,7 @@ logins:
 
 ### Option: `anonymous`
 
-Allow anonymous connections. If logins are set, the anonymous user can only read data.
+Allow anonymous connections. If logins are set, the anonymous user can only read data. Since version 4.1 of the add-on, an explicit ACL definition is required for anonymous connections [see these instructions](#access-control-lists-acls).
 
 Default value: `false`
 


### PR DESCRIPTION
Added ACL requirement at anonymous description (in addition to 'Known issues and limitations').

New users (e.g. myself) do not read the complete documenation bevor they start using the add-on. If you do not read the docu till the bottom, you don't know that ACL is required for anonymous connections. 