### PR TITLE
git_pull: Bump CLI & Base image

### DIFF
--- a/git_pull/CHANGELOG.md
+++ b/git_pull/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Update Home Assistant CLI to 4.12.1
 - Upgrade base image to Alpine 3.13
+- Supress a shellcheck warning happening in CI
 
 ## 7.12.2
 

--- a/git_pull/CHANGELOG.md
+++ b/git_pull/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 7.13.0
+
+- Update Home Assistant CLI to 4.12.1
+- Upgrade base image to Alpine 3.13
+
 ## 7.12.2
 
 - Update Home Assistant CLI to 4.11.0

--- a/git_pull/build.json
+++ b/git_pull/build.json
@@ -7,6 +7,6 @@
     "i386": "ghcr.io/home-assistant/i386-base:3.13"
   },
   "args": {
-    "CLI_VERSION": "4.11.0"
+    "CLI_VERSION": "4.12.1"
   }
 }

--- a/git_pull/build.json
+++ b/git_pull/build.json
@@ -1,10 +1,10 @@
 {
   "build_from": {
-    "aarch64": "homeassistant/aarch64-base:3.11",
-    "amd64": "homeassistant/amd64-base:3.11",
-    "armhf": "homeassistant/armhf-base:3.11",
-    "armv7": "homeassistant/armv7-base:3.11",
-    "i386": "homeassistant/i386-base:3.11"
+    "aarch64": "ghcr.io/home-assistant/aarch64-base:3.13",
+    "amd64": "ghcr.io/home-assistant/amd64-base:3.13",
+    "armhf": "ghcr.io/home-assistant/armhf-base:3.13",
+    "armv7": "ghcr.io/home-assistant/armv7-base:3.13",
+    "i386": "ghcr.io/home-assistant/i386-base:3.13"
   },
   "args": {
     "CLI_VERSION": "4.11.0"

--- a/git_pull/config.json
+++ b/git_pull/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Git pull",
-  "version": "7.12.2",
+  "version": "7.13.0",
   "slug": "git_pull",
   "description": "Simple git pull to update the local configuration",
   "url": "https://github.com/home-assistant/hassio-addons/tree/master/git_pull",

--- a/git_pull/data/run.sh
+++ b/git_pull/data/run.sh
@@ -107,6 +107,7 @@ password=${DEPLOYMENT_PASSWORD}
 "
 
     # Use git commands to write the credentials to ~/.git-credentials
+    # shellcheck disable=SC2259
     echo "[Info] Saving git credentials to /tmp/git-credentials"
     git credential fill | git credential approve <<< "$cred_data"
 fi

--- a/git_pull/data/run.sh
+++ b/git_pull/data/run.sh
@@ -107,8 +107,8 @@ password=${DEPLOYMENT_PASSWORD}
 "
 
     # Use git commands to write the credentials to ~/.git-credentials
-    # shellcheck disable=SC2259
     echo "[Info] Saving git credentials to /tmp/git-credentials"
+    # shellcheck disable=SC2259
     git credential fill | git credential approve <<< "$cred_data"
 fi
 }


### PR DESCRIPTION
## 7.13.0

- Update Home Assistant CLI to 4.12.1
- Upgrade base image to Alpine 3.13
- Supress a shellcheck warning happening in CI