### PR TITLE
Bump zwave-js-server to 1.3.1

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.1.16
+
+- Bump Z-Wave JS Server to 1.3.1
+- Add log level as a configuration option
+
 ## 0.1.15
 
 - Pin Z-Wave JS to version 7.0.1

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## 0.1.16
 
 - Bump Z-Wave JS Server to 1.3.1
-- Add log level as a configuration option
 
 ## 0.1.15
 

--- a/zwave_js/build.json
+++ b/zwave_js/build.json
@@ -7,7 +7,7 @@
     "aarch64": "homeassistant/aarch64-base:3.13"
   },
   "args": {
-    "ZWAVEJS_SERVER_VERSION": "1.3.0",
+    "ZWAVEJS_SERVER_VERSION": "1.3.1",
     "ZWAVEJS_VERSION": "7.0.1"
   }
 }

--- a/zwave_js/config.json
+++ b/zwave_js/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Z-Wave JS",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "slug": "zwave_js",
   "description": "Control a ZWave network with Home Assistant Z-Wave JS",
   "arch": ["amd64", "i386", "armhf", "armv7", "aarch64"],


### PR DESCRIPTION
I wrote the changelog with the assumption that we would be merging https://github.com/home-assistant/addons/pull/1950 first. Let me know if you'd like to remove that so we can release the updated version ahead of that PR.

Changelog for zwave-js-server: https://github.com/zwave-js/zwave-js-server/releases/tag/1.3.1