### PR TITLE
duckdns: fix ipv6 by adding "host_network: true"

### DIFF
--- a/duckdns/config.json
+++ b/duckdns/config.json
@@ -1,12 +1,13 @@
 {
   "name": "Duck DNS",
-  "version": "1.12.4",
+  "version": "1.12.5",
   "slug": "duckdns",
   "description": "Free Dynamic DNS (DynDNS or DDNS) service with Let's Encrypt support",
   "url": "https://github.com/home-assistant/hassio-addons/tree/master/duckdns",
   "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],
   "startup": "services",
   "boot": "auto",
+  "host_network": true,
   "map": ["ssl:rw"],
   "options": {
     "lets_encrypt": {


### PR DESCRIPTION
fixes #1715 

Sadly, I couldn't find another way to make this work, as this addon has to curl from an ipv6 server to get the IP and default docker containers don't have an ipv6 address.