### PR TITLE
ssh: Upgrade CLI to 4.10.1

### DIFF
--- a/ssh/CHANGELOG.md
+++ b/ssh/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 9.0.1
+
+- Upgrade Home Assistant CLI to 4.10.1
+
 ## 9.0.0
 
 - Upgrade Alpine Linux to 3.13

--- a/ssh/build.json
+++ b/ssh/build.json
@@ -7,7 +7,7 @@
     "i386": "homeassistant/i386-base:3.13"
   },
   "args": {
-    "CLI_VERSION": "4.10.0",
+    "CLI_VERSION": "4.10.1",
     "LIBWEBSOCKETS_VERSION": "4.1.4",
     "TTYD_VERSION": "1.6.3"
   }

--- a/ssh/config.json
+++ b/ssh/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Terminal & SSH",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "slug": "ssh",
   "description": "Allow logging in remotely to Home Assistant using SSH",
   "url": "https://github.com/home-assistant/hassio-addons/tree/master/ssh",


### PR DESCRIPTION
Small tweak/fix upstream:

https://github.com/home-assistant/cli/releases/tag/4.10.1