### PR TITLE
Update config.json to allow the use of serial over tcp socket

### DIFF
--- a/zwave_js/config.json
+++ b/zwave_js/config.json
@@ -21,7 +21,7 @@
     "network_key": ""
   },
   "schema": {
-    "device": "device(subsystem=tty)",
+    "device": "str",
     "network_key": "match(|[0-9a-fA-F]{32,32})",
     "emulate_hardware": "bool?"
   },


### PR DESCRIPTION
Underlying zwave-js and zwave-js-server supports the use of tcp://ip:port to connect serial over TCP to a zwave stick. I have tested this with the home-assistant add on and it works as it should.

Tested ok with a local custom addon. Is this the correct way about allowing the TCP path to be entered into the addon configuration?

From that zwave-js changelog.

> In addition to serial ports, serial-over-tcp connections (e.g. by using ser2net ) are now supported. You can connect to such a host using a connection string of the form tcp://hostname:port . Use these ser2net settings to host a serial port: `:raw:0::115200 8DATABITS NONE 1STOPBIT

