### PR TITLE
autodetect workspace name

### DIFF
--- a/.devcontainer/supervisor.sh
+++ b/.devcontainer/supervisor.sh
@@ -74,6 +74,16 @@ function cleanup_docker() {
 
 function run_supervisor() {
     mkdir -p /tmp/supervisor_data
+    WORKSPACE=/workspaces/addons
+    if [ ! -d ${WORKSPACE} ]; then
+        for WORKSPACE in /workspaces/*; do
+            [[ -d "$WORKSPACE" ]] && break
+        done
+    fi
+    if [ ! -d "${WORKSPACE}" ]; then 
+        echo "Could not find workspace directory to mount as volume"
+    fi
+
     docker run --rm --privileged \
         --name hassio_supervisor \
         --security-opt seccomp=unconfined \
@@ -82,7 +92,7 @@ function run_supervisor() {
         -v /run/dbus:/run/dbus:ro \
         -v /run/udev:/run/udev:ro \
         -v /tmp/supervisor_data:/data:rw \
-        -v "/workspaces/addons":/data/addons/local:rw \
+        -v "${WORKSPACE}":/data/addons/local:rw \
         -v /etc/machine-id:/etc/machine-id:ro \
         -e SUPERVISOR_SHARE="/tmp/supervisor_data" \
         -e SUPERVISOR_NAME=hassio_supervisor \


### PR DESCRIPTION
This fixes issues when you do not checkout this repo into the folder `addons` but for example `ha-addons`.

But it also helps with the instructions to copy & paste the `.devcontainer` and `.vscode` folders from the addons project into your own addons folder. That might not have been named `addons`
