### PR TITLE
Bump zwave-js-server to 1.3.0

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.1.14
+
+- Bump Z-Wave JS Server to 1.3.0
+- Pin Z-Wave JS to version 7.0.0
+
 ## 0.1.13
 
 - Bump Z-Wave JS Server to 1.2.1

--- a/zwave_js/build.json
+++ b/zwave_js/build.json
@@ -7,7 +7,7 @@
     "aarch64": "homeassistant/aarch64-base:3.13"
   },
   "args": {
-    "ZWAVEJS_SERVER_VERSION": "1.2.1",
-    "ZWAVEJS_VERSION": "6.6.3"
+    "ZWAVEJS_SERVER_VERSION": "1.3.0",
+    "ZWAVEJS_VERSION": "7.0.0"
   }
 }

--- a/zwave_js/config.json
+++ b/zwave_js/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Z-Wave JS",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "slug": "zwave_js",
   "description": "Control a ZWave network with Home Assistant Z-Wave JS",
   "arch": ["amd64", "i386", "armhf", "armv7", "aarch64"],


### PR DESCRIPTION
Changelog: https://github.com/zwave-js/zwave-js-server/releases/tag/1.3.0