### PR TITLE
deCONZ: Update to v2.11.5

### DIFF
--- a/deconz/CHANGELOG.md
+++ b/deconz/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.9.0
+
+- Bump deCONZ to 2.11.5
+
 ## 6.8.0
 
 - Bump deCONZ to 2.10.4

--- a/deconz/build.json
+++ b/deconz/build.json
@@ -5,6 +5,6 @@
     "armhf": "homeassistant/armhf-base-raspbian:buster"
   },
   "args": {
-    "DECONZ_VERSION": "2.10.04"
+    "DECONZ_VERSION": "2.11.05"
   }
 }

--- a/deconz/config.json
+++ b/deconz/config.json
@@ -1,6 +1,6 @@
 {
   "name": "deCONZ",
-  "version": "6.8.0",
+  "version": "6.9.0",
   "slug": "deconz",
   "description": "Control a Zigbee network with ConBee or RaspBee by Dresden Elektronik",
   "arch": ["amd64", "armhf", "aarch64"],


### PR DESCRIPTION
See: https://github.com/dresden-elektronik/deconz-rest-plugin/releases/tag/v2.11.5