### PR TITLE
Specific install zwave js

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 0.1.5
 
 - Update hardware configuration for Supervisor 2021.02.5
+- Upgrade Z-Wave JS Server to 1.0.0-beta 5
+- Pin Z-Wave JS to version 6.1.3
 
 ## 0.1.4
 

--- a/zwave_js/Dockerfile
+++ b/zwave_js/Dockerfile
@@ -2,6 +2,7 @@ ARG BUILD_FROM
 FROM ${BUILD_FROM}
 
 ARG ZWAVEJS_SERVER_VERSION
+ARG ZWAVEJS_VERSION
 
 # Install Z-Wave JS
 WORKDIR /usr/src
@@ -17,7 +18,7 @@ RUN \
         python3 \
     \
     && npm config set unsafe-perm \
-    && npm install -g @zwave-js/server@${ZWAVEJS_SERVER_VERSION} \
+    && npm install -g @zwave-js/server@${ZWAVEJS_SERVER_VERSION} zwave-js@${ZWAVEJS_VERSION} \
     \
     && apk del --no-cache \
         .build-dependencies

--- a/zwave_js/build.json
+++ b/zwave_js/build.json
@@ -7,6 +7,7 @@
     "aarch64": "homeassistant/aarch64-base:3.13"
   },
   "args": {
-    "ZWAVEJS_SERVER_VERSION": "1.0.0-beta.4"
+    "ZWAVEJS_SERVER_VERSION": "1.0.0-beta.5",
+    "ZWAVEJS_VERSION": "6.1.3"
   }
 }

--- a/zwave_js/config.json
+++ b/zwave_js/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Z-Wave JS",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "slug": "zwave_js",
   "description": "Control a ZWave network with Home Assistant Z-Wave JS",
   "arch": ["amd64", "i386", "armhf", "armv7", "aarch64"],


### PR DESCRIPTION
- Specify exact version of Z-Wave JS to use.
- Bump Z-Wave JS Server ([changelog](https://github.com/zwave-js/zwave-js-server/compare/1.0.0-beta.4...1.0.0-beta.5)) and Z-Wave JS ([changelog](https://github.com/zwave-js/node-zwave-js/compare/v6.1.1...v6.1.3)) to latest versions.

Not sure how to test this.