### PR TITLE
Set up a workspace path in devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,13 +4,15 @@
 	"context": "..",
 	"dockerFile": "Dockerfile",
 	"appPort": ["7123:8123", "7357:4357"],
-    "postStartCommand": "service docker start",
+	"postStartCommand": "service docker start",
 	"runArgs": ["-e", "GIT_EDITOR=code --wait", "--privileged"],
 	"extensions": [
 		"timonwong.shellcheck",
 		"esbenp.prettier-vscode"
 	],
-	"settings": { 
+	"settings": {
 		"terminal.integrated.shell.linux": "/bin/bash"
-	}
+	},
+	"workspaceMount": "source=${localWorkspaceFolder},target=/workspaces/addons,type=bind,consistency=delegated",
+	"workspaceFolder": "/workspaces/addons"
 }


### PR DESCRIPTION
This change is not necessary if you just clone this repo and keep its name unchanged.

The problem is only if you either rename the repo, or more importantly, follow the
guide at https://developers.home-assistant.io/docs/add-ons/testing and copy that
setup to your own addons repo. Since your repo (and thus directory) will likely be
named differently, the path mapping set-up in [1] will no longer work.

Fix by explicitly defining the workspace path and mount path so that the setup works
regardless of directory name.

[1] https://github.com/home-assistant/addons/blob/e933cba5a457a492fec458dcb2629e9dbadeb569/.devcontainer/supervisor.sh#L85