### PR TITLE
ssh: Upgrades Home Assistant CLI to v4.9.0

### DIFF
--- a/ssh/CHANGELOG.md
+++ b/ssh/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 8.10.0
+
+- Update Home Assistant CLI to 4.9.0
+
 ## 8.9.1
 
 - Fix bluez package

--- a/ssh/build.json
+++ b/ssh/build.json
@@ -7,7 +7,7 @@
     "i386": "homeassistant/i386-base:3.12"
   },
   "args": {
-    "CLI_VERSION": "4.5.0",
+    "CLI_VERSION": "4.9.0",
     "LIBWEBSOCKETS_VERSION": "v3.2.2",
     "TTYD_VERSION": "1.6.0"
   }

--- a/ssh/config.json
+++ b/ssh/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Terminal & SSH",
-  "version": "8.9.1",
+  "version": "8.10.0",
   "slug": "ssh",
   "description": "Allow logging in remotely to Home Assistant using SSH",
   "url": "https://github.com/home-assistant/hassio-addons/tree/master/ssh",


### PR DESCRIPTION
Release notes:

<https://github.com/home-assistant/cli/releases/tag/4.9.0>