### PR TITLE
Z-Wave JS: Bump ZJS Server to 2.0.0

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.9
+
+- Bump Z-Wave JS Server to 2.0.0
+
 ## 0.1.8
 
 - Bump Z-Wave JS Server to 1.0.0

--- a/zwave_js/build.json
+++ b/zwave_js/build.json
@@ -7,7 +7,7 @@
     "aarch64": "homeassistant/aarch64-base:3.13"
   },
   "args": {
-    "ZWAVEJS_SERVER_VERSION": "1.0.0",
+    "ZWAVEJS_SERVER_VERSION": "2.0.0",
     "ZWAVEJS_VERSION": "6.5.0"
   }
 }

--- a/zwave_js/config.json
+++ b/zwave_js/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Z-Wave JS",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "slug": "zwave_js",
   "description": "Control a ZWave network with Home Assistant Z-Wave JS",
   "arch": ["amd64", "i386", "armhf", "armv7", "aarch64"],
@@ -8,7 +8,7 @@
   "startup": "services",
   "init": false,
   "stage": "experimental",
-  "homeassistant": "2021.3.0b0",
+  "homeassistant": "2021.2.0b0",
   "ports": {
     "3000/tcp": null
   },


### PR DESCRIPTION
This bumps ZJS Server to 2.0.0.

This will re-instate backwards compatibility with the last release as it now needs a new version schema. We should merge this after we release a new beta with a new release of Z-Wave JS Server Python that includes https://github.com/home-assistant-libs/zwave-js-server-python/pull/144