### PR TITLE
Docs: update CloudFlare token permissions

### DIFF
--- a/letsencrypt/DOCS.md
+++ b/letsencrypt/DOCS.md
@@ -207,8 +207,7 @@ For security reasons, don't use your main account's credentials. Instead, add a 
 Previously, Cloudflare’s “Global API Key” was used for authentication, however this key can access the entire Cloudflare API for all domains in your account, meaning it could cause a lot of damage if leaked.
 
 Cloudflare’s newer API Tokens can be restricted to specific domains and operations, and are therefore now the recommended authentication option.
-
-However, due to some shortcomings in Cloudflare’s implementation of Tokens, Tokens created for Certbot currently require `Zone:Zone:Read` and `Zone:DNS:Edit` permissions for all zones in your account.
+The API Token used for Certbot requires only the `Zone:DNS:Edit` permission for the zone in which you want a certificate.
 
 Example credentials file using restricted API Token (recommended):
 ```yaml


### PR DESCRIPTION
CloudFlare has improved its API, and as of [Certbot 1.6.0][1] (2020-07-07),
Certbot no longer requires permissions on all zones in your CloudFlare account.
(See PR certbot/certbot#8015.)

Verified in Let's Encrypt Add-on 4.11.0 running in Home Assistant 0.118.4.

[1]: https://github.com/certbot/certbot/releases/tag/v1.6.0