### PR TITLE
Swap iptables to make Docker work on WSL2

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -32,3 +32,7 @@ RUN \
 
 # Generate a machine-id for this container
 RUN rm /etc/machine-id && dbus-uuidgen --ensure=/etc/machine-id
+
+# Swap iptables for Docker to work correctly on WSL2
+RUN update-alternatives --set iptables /usr/sbin/iptables-legacy
+RUN update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy


### PR DESCRIPTION
This fixes the issue of Docker not starting when using devcontainer on DockerForDesktop via WSL2 setup.

I'm not really sure why this helps, but I found it in devcontainer template here:
https://github.com/microsoft/vscode-dev-containers/blob/12230d5dcc199ed5c76d5d443d970280e531e3ef/containers/docker-in-docker/.devcontainer/library-scripts/docker-in-docker-debian.sh#L61

I have tested it on macOS, to ensure it doesn't break on non-WSL2 environments.