### PR TITLE
ssh: Upgrade CLI to 4.12.2

### DIFF
--- a/ssh/CHANGELOG.md
+++ b/ssh/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 9.1.2
+
+- Upgrade Home Assistant CLI to 4.12.2
+
 ## 9.1.1
 
 - Use GitHub Container Registry for the base image

--- a/ssh/build.json
+++ b/ssh/build.json
@@ -7,7 +7,7 @@
     "i386": "ghcr.io/home-assistant/i386-base:3.13"
   },
   "args": {
-    "CLI_VERSION": "4.12.1",
+    "CLI_VERSION": "4.12.2",
     "LIBWEBSOCKETS_VERSION": "4.1.4",
     "TTYD_VERSION": "1.6.3"
   }

--- a/ssh/config.json
+++ b/ssh/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Terminal & SSH",
-  "version": "9.1.1",
+  "version": "9.1.2",
   "slug": "ssh",
   "description": "Allow logging in remotely to Home Assistant using SSH",
   "url": "https://github.com/home-assistant/hassio-addons/tree/master/ssh",


### PR DESCRIPTION
# Changelog

## 9.1.2

- Upgrade Home Assistant CLI to 4.12.2

Upstream release notes: https://github.com/home-assistant/cli/releases/tag/4.12.2