### PR TITLE
Bump zwave-js to 7.0.1

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.15
+
+- Pin Z-Wave JS to version 7.0.1
+
 ## 0.1.14
 
 - Bump Z-Wave JS Server to 1.3.0

--- a/zwave_js/build.json
+++ b/zwave_js/build.json
@@ -8,6 +8,6 @@
   },
   "args": {
     "ZWAVEJS_SERVER_VERSION": "1.3.0",
-    "ZWAVEJS_VERSION": "7.0.0"
+    "ZWAVEJS_VERSION": "7.0.1"
   }
 }

--- a/zwave_js/config.json
+++ b/zwave_js/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Z-Wave JS",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "slug": "zwave_js",
   "description": "Control a ZWave network with Home Assistant Z-Wave JS",
   "arch": ["amd64", "i386", "armhf", "armv7", "aarch64"],


### PR DESCRIPTION
Changelog: https://github.com/zwave-js/node-zwave-js/releases/tag/v7.0.1

A couple of notes:
1. There appears to be a change introduced in zwave-js 7.0.0 that causes different values to be mapped to different endpoints in such a way that our existing climate discovery logic doesn't capture all of the necessary values (https://github.com/zwave-js/node-zwave-js/issues/2165). It looks like this is resolved in 7.0.1 but I am waiting for confirmation.
2. Even in 7.0.1 the `Thermostat Setpoint` and `Thermostat Mode` values for my thermostat used to be on endpoint 0 and now are on endpoint 1. The end result is that the originally created climate entry is effectively abandoned, and a new one has been created. We probably need to add some logic to clean up entities that previously existed that are no longer being discovered to handle this change. I am not sure the best way to address it yet though so open to suggestions.