### PR TITLE
Turn off NGINX server tokens by default

### DIFF
--- a/nginx_proxy/data/nginx.conf
+++ b/nginx_proxy/data/nginx.conf
@@ -12,6 +12,7 @@ http {
         ''      close;
     }
     
+    server_tokens off;
     server_names_hash_bucket_size 64;
 	
     #include /data/cloudflare.conf;


### PR DESCRIPTION
SECURITY BEST PRACTICE:
add "server_tokens off" option to not display the version of nginx that you use