### PR TITLE
Bump zwave_js addon dependency versions

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.1.17
+
+- Bump Z-Wave JS Server to 1.4.0
+- Pin Z-Wave JS to 7.1.1
+
 ## 0.1.16
 
 - Bump Z-Wave JS Server to 1.3.1

--- a/zwave_js/build.json
+++ b/zwave_js/build.json
@@ -7,7 +7,7 @@
     "aarch64": "homeassistant/aarch64-base:3.13"
   },
   "args": {
-    "ZWAVEJS_SERVER_VERSION": "1.3.1",
-    "ZWAVEJS_VERSION": "7.0.1"
+    "ZWAVEJS_SERVER_VERSION": "1.4.0",
+    "ZWAVEJS_VERSION": "7.1.1"
   }
 }

--- a/zwave_js/config.json
+++ b/zwave_js/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Z-Wave JS",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "slug": "zwave_js",
   "description": "Control a ZWave network with Home Assistant Z-Wave JS",
   "arch": ["amd64", "i386", "armhf", "armv7", "aarch64"],


### PR DESCRIPTION
Changelogs:
https://github.com/zwave-js/zwave-js-server/releases/tag/1.4.0
https://github.com/zwave-js/node-zwave-js/releases/tag/v7.1.0
https://github.com/zwave-js/node-zwave-js/releases/tag/v7.1.1

Among other things, 7.1.0 of zwave-js introduced some fixes to thermostat interview issues that were preventing some values from being discovered.

Potentially fixes https://github.com/home-assistant/core/issues/48440