### PR TITLE
Use ${MARIADB_DATA} everywhere in run script

### DIFF
--- a/mariadb/rootfs/etc/services.d/mariadb/run
+++ b/mariadb/rootfs/etc/services.d/mariadb/run
@@ -15,8 +15,8 @@ else
 fi
 
 # Redirect log output
-rm -f /data/databases/mariadb.err
-ln -s /proc/1/fd/1 /data/databases/mariadb.err
+rm -f "${MARIADB_DATA}/mariadb.err"
+ln -s /proc/1/fd/1 "${MARIADB_DATA}/mariadb.err"
 
 # Start mariadb
 bashio::log.info "Starting MariaDB"


### PR DESCRIPTION
At 2 places the default ```/data/databases``` is hard coded, and not the ```${MARIADB_DATA}``` variable is used.

The fix is tested, works.