### PR TITLE
Fix snapshot exclude

### DIFF
--- a/deconz/CHANGELOG.md
+++ b/deconz/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.6.2
+
+- Fixes issues where the `otau` directory was not excluded from snapshots
+
 ## 6.6.1
 
 - Small cleanup with s6-overlay

--- a/deconz/config.json
+++ b/deconz/config.json
@@ -30,7 +30,7 @@
   "apparmor": false,
   "privileged": ["SYS_MODULE", "SYS_RAWIO"],
   "devices": ["/dev/bus/usb:/dev/bus/usb:rwm", "/dev/mem:/dev/mem:rw"],
-  "snapshot_exclude": ["/data/otau"],
+  "snapshot_exclude": ["*/otau"],
   "options": {
     "device": null
   },

--- a/deconz/config.json
+++ b/deconz/config.json
@@ -30,7 +30,7 @@
   "apparmor": false,
   "privileged": ["SYS_MODULE", "SYS_RAWIO"],
   "devices": ["/dev/bus/usb:/dev/bus/usb:rwm", "/dev/mem:/dev/mem:rw"],
-  "snapshot_exclude": ["/data/otau/*"],
+  "snapshot_exclude": ["/data/otau"],
   "options": {
     "device": null
   },

--- a/deconz/config.json
+++ b/deconz/config.json
@@ -1,6 +1,6 @@
 {
   "name": "deCONZ",
-  "version": "6.6.1",
+  "version": "6.6.2",
   "slug": "deconz",
   "description": "Control a Zigbee network with ConBee or RaspBee by Dresden Elektronik",
   "arch": ["amd64", "armhf", "aarch64"],


### PR DESCRIPTION
```python
import os
from supervisor.utils.tar import atomic_contents_add, SecureTarFile


def test_snapshot_exclude(tmp_path):
    """Test atomic_contents_add."""
    os.makedirs(f"{tmp_path}/data/otau/")
    with open(f"{tmp_path}/data/otau/test", "w") as testfile:
        testfile.write("test")

    with SecureTarFile(f"{tmp_path}/tar_file.gz", "w") as tar_file:
        atomic_contents_add(
            tar_file,
            tmp_path,
            excludes=["/data/otau/*"],
            arcname="data",
        )

        assert "data/data/otau/test" in [x.path for x in tar_file.getmembers()]

    with SecureTarFile(f"{tmp_path}/tar_file.gz", "w") as tar_file:
        atomic_contents_add(
            tar_file,
            tmp_path,
            excludes=["*/otau"],
            arcname="data",
        )

        assert "data/data/otau/test" not in [x.path for x in tar_file.getmembers()]
```

Fixes https://github.com/home-assistant/addons/issues/1680