### PR TITLE
Bump ZJS Server to 1.1.0

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.10
+
+- Bump Z-Wave JS Server to 1.1.0. This is the same code as 2.0.0. Home Assistant 2021.2 rejects any ZJS Server version that is v2+
+
 ## 0.1.9
 
 - Bump Z-Wave JS Server to 2.0.0

--- a/zwave_js/build.json
+++ b/zwave_js/build.json
@@ -7,7 +7,7 @@
     "aarch64": "homeassistant/aarch64-base:3.13"
   },
   "args": {
-    "ZWAVEJS_SERVER_VERSION": "2.0.0",
+    "ZWAVEJS_SERVER_VERSION": "1.1.0",
     "ZWAVEJS_VERSION": "6.5.0"
   }
 }

--- a/zwave_js/config.json
+++ b/zwave_js/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Z-Wave JS",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "slug": "zwave_js",
   "description": "Control a ZWave network with Home Assistant Z-Wave JS",
   "arch": ["amd64", "i386", "armhf", "armv7", "aarch64"],


### PR DESCRIPTION
ZJS Server 1.1.0 is the exact same code as ZJS Server 2.0.0 but will not be rejected by Home Assistant 2021.2.

Previous PR that bumped it to 2.0.0 https://github.com/home-assistant/addons/pull/1884