### PR TITLE
OpenZWave 0.6.1

### DIFF
--- a/zwave/CHANGELOG.md
+++ b/zwave/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.6.1
+
+- Fix novnc "missing vnc_lite.html" build issue.
+- Map /config folder.
+- Make config-dir and user-dir configurable.
+
 ## 0.5.2
 
 - Rollback the docker image to 0.5.2.

--- a/zwave/DOCS.md
+++ b/zwave/DOCS.md
@@ -94,6 +94,24 @@ The instance ID defaults to `1`, which is generally fine to keep and use.
 Only change this in case you are using multiple instances on the same MQTT
 server.
 
+### Option `config_dir` (optional)
+
+Set the path to the Device Database.
+
+To tweak configs in Device Database, or to test new configs, set to a directory under `/config`. 
+The latest Device Database will be automatically fetched to this directory by ozwdaemon.
+
+Defaults to `/data/ozw/config`
+
+### Option `user_dir` (optional)
+
+Change the path where Network Specific Cache/Config Files are stored.
+
+Set to a path under `/config` to make the Cache/Config files persistant and editable.
+This is helpful to tweak ozwcache_*.xml and to save node name persistantly (if the device doesn't support node name).
+
+Defaults to `/data/ozw/config`
+
 ## Accessing the ozw-admin application
 
 The add-on allows you to access the underlying ozw-admin application running

--- a/zwave/Dockerfile
+++ b/zwave/Dockerfile
@@ -88,9 +88,9 @@ RUN \
     && git clone --depth 1 -b \
         v${NOVNC_VERSION} https://github.com/novnc/noVNC \
     && cd noVNC \
-    && mkdir -p /usr/share/noVNC \
+    && mkdir -p /usr/share/novnc \
     && rm -rf .git utils \
-    && cp -rf ./* /usr/share/noVNC/ \
+    && cp -rf ./* /usr/share/novnc/ \
     \
     && git clone --depth 1 -b \
         v${WEBSOCKIFY_VERSION} https://github.com/novnc/websockify \

--- a/zwave/config.json
+++ b/zwave/config.json
@@ -1,6 +1,6 @@
 {
   "name": "OpenZWave",
-  "version": "0.5.2",
+  "version": "0.6.1",
   "slug": "zwave",
   "description": "Control a ZWave network with Home Assistant",
   "arch": ["amd64", "i386", "armhf", "armv7", "aarch64"],
@@ -22,6 +22,7 @@
     "1983/tcp": "ozw-admin port",
     "5900/tcp": "VNC port"
   },
+  "map": ["config:rw"],
   "services": ["mqtt:want"],
   "discovery": ["ozw"],
   "auto_uart": true,
@@ -36,6 +37,8 @@
   "schema": {
     "device": "str",
     "network_key": "password",
+    "config_dir": "str?",
+    "user_dir": "str?",
     "instance": "int(1,)?"
   },
   "image": "homeassistant/{arch}-addon-zwave"

--- a/zwave/rootfs/etc/services.d/zwave/run
+++ b/zwave/rootfs/etc/services.d/zwave/run
@@ -10,6 +10,7 @@ export OZW_NETWORK_KEY
 
 MQTT_PASSWORD="$(bashio::jq /data/auth.json '.ozw_password')"
 OZW_CONFIG=/data/ozw/config
+OZW_USER=/data/ozw/config
 OZW_DEVICE=$(bashio::config 'device')
 OZW_INSTANCE=1
 OZW_NETWORK_KEY=$(bashio::config 'network_key')
@@ -17,6 +18,14 @@ OZW_NETWORK_KEY=$(bashio::config 'network_key')
 # Set custom instance ID if configured
 if bashio::config.has_value 'instance'; then
     OZW_INSTANCE=$(bashio::config 'instance')
+fi
+
+# Set custom config_dir and user_dir
+if bashio::config.has_value 'config_dir'; then
+    OZW_CONFIG=$(bashio::config 'config_dir')
+fi
+if bashio::config.has_value 'user_dir'; then
+    OZW_USER=$(bashio::config 'user_dir')
 fi
 
 # Wait until mosqitto is up and running
@@ -37,7 +46,7 @@ cd /data/ozw || bashio::exit.nok "Could not change to OZW working directory"
 exec ozwdaemon \
     -s "${OZW_DEVICE}" \
     --config-dir "${OZW_CONFIG}" \
-    --user-dir "${OZW_CONFIG}" \
+    --user-dir "${OZW_USER}" \
     --mqtt-server 127.0.0.1 \
     --mqtt-port 1883 \
     --mqtt-username ozw \


### PR DESCRIPTION
* Fix novnc "missing vnc_lite.html" build issue on 0.6.0.
* Map /config folder.
* Make config-dir and user-dir configurable.