### PR TITLE
Use hostname for deconz discovery host instead of IP

### DIFF
--- a/deconz/CHANGELOG.md
+++ b/deconz/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.6.3
+
+- Use hostname for discovery instead of IP
+
 ## 6.6.2
 
 - Fixes issues where the `otau` directory was not excluded from snapshots

--- a/deconz/config.json
+++ b/deconz/config.json
@@ -1,6 +1,6 @@
 {
   "name": "deCONZ",
-  "version": "6.6.2",
+  "version": "6.6.3",
   "slug": "deconz",
   "description": "Control a Zigbee network with ConBee or RaspBee by Dresden Elektronik",
   "arch": ["amd64", "armhf", "aarch64"],

--- a/deconz/rootfs/etc/services.d/deconz/discovery
+++ b/deconz/rootfs/etc/services.d/deconz/discovery
@@ -56,7 +56,7 @@ done
 
 # Create config payload for Home Assistant
 config=$(bashio::var.json \
-    host "$(bashio::addon.ip_address)" \
+    host "$(hostname)" \
     port "^40850" \
     api_key "${api_key}" \
     serial "${serial}" \


### PR DESCRIPTION
Using an IP for discovery is temperamental because the container can pick up a new IP on restart. Using a hostname will ensure that HA is always able to connect to the add-on. I noticed this issue because I lost connectivity to my deconz add-on due to the IP change issue.

I originally opened https://github.com/home-assistant/core/pull/45674 but I think fixing it on the add-on side is better