### PR TITLE
Add proxy_pass customizability

### DIFF
--- a/nginx_proxy/DOCS.md
+++ b/nginx_proxy/DOCS.md
@@ -33,6 +33,7 @@ domain: home.example.com
 certfile: fullchain.pem
 keyfile: privkey.pem
 hsts: "max-age=31536000; includeSubDomains"
+proxypass: http://homeassistant.local.hass.io:8123  
 customize:
   active: false
   default: "nginx_proxy_default*.conf"
@@ -55,6 +56,10 @@ Private key file to use in the `/ssl` directory.
 ### Option: `hsts` (required)
 
 Value for the [`Strict-Transport-Security`][hsts] HTTP header to send. If empty, the header is not sent.
+
+### Option: `proxypass` (required)
+
+Value for the `proxy_pass` parameter in nginx.conf. Default setting will work for most uses cases.
 
 ### Option `customize.active` (required)
 

--- a/nginx_proxy/config.json
+++ b/nginx_proxy/config.json
@@ -16,6 +16,7 @@
     "keyfile": "privkey.pem",
     "hsts": "max-age=31536000; includeSubDomains",
     "cloudflare": false,
+	"proxypass": "http://homeassistant.local.hass.io:8123",
     "customize": {
       "active": false,
       "default": "nginx_proxy_default*.conf",

--- a/nginx_proxy/data/nginx.conf
+++ b/nginx_proxy/data/nginx.conf
@@ -58,7 +58,7 @@ http {
         #include /share/nginx_proxy_default*.conf;
 
         location / {
-            proxy_pass http://homeassistant.local.hass.io:8123;
+            proxy_pass %%PROXYPASS%%;
             proxy_set_header Host $host;
             proxy_redirect http:// https://;
             proxy_http_version 1.1;

--- a/nginx_proxy/data/run.sh
+++ b/nginx_proxy/data/run.sh
@@ -12,6 +12,7 @@ DOMAIN=$(bashio::config 'domain')
 KEYFILE=$(bashio::config 'keyfile')
 CERTFILE=$(bashio::config 'certfile')
 HSTS=$(bashio::config 'hsts')
+HSTS=$(bashio::config 'proxypass')
 
 # Generate dhparams
 if ! bashio::fs.file_exists "${DHPARAMS_PATH}"; then
@@ -52,6 +53,7 @@ fi
 sed -i "s#%%FULLCHAIN%%#$CERTFILE#g" /etc/nginx.conf
 sed -i "s#%%PRIVKEY%%#$KEYFILE#g" /etc/nginx.conf
 sed -i "s/%%DOMAIN%%/$DOMAIN/g" /etc/nginx.conf
+sed -i "s/%%PROXYPASS%%/$PROXYPASS/g" /etc/nginx.conf
 
 [ -n "$HSTS" ] && HSTS="add_header Strict-Transport-Security \"$HSTS\" always;"
 sed -i "s/%%HSTS%%/$HSTS/g" /etc/nginx.conf


### PR DESCRIPTION
Add a new config option allowing users to change the _proxy_pass_ parameter in nginx.conf.
The default setting is left as it was so most users won't see any difference. 

Changing this config option can increase the security level for users willing to do so.
A good hardening practice is to reduce the service exposure as much as possible.
This option enable users to remove the local exposure with unciphered protocol (http) on port 8123 on the LAN interface.

In configuration.yaml, you can set the _http: server_host_ to choose the binded interface.
Setting this parameter to 127.0.0.1 bind the home assistant web service on the loopback and therefore remove the LAN exposure.
This configuration needs the Nginx Reverse Proxy to send back the web feed to the loopback interface, which is not possible with the static FQDN configuration on _homeassistant.local.hass.io_ with static port.

This commit enable user to set the _proxy_pass setting_ to _http://127.0.0.1:8123_ and the _http: server_host_ configuration to _127.0.0.1_ in order to harden their system.

Discussion is open in case this is a bad idea for others considerations than hardening :)
Got inspiration from https://community.home-assistant.io/t/reverse-proxy-using-nginx/196954 
