### PR TITLE
Made git_pull more robust to wrong repo setup and added failsafe backup

### DIFF
--- a/git_pull/CHANGELOG.md
+++ b/git_pull/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 7.12.2
+
+- Added automatic backup recovery
+- Corrected too harsh deletion of config files
+
 ## 7.12.1
 
 - Update options schema for passwords

--- a/git_pull/DOCS.md
+++ b/git_pull/DOCS.md
@@ -15,6 +15,9 @@ of your Home Assistant configuration files exists in the Github repository. Othe
 your local machine configuration folder will be overwritten with an empty configuration 
 folder and you will need to restore from a backup.
 
+Also make sure you have access to your system via SSH or to the homeassistant filesystem
+in case you have to restore files from backup.
+
 ## How to use
 
 In the configuration section, set the repository field to your repository's

--- a/git_pull/config.json
+++ b/git_pull/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Git pull",
-  "version": "7.12.1",
+  "version": "7.12.2",
   "slug": "git_pull",
   "description": "Simple git pull to update the local configuration",
   "url": "https://github.com/home-assistant/hassio-addons/tree/master/git_pull",


### PR DESCRIPTION
This patch is to solve issue #1690 and similar.
The problem is, that especially in the beginning it is very likely to run into problems, but without checking quality of remote Repo, all data is deleted.
This patch tries to solve this, but not only create backups far more often, but because it reverts configuration in case of bigger problems.

A second, small change is, to not delete the whole config folder, but to just delete yaml files from it. If additional files should be deleted, this could be achieved with git, too. (add a file to repo once and then delete it from repo). I would assume that only pulling updates from Repo is sufficient, but this is not yet implemented.