### PR TITLE
homematic: backup groups

### DIFF
--- a/homematic/CHANGELOG.md
+++ b/homematic/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 11.0.6
+
+- Persist groups
+
 ## 11.0.5
 
 - Skip HmIP firmware update for udev path

--- a/homematic/config.json
+++ b/homematic/config.json
@@ -1,6 +1,6 @@
 {
   "name": "HomeMatic CCU",
-  "version": "11.0.5",
+  "version": "11.0.6",
   "slug": "homematic",
   "description": "HomeMatic central based on OCCU",
   "url": "https://github.com/home-assistant/hassio-addons/tree/master/homematic",

--- a/homematic/rootfs/etc/cont-init.d/env.sh
+++ b/homematic/rootfs/etc/cont-init.d/env.sh
@@ -10,10 +10,13 @@ mkdir -p /data/rfd
 mkdir -p /data/hs485d
 mkdir -p /data/userprofiles
 
-ln -s /data/userprofiles /etc/config/userprofiles
-
 # Init files
+touch /data/groups.json
 touch /data/hmip_user.conf
 touch /data/rega_user.conf
 touch /data/homematic.regadom
 touch /data/userprofiles/userAckInstallWizard_Admin
+
+# Persist
+ln -s /data/userprofiles /etc/config/userprofiles
+ln -s /data/groups.gson /opt/hm/etc/config/groups.gson


### PR DESCRIPTION
This backs up groups.gson on addon stop/restart.
The file is restored if we have it in our data directory.

This is the same approach as for the Homematic_IP address file.
It might be better to use some sort of symlinks at Addon start time to keep files after crashes. There are also likely other files we should backup #1709 