### PR TITLE
Add warning about loss if run with an empty repo

### DIFF
--- a/git_pull/DOCS.md
+++ b/git_pull/DOCS.md
@@ -8,6 +8,13 @@ Follow these steps to get the add-on installed on your system:
 2. Find the "Git pull" add-on and click it.
 3. Click on the "INSTALL" button.
 
+## WARNING
+
+Risk of complete loss is possible.  Prior to starting this add-on, ensure a copy 
+of your Home Assistant configuration files exists in the Github repository.  Otherwise, 
+your local machine configuration folder will be overwritten with an empty configuration 
+folder and you will need to restore from a backup.
+
 ## How to use
 
 In the configuration section, set the repository field to your repository's

--- a/git_pull/DOCS.md
+++ b/git_pull/DOCS.md
@@ -10,8 +10,8 @@ Follow these steps to get the add-on installed on your system:
 
 ## WARNING
 
-Risk of complete loss is possible.  Prior to starting this add-on, ensure a copy 
-of your Home Assistant configuration files exists in the Github repository.  Otherwise, 
+The risk of complete loss is possible. Prior to starting this add-on, ensure a copy
+of your Home Assistant configuration files exists in the Github repository. Otherwise, 
 your local machine configuration folder will be overwritten with an empty configuration 
 folder and you will need to restore from a backup.
 


### PR DESCRIPTION
Added a warning explaining that if the add-on is started with an empty Github repository, then their local configuration folder will be wiped.