### PR TITLE
MQTT documentation: clarifying write access for anonymous users

### DIFF
--- a/mosquitto/DOCS.md
+++ b/mosquitto/DOCS.md
@@ -57,7 +57,7 @@ logins:
 
 ### Option: `anonymous`
 
-Allow anonymous connections. If logins are set, the anonymous user can only read data.
+Allow anonymous connections. The anonymous user can only read data. To enable anonymous users with write access [see these instructions](#access-control-lists-acls)
 
 Default value: `false`
 


### PR DESCRIPTION
I've had issues with enabling mqtt for a device. From the current documentation I understood, that anonymous: true should be enough, since I didn't specify any logins