### PR TITLE
nginx_proxy: Add a new "listen_parameters" config option

### DIFF
--- a/nginx_proxy/DOCS.md
+++ b/nginx_proxy/DOCS.md
@@ -33,6 +33,7 @@ domain: home.example.com
 certfile: fullchain.pem
 keyfile: privkey.pem
 hsts: "max-age=31536000; includeSubDomains"
+listen_parameters: http2
 customize:
   active: false
   default: "nginx_proxy_default*.conf"
@@ -55,6 +56,10 @@ Private key file to use in the `/ssl` directory.
 ### Option: `hsts` (required)
 
 Value for the [`Strict-Transport-Security`][hsts] HTTP header to send. If empty, the header is not sent.
+
+### Option `listen_parameters` (required)
+
+Additional `listen` parameters for secured connections (ssl, port 443). Default value is `http2`.
 
 ### Option `customize.active` (required)
 

--- a/nginx_proxy/config.json
+++ b/nginx_proxy/config.json
@@ -18,6 +18,7 @@
     "keyfile": "privkey.pem",
     "hsts": "max-age=31536000; includeSubDomains",
     "cloudflare": false,
+    "listen_parameters": "http2",
     "customize": {
       "active": false,
       "default": "nginx_proxy_default*.conf",
@@ -30,6 +31,7 @@
     "keyfile": "str",
     "hsts": "str",
     "cloudflare": "bool",
+    "listen_parameters": "str",
     "customize": {
       "active": "bool",
       "default": "str",

--- a/nginx_proxy/data/nginx.conf
+++ b/nginx_proxy/data/nginx.conf
@@ -45,7 +45,7 @@ http {
         # dhparams file
         ssl_dhparam /data/dhparams.pem;
 
-        listen 443 ssl http2;
+        listen 443 ssl %%LISTEN_PARAMETERS%%;
         %%HSTS%%
         
         # intermediate configuration

--- a/nginx_proxy/data/run.sh
+++ b/nginx_proxy/data/run.sh
@@ -12,6 +12,7 @@ DOMAIN=$(bashio::config 'domain')
 KEYFILE=$(bashio::config 'keyfile')
 CERTFILE=$(bashio::config 'certfile')
 HSTS=$(bashio::config 'hsts')
+LISTEN_PARAMETERS=$(bashio::config 'listen_parameters')
 
 # Generate dhparams
 if ! bashio::fs.file_exists "${DHPARAMS_PATH}"; then
@@ -52,6 +53,7 @@ fi
 sed -i "s#%%FULLCHAIN%%#$CERTFILE#g" /etc/nginx.conf
 sed -i "s#%%PRIVKEY%%#$KEYFILE#g" /etc/nginx.conf
 sed -i "s/%%DOMAIN%%/$DOMAIN/g" /etc/nginx.conf
+sed -i "s/%%LISTEN_PARAMETERS%%/$LISTEN_PARAMETERS/g" /etc/nginx.conf
 
 [ -n "$HSTS" ] && HSTS="add_header Strict-Transport-Security \"$HSTS\" always;"
 sed -i "s/%%HSTS%%/$HSTS/g" /etc/nginx.conf


### PR DESCRIPTION
This new config option allows to change the default `listen` arguments
used in nginx configuration. In particular, this allows to use the
`proxy_protocol` to retrieve the end-user IP address (along with a
config file stored into a `customize.default` file).
Default options are not changed by this commit.

I made this change generic, but it would also make sense to add a `proxy_protocol` config option directly. Discussion is open :-)