### PR TITLE
[Typo] [MariaDB] Repair Example Home Assistant configuration

### DIFF
--- a/mariadb/DOCS.md
+++ b/mariadb/DOCS.md
@@ -69,7 +69,7 @@ Example Home Assistant configuration:
 
 ```yaml
 recorder:
-  db_url: mysql://homeassistant:password@core-mariadb/homeassistant?charset=utf8mb4
+  db_url: mysql://homeassistant:password@local-mariadb/homeassistant?charset=utf8mb4
 ```
 
 ## Support


### PR DESCRIPTION
At least in OS (5.10) environment, the correct host name is ```local-mariadb``` and not ```core-mariadb```.

Though in Supervisor log this has _ (underscore). But my knowledge is way insufficient to figure out this second problem.
```text
21-01-23 20:18:02 INFO (MainThread) [supervisor.services.modules.mysql] Set local_mariadb as service provider for MySQL
```