### PR TITLE
Expose log level as a configuration option for zwave_js

### DIFF
--- a/zwave_js/DOCS.md
+++ b/zwave_js/DOCS.md
@@ -86,7 +86,7 @@ and your controller, before rebuilding your Z-Wave network.
 ### Option `log_level` (optional)
 
 This option sets the log level of Z-Wave JS. If no `log_level` is specified, the
-log level will be set to default. Options are:
+log level will be set to `info`. Valid options are:
 - silly
 - debug
 - verbose

--- a/zwave_js/DOCS.md
+++ b/zwave_js/DOCS.md
@@ -86,7 +86,7 @@ and your controller, before rebuilding your Z-Wave network.
 ### Option `log_level` (optional)
 
 This option sets the log level of Z-Wave JS. If no `log_level` is specified, the
-log level will be set to `info`. Valid options are:
+log level will be set to the level set in the Supervisor. Valid options are:
 - silly
 - debug
 - verbose

--- a/zwave_js/DOCS.md
+++ b/zwave_js/DOCS.md
@@ -83,6 +83,18 @@ don't have a backup of this key, you won't be able to reconnect to any securely
 included devices. This may mean you have to do a factory reset on those devices
 and your controller, before rebuilding your Z-Wave network.
 
+### Option `log_level` (optional)
+
+This option sets the log level of Z-Wave JS. If no `log_level` is specified, the
+log level will be set to default. Options are:
+- silly
+- debug
+- verbose
+- http
+- info
+- warn
+- error
+
 ### Option `emulate_hardware` (optional)
 
 If you don't have a USB stick, you can use a fake stick for testing purposes.

--- a/zwave_js/DOCS.md
+++ b/zwave_js/DOCS.md
@@ -85,8 +85,7 @@ and your controller, before rebuilding your Z-Wave network.
 
 ### Option `log_level` (optional)
 
-This option sets the log level of Z-Wave JS. If no `log_level` is specified, the
-log level will be set to the level set in the Supervisor. Valid options are:
+This option sets the log level of Z-Wave JS. Valid options are:
 - silly
 - debug
 - verbose
@@ -94,6 +93,9 @@ log level will be set to the level set in the Supervisor. Valid options are:
 - info
 - warn
 - error
+
+If no `log_level` is specified, the log level will be set to the level set in
+the Supervisor.
 
 ### Option `emulate_hardware` (optional)
 

--- a/zwave_js/config.json
+++ b/zwave_js/config.json
@@ -24,7 +24,7 @@
   "schema": {
     "device": "device(subsystem=tty)",
     "network_key": "match(|[0-9a-fA-F]{32,32})",
-    "log_level": "list(silly|debug|verbose|http|info|warn|error)",
+    "log_level": "list(silly|debug|verbose|http|info|warn|error)?",
     "emulate_hardware": "bool?"
   },
   "image": "homeassistant/{arch}-addon-zwave_js"

--- a/zwave_js/config.json
+++ b/zwave_js/config.json
@@ -18,11 +18,13 @@
   "discovery": ["zwave_js"],
   "options": {
     "device": null,
-    "network_key": ""
+    "network_key": "",
+    "log_level": "info"
   },
   "schema": {
     "device": "device(subsystem=tty)",
     "network_key": "match(|[0-9a-fA-F]{32,32})",
+    "log_level": "list(silly|debug|verbose|http|info|warn|error)",
     "emulate_hardware": "bool?"
   },
   "image": "homeassistant/{arch}-addon-zwave_js"

--- a/zwave_js/rootfs/etc/cont-init.d/config.sh
+++ b/zwave_js/rootfs/etc/cont-init.d/config.sh
@@ -32,16 +32,14 @@ fi
 
 if  ! bashio::config.has_value 'log_level'; then
     bashio::log.info "No log level specified, falling back to info..."
-    log_level="info"
-else
-    log_level=$(bashio::config 'log_level')
+    bashio::addon.option log_level "info"
 fi
 
 
 # Generate config
 bashio::var.json \
     network_key "${network_key}" \
-    log_level "${log_level}" \
+    log_level "$(bashio::config 'log_level')" \
     | tempio \
         -template /usr/share/tempio/zwave_config.conf \
         -out /etc/zwave_config.json

--- a/zwave_js/rootfs/etc/cont-init.d/config.sh
+++ b/zwave_js/rootfs/etc/cont-init.d/config.sh
@@ -30,10 +30,18 @@ else
     network_key=$(bashio::config 'network_key')
 fi
 
+if  ! bashio::config.has_value 'log_level'; then
+    bashio::log.info "No log level specified, falling back to info..."
+    log_level="info"
+else
+    log_level=$(bashio::config 'log_level')
+fi
+
+
 # Generate config
 bashio::var.json \
     network_key "${network_key}" \
-    log_level "$(bashio::config 'log_level')" \
+    log_level "${log_level}" \
     | tempio \
         -template /usr/share/tempio/zwave_config.conf \
         -out /etc/zwave_config.json

--- a/zwave_js/rootfs/etc/cont-init.d/config.sh
+++ b/zwave_js/rootfs/etc/cont-init.d/config.sh
@@ -30,8 +30,6 @@ else
     network_key=$(bashio::config 'network_key')
 fi
 
-# log_level=$(bashio::config 'log_level')
-
 # Generate config
 bashio::var.json \
     network_key "${network_key}" \

--- a/zwave_js/rootfs/etc/cont-init.d/config.sh
+++ b/zwave_js/rootfs/etc/cont-init.d/config.sh
@@ -30,11 +30,12 @@ else
     network_key=$(bashio::config 'network_key')
 fi
 
+# log_level=$(bashio::config 'log_level')
 
 # Generate config
 bashio::var.json \
     network_key "${network_key}" \
-    logging "$(bashio::info.logging)" \
+    log_level "$(bashio::config 'log_level')" \
     | tempio \
         -template /usr/share/tempio/zwave_config.conf \
         -out /etc/zwave_config.json

--- a/zwave_js/rootfs/etc/cont-init.d/config.sh
+++ b/zwave_js/rootfs/etc/cont-init.d/config.sh
@@ -31,8 +31,9 @@ else
 fi
 
 if  ! bashio::config.has_value 'log_level'; then
-    bashio::log.info "No log level specified, falling back to info..."
-    log_level="info"
+    log_level=$(bashio::info.logging)
+    bashio::log.info "No log level specified, falling back to Supervisor"
+    bashio::log.info "log level (${log_level})..."
 else
     log_level=$(bashio::config 'log_level')
 fi

--- a/zwave_js/rootfs/etc/cont-init.d/config.sh
+++ b/zwave_js/rootfs/etc/cont-init.d/config.sh
@@ -32,14 +32,16 @@ fi
 
 if  ! bashio::config.has_value 'log_level'; then
     bashio::log.info "No log level specified, falling back to info..."
-    bashio::addon.option log_level "info"
+    log_level="info"
+else
+    log_level=$(bashio::config 'log_level')
 fi
 
 
 # Generate config
 bashio::var.json \
     network_key "${network_key}" \
-    log_level "$(bashio::config 'log_level')" \
+    log_level "${log_level}" \
     | tempio \
         -template /usr/share/tempio/zwave_config.conf \
         -out /etc/zwave_config.json

--- a/zwave_js/rootfs/usr/share/tempio/zwave_config.conf
+++ b/zwave_js/rootfs/usr/share/tempio/zwave_config.conf
@@ -1,7 +1,7 @@
 {
     "logConfig": {
         "enabled": true,
-        "level": {{ if eq .logging "debug" }}5{{ else }}2{{ end }},
+        "level": "{{ .log_level }}",
         "forceConsole": true
     },
     "storage": {


### PR DESCRIPTION
Right now, log level is decided based on the supervisor log level. That buries the option for most users and doesn't allow for the other levels that `zwave-js` supports, so this makes it user configurable directly on the addon.