### PR TITLE
duckdns: Use third-level domain label when configuring duckdns records.

### DIFF
--- a/duckdns/CHANGELOG.md
+++ b/duckdns/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.12.5
+
+- Fix bug preventing letsencrypt validation beyond third-level duckdns domain
+
 ## 1.12.4
 
 - Fix bug where IPv6 got the value of IPv4

--- a/duckdns/config.json
+++ b/duckdns/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Duck DNS",
-  "version": "1.12.4",
+  "version": "1.12.5",
   "slug": "duckdns",
   "description": "Free Dynamic DNS (DynDNS or DDNS) service with Let's Encrypt support",
   "url": "https://github.com/home-assistant/hassio-addons/tree/master/duckdns",

--- a/duckdns/data/hooks.sh
+++ b/duckdns/data/hooks.sh
@@ -13,6 +13,7 @@ SYS_KEYFILE=$(jq --raw-output '.lets_encrypt.keyfile' $CONFIG_PATH)
 deploy_challenge() {
     local DOMAIN="${1}" TOKEN_FILENAME="${2}" TOKEN_VALUE="${3}" ALIAS
     ALIAS="$(jq --raw-output --exit-status "[.aliases[]|{(.domain):.alias}]|add.\"$DOMAIN\"" $CONFIG_PATH)" || ALIAS="$DOMAIN"
+    ALIAS="$(echo "$ALIAS" | awk -F. -e '/.duckdns.org$/ { print $(NF-2) }')"
 
     # This hook is called once for every domain that needs to be
     # validated, including any alternative names you may have listed.
@@ -37,6 +38,7 @@ deploy_challenge() {
 clean_challenge() {
     local DOMAIN="${1}" TOKEN_FILENAME="${2}" TOKEN_VALUE="${3}" ALIAS
     ALIAS="$(jq --raw-output --exit-status "[.aliases[]|{(.domain):.alias}]|add.\"$DOMAIN\"" $CONFIG_PATH)" || ALIAS="$DOMAIN"
+    ALIAS="$(echo "$ALIAS" | awk -F. -e '/.duckdns.org$/ { print $(NF-2) }')"
 
     # This hook is called after attempting to validate each domain,
     # whether or not validation was successful. Here you can delete


### PR DESCRIPTION
When using a fourth-level domain name, addon attempts to update TXT record on the fourth-level domain, which fails.

DuckDNS only allows configuration of third-level domains, and that configuration is repeated at every further level.

Resolves #1791. Version-bump.