### PR TITLE
[homematic] Add troubleshoot coprocessor firmware to docs

### DIFF
--- a/homematic/DOCS.md
+++ b/homematic/DOCS.md
@@ -132,6 +132,21 @@ configuration. If you installed Hassio on another distribution of Linux, you nee
 follow the installation guide for the UART USB to setup the UART USB interface on
 your computer.
 
+## BidCos Errors / Coming from raspmatic/pivccu ?
+
+It is recommended to flash the HM-MOD-RPI-PCB again as raspmatic uses a modified firmware as far as we know.
+This causes strange issues with BidCos init
+The logs look simmilar to:
+- CCU2CoprocessorCommand::CCU2CoprocessorCommand(): Message too small: 2 byte
+- CCU2CommController::handleIncomingSerialFrame(): Command not parseable. 
+- CCU2CommController::waitForCoProcessorResponse(): Timeout while waiting for response.
+- <Error> No BidCoS-Interface available
+  
+If you have those kind of issues and your module was never used with raspmatic you can try this anyway.
+  
+To flash the coprocessor firmware one can e.g follow this guide(works from within hassos):
+https://gist.github.com/FloThinksPi/a2cc6e0e8d106ca9e6378c8c6c61ee67
+
 ## Support
 
 Got questions?


### PR DESCRIPTION
Add a section to docs with errors related to a custom HM-MOD-RPI-PCB firmware version.
In this case one needs to flash firmware from occu otherwise one gets strange errors in logs.
This e.g. happens when having used the HM-MOD-RPI-PCB before on e.g. raspmatic.