### PR TITLE
Bump Z-Wave JS add-on to 0.1.8

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.1.8
+
+- Bump Z-Wave JS Server to 1.0.0
+- Pin Z-Wave JS to version 6.5.0
+
 ## 0.1.7
 
 - Bump Z-Wave JS Server to 1.0.0-beta.6

--- a/zwave_js/Dockerfile
+++ b/zwave_js/Dockerfile
@@ -18,7 +18,7 @@ RUN \
         python3 \
     \
     && npm config set unsafe-perm \
-    && npm install -g @zwave-js/server@${ZWAVEJS_SERVER_VERSION} zwave-js@${ZWAVEJS_VERSION} \
+    && npm install -g @zwave-js/server@${ZWAVEJS_SERVER_VERSION} zwave-js@${ZWAVEJS_VERSION} zwave-js/core@${ZWAVEJS_VERSION} \
     \
     && apk del --no-cache \
         .build-dependencies

--- a/zwave_js/Dockerfile
+++ b/zwave_js/Dockerfile
@@ -18,7 +18,10 @@ RUN \
         python3 \
     \
     && npm config set unsafe-perm \
-    && npm install -g @zwave-js/server@${ZWAVEJS_SERVER_VERSION} zwave-js@${ZWAVEJS_VERSION} zwave-js/core@${ZWAVEJS_VERSION} \
+    && npm install -g \
+        @zwave-js/server@${ZWAVEJS_SERVER_VERSION} \
+        zwave-js@${ZWAVEJS_VERSION} \
+        @zwave-js/core@${ZWAVEJS_VERSION} \
     \
     && apk del --no-cache \
         .build-dependencies

--- a/zwave_js/build.json
+++ b/zwave_js/build.json
@@ -7,7 +7,7 @@
     "aarch64": "homeassistant/aarch64-base:3.13"
   },
   "args": {
-    "ZWAVEJS_SERVER_VERSION": "1.0.0-beta.6",
-    "ZWAVEJS_VERSION": "6.2.0"
+    "ZWAVEJS_SERVER_VERSION": "1.0.0",
+    "ZWAVEJS_VERSION": "6.5.0"
   }
 }

--- a/zwave_js/config.json
+++ b/zwave_js/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Z-Wave JS",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "slug": "zwave_js",
   "description": "Control a ZWave network with Home Assistant Z-Wave JS",
   "arch": ["amd64", "i386", "armhf", "armv7", "aarch64"],
@@ -8,7 +8,7 @@
   "startup": "services",
   "init": false,
   "stage": "experimental",
-  "homeassistant": "2021.2.0b0",
+  "homeassistant": "2021.3.0b0",
   "ports": {
     "3000/tcp": null
   },


### PR DESCRIPTION
Server version 1.0.0 is only compatible with HA 2021.3.