### PR TITLE
Update configurator / file editor to 0.4.1

### DIFF
--- a/configurator/CHANGELOG.md
+++ b/configurator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.3.0
+
+- Ignore input-keyword used in blueprints in yaml-linting
+
 ## 5.2.0
 
 - Add git option which allows disabling the (default) git initialization

--- a/configurator/build.json
+++ b/configurator/build.json
@@ -7,6 +7,6 @@
     "i386": "homeassistant/i386-base:3.12"
   },
   "args": {
-    "CONFIGURATOR_VERSION": "0.4.0"
+    "CONFIGURATOR_VERSION": "0.4.1"
   }
 }

--- a/configurator/config.json
+++ b/configurator/config.json
@@ -1,6 +1,6 @@
 {
   "name": "File editor",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "slug": "configurator",
   "description": "Simple browser-based file editor for Home Assistant",
   "url": "https://github.com/home-assistant/hassio-addons/tree/master/configurator",


### PR DESCRIPTION
I have released a new version of the configurator which ignores the `input` keyword during yaml-linting. This PR references this new version.

I don't know how the versions here are _calculated_, so I just went with `5.3.0`. Tell me if it should be something else. 👍