### PR TITLE
Bump zwave-js to 7.2.2

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.18
+
+- Pin Z-Wave JS to 7.2.2
+
 ## 0.1.17
 
 - Bump Z-Wave JS Server to 1.4.0

--- a/zwave_js/build.json
+++ b/zwave_js/build.json
@@ -8,6 +8,6 @@
   },
   "args": {
     "ZWAVEJS_SERVER_VERSION": "1.4.0",
-    "ZWAVEJS_VERSION": "7.1.1"
+    "ZWAVEJS_VERSION": "7.2.2"
   }
 }

--- a/zwave_js/config.json
+++ b/zwave_js/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Z-Wave JS",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "slug": "zwave_js",
   "description": "Control a ZWave network with Home Assistant Z-Wave JS",
   "arch": ["amd64", "i386", "armhf", "armv7", "aarch64"],


### PR DESCRIPTION
Changelogs:
https://github.com/zwave-js/node-zwave-js/releases/tag/v7.2.1
https://github.com/zwave-js/node-zwave-js/releases/tag/v7.2.2

This update will hopefully fix issues some users were having with interviews