### PR TITLE
Make the fallback certificate and key user configurable.

### DIFF
--- a/nginx_proxy/DOCS.md
+++ b/nginx_proxy/DOCS.md
@@ -56,6 +56,14 @@ Private key file to use in the `/ssl` directory.
 
 Value for the [`Strict-Transport-Security`][hsts] HTTP header to send. If empty, the header is not sent.
 
+### Option: `fallback_certfile` (required)
+
+Location of the fallback certificate - this will be automatically generated if it doens't exsist but can't be null. Default is /data/ssl-cert-snakeoil.pem
+
+### Option: `fallback_keyfile` (required)
+
+Location of the fallback certificate's key - this will be automatically generated if the certificate doens't exsist but can't be null. Default is /data/ssl-cert-snakeoil.key
+
 ### Option `customize.active` (required)
 
 If true, additional NGINX configuration files for the default server and additional servers are read from files in the `/share` directory specified by the `default` and `servers` variables.

--- a/nginx_proxy/config.json
+++ b/nginx_proxy/config.json
@@ -15,6 +15,8 @@
     "certfile": "fullchain.pem",
     "keyfile": "privkey.pem",
     "hsts": "max-age=31536000; includeSubDomains",
+    "fallback_certfile": "/data/ssl-cert-snakeoil.pem",
+    "fallback_keyfile": "/data/ssl-cert-snakeoil.key",
     "cloudflare": false,
     "customize": {
       "active": false,

--- a/nginx_proxy/data/nginx.conf
+++ b/nginx_proxy/data/nginx.conf
@@ -20,8 +20,8 @@ http {
         server_name _;
         listen 80 default_server;
         listen 443 ssl http2 default_server;
-        ssl_certificate /data/ssl-cert-snakeoil.pem;
-        ssl_certificate_key /data/ssl-cert-snakeoil.key;
+        ssl_certificate %%FALLBACK_CERT%%;
+        ssl_certificate_key %%FALLBACK_KEY%%;
         return 444;
     }
 

--- a/nginx_proxy/data/run.sh
+++ b/nginx_proxy/data/run.sh
@@ -3,8 +3,8 @@ set -e
 
 DHPARAMS_PATH=/data/dhparams.pem
 
-SNAKEOIL_CERT=/data/ssl-cert-snakeoil.pem
-SNAKEOIL_KEY=/data/ssl-cert-snakeoil.key
+SNAKEOIL_CERT=$(bashio::config 'fallback_certfile')
+SNAKEOIL_KEY=$(bashio::config 'fallback_keyfile')
 
 CLOUDFLARE_CONF=/data/cloudflare.conf
 
@@ -52,6 +52,8 @@ fi
 sed -i "s#%%FULLCHAIN%%#$CERTFILE#g" /etc/nginx.conf
 sed -i "s#%%PRIVKEY%%#$KEYFILE#g" /etc/nginx.conf
 sed -i "s/%%DOMAIN%%/$DOMAIN/g" /etc/nginx.conf
+sed -i "s/%%FALLBACK_CERT%%/$SNAKEOIL_CERT/g" /etc/nginx.conf
+sed -i "s/%%FALLBACK_KEY%%/SNAKEOIL_KEY/g" /etc/nginx.conf
 
 [ -n "$HSTS" ] && HSTS="add_header Strict-Transport-Security \"$HSTS\" always;"
 sed -i "s/%%HSTS%%/$HSTS/g" /etc/nginx.conf


### PR DESCRIPTION
Make the fallback certificate and the key used by the nginx add on configurable. This is useful if you want to serve a different certificate/key if the nginx addon is referenced directly as an IP address. 

The certificate/key is by default set to the previous versions and it will still be auto generated if it doesn't exist so this should be a non-breaking change.