### PR TITLE
Update zwave-js to 6.2.0 release

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.6
+
+- Update zwave-js to version 6.2.0
+
 ## 0.1.5
 
 - Update hardware configuration for Supervisor 2021.02.5

--- a/zwave_js/build.json
+++ b/zwave_js/build.json
@@ -8,6 +8,6 @@
   },
   "args": {
     "ZWAVEJS_SERVER_VERSION": "1.0.0-beta.5",
-    "ZWAVEJS_VERSION": "6.1.3"
+    "ZWAVEJS_VERSION": "6.2.0"
   }
 }


### PR DESCRIPTION
This release fixes lock reporting status.
See https://github.com/zwave-js/node-zwave-js/pull/1641 for details.