### PR TITLE
ssh: Upgrade Home Assistant CLI

### DIFF
--- a/ssh/CHANGELOG.md
+++ b/ssh/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 9.1.1
+
+- Use GitHub Container Registry for the base image
+- Upgrade Home Assistant CLI to 4.12.1
+
 ## 9.1.0
 
 - Upgrade Home Assistant CLI to 4.11.0

--- a/ssh/CHANGELOG.md
+++ b/ssh/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Use GitHub Container Registry for the base image
 - Upgrade Home Assistant CLI to 4.12.1
+- Upstream ttyd project now uses the main branch
 
 ## 9.1.0
 

--- a/ssh/Dockerfile
+++ b/ssh/Dockerfile
@@ -50,7 +50,7 @@ RUN \
     && make \
     && make install \
     \
-    && git clone --branch master --single-branch \
+    && git clone --branch main --single-branch \
         https://github.com/tsl0922/ttyd.git /tmp/ttyd \
     && git -C /tmp/ttyd checkout "${TTYD_VERSION}" \
     \

--- a/ssh/build.json
+++ b/ssh/build.json
@@ -1,10 +1,10 @@
 {
   "build_from": {
-    "aarch64": "homeassistant/aarch64-base:3.13",
-    "amd64": "homeassistant/amd64-base:3.13",
-    "armhf": "homeassistant/armhf-base:3.13",
-    "armv7": "homeassistant/armv7-base:3.13",
-    "i386": "homeassistant/i386-base:3.13"
+    "aarch64": "ghcr.io/home-assistant/aarch64-base:3.13",
+    "amd64": "ghcr.io/home-assistant/amd64-base:3.13",
+    "armhf": "ghcr.io/home-assistant/armhf-base:3.13",
+    "armv7": "ghcr.io/home-assistant/armv7-base:3.13",
+    "i386": "ghcr.io/home-assistant/i386-base:3.13"
   },
   "args": {
     "CLI_VERSION": "4.11.0",

--- a/ssh/build.json
+++ b/ssh/build.json
@@ -7,7 +7,7 @@
     "i386": "ghcr.io/home-assistant/i386-base:3.13"
   },
   "args": {
-    "CLI_VERSION": "4.11.0",
+    "CLI_VERSION": "4.12.1",
     "LIBWEBSOCKETS_VERSION": "4.1.4",
     "TTYD_VERSION": "1.6.3"
   }

--- a/ssh/config.json
+++ b/ssh/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Terminal & SSH",
-  "version": "9.1.0",
+  "version": "9.1.1",
   "slug": "ssh",
   "description": "Allow logging in remotely to Home Assistant using SSH",
   "url": "https://github.com/home-assistant/hassio-addons/tree/master/ssh",
@@ -19,7 +19,14 @@
   "ports": {
     "22/tcp": null
   },
-  "map": ["config:rw", "ssl:rw", "addons:rw", "share:rw", "backup:rw", "media:rw"],
+  "map": [
+    "config:rw",
+    "ssl:rw",
+    "addons:rw",
+    "share:rw",
+    "backup:rw",
+    "media:rw"
+  ],
   "options": {
     "authorized_keys": [],
     "apks": [],


### PR DESCRIPTION
## 9.1.1

- Use GitHub Container Registry for the base image
- Upgrade Home Assistant CLI to 4.12.1
- Upstream ttyd project now uses the main branch