### PR TITLE
Bump zwave_js server to 1.0.0-beta.2

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.2
+
+- Bump Z-Wave JS Server to 1.0.0-beta.2
+
 ## 0.1.1
 
 - Bump Z-Wave JS Server to 1.0.0-beta.1

--- a/zwave_js/build.json
+++ b/zwave_js/build.json
@@ -7,6 +7,6 @@
     "aarch64": "homeassistant/aarch64-base:3.13"
   },
   "args": {
-    "ZWAVEJS_SERVER_VERSION": "1.0.0-beta.1"
+    "ZWAVEJS_SERVER_VERSION": "1.0.0-beta.2"
   }
 }

--- a/zwave_js/config.json
+++ b/zwave_js/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Z-Wave JS",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "slug": "zwave_js",
   "description": "Control a ZWave network with Home Assistant Z-Wave JS",
   "arch": ["amd64", "i386", "armhf", "armv7", "aarch64"],


### PR DESCRIPTION
Bumps version of zwave_js addon to 1.0.2, we published a new version of the WS server which contains a few fixes