### PR TITLE
Pin zwave-js dependencies

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.1.12
+
+- Bump Z-Wave JS to 6.5.1
+- Pin Z-Wave JS dependencies
+
 ## 0.1.11
 
 - Bump Z-Wave JS Server to 1.1.1

--- a/zwave_js/Dockerfile
+++ b/zwave_js/Dockerfile
@@ -31,3 +31,5 @@ RUN \
 
 WORKDIR /
 COPY rootfs /
+
+ENV PATH=/usr/src/node_modules/.bin:$PATH

--- a/zwave_js/Dockerfile
+++ b/zwave_js/Dockerfile
@@ -18,10 +18,13 @@ RUN \
         python3 \
     \
     && npm config set unsafe-perm \
-    && npm install -g \
-        @zwave-js/server@${ZWAVEJS_SERVER_VERSION} \
-        zwave-js@${ZWAVEJS_VERSION} \
-        @zwave-js/core@${ZWAVEJS_VERSION} \
+    && npm install \
+      zwave-js@${ZWAVEJS_VERSION} \
+      @zwave-js/core@${ZWAVEJS_CORE_VERSION} \
+      @zwave-js/serial@${ZWAVEJS_SERIAL_VERSION} \
+      @zwave-js/config@${ZWAVEJS_CONFIG_VERSION} \
+      @zwave-js/shared@${ZWAVEJS_SHARED_VERSION} \
+      @zwave-js/server@${ZWAVEJS_SERVER_VERSION} \
     \
     && apk del --no-cache \
         .build-dependencies

--- a/zwave_js/Dockerfile
+++ b/zwave_js/Dockerfile
@@ -19,12 +19,12 @@ RUN \
     \
     && npm config set unsafe-perm \
     && npm install \
-      zwave-js@${ZWAVEJS_VERSION} \
-      @zwave-js/core@${ZWAVEJS_CORE_VERSION} \
-      @zwave-js/serial@${ZWAVEJS_SERIAL_VERSION} \
-      @zwave-js/config@${ZWAVEJS_CONFIG_VERSION} \
-      @zwave-js/shared@${ZWAVEJS_SHARED_VERSION} \
-      @zwave-js/server@${ZWAVEJS_SERVER_VERSION} \
+        "zwave-js@${ZWAVEJS_VERSION}" \
+        "@zwave-js/core@${ZWAVEJS_CORE_VERSION}" \
+        "@zwave-js/serial@${ZWAVEJS_SERIAL_VERSION}" \
+        "@zwave-js/config@${ZWAVEJS_CONFIG_VERSION}" \
+        "@zwave-js/shared@${ZWAVEJS_SHARED_VERSION}" \
+        "@zwave-js/server@${ZWAVEJS_SERVER_VERSION}" \
     \
     && apk del --no-cache \
         .build-dependencies

--- a/zwave_js/build.json
+++ b/zwave_js/build.json
@@ -8,6 +8,10 @@
   },
   "args": {
     "ZWAVEJS_SERVER_VERSION": "1.1.1",
-    "ZWAVEJS_VERSION": "6.5.0"
+    "ZWAVEJS_VERSION": "6.5.1",
+    "ZWAVEJS_CORE_VERSION": "6.5.0",
+    "ZWAVEJS_SERIAL_VERSION": "6.5.0",
+    "ZWAVEJS_CONFIG_VERSION": "6.5.1",
+    "ZWAVEJS_SHARED_VERSION": "6.5.0"
   }
 }

--- a/zwave_js/config.json
+++ b/zwave_js/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Z-Wave JS",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "slug": "zwave_js",
   "description": "Control a ZWave network with Home Assistant Z-Wave JS",
   "arch": ["amd64", "i386", "armhf", "armv7", "aarch64"],


### PR DESCRIPTION
- Bump Z-Wave JS to 6.5.1
- Pin Z-Wave JS dependencies
- Install zwave-js and zwave-js-server locally instead of globally.
- Add node modules binaries to path.

fixes #1922 