### PR TITLE
SSH: Add persistent TMUX settings.

### DIFF
--- a/ssh/rootfs/etc/cont-init.d/profile.sh
+++ b/ssh/rootfs/etc/cont-init.d/profile.sh
@@ -9,6 +9,14 @@ touch /data/.bash_history
 chmod 600 /data/.bash_history
 ln -s -f /data/.bash_history /root/.bash_history
 
+# Persist tmux configuration by redirecting .tmux.conf to /data
+if ! bashio::fs.file_exists /data/.tmux.conf; then
+    cp /root/.tmux.conf /data/.tmux.conf \
+	|| bashio::exit.nok 'Failed to create .tmux.conf file'
+
+fi
+ln -s -f /data/.tmux.conf /root/.tmux.conf
+
 # Make Home Assistant TOKEN available on the CLI
 echo "export SUPERVISOR_TOKEN=${SUPERVISOR_TOKEN}" >> /etc/profile.d/homeassistant.sh
 


### PR DESCRIPTION
Updated profile.sh to copy the default .tmux.conf to the /data directory and then create a symbolic link to it at /root. This allows changes to TMUX bindings and other settings to be persistent across reboots.