### PR TITLE
git-pull: Upgrade CLI to 4.12.2

### DIFF
--- a/git_pull/CHANGELOG.md
+++ b/git_pull/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 7.13.1
+
+- Update Home Assistant CLI to 4.12.2
+
 ## 7.13.0
 
 - Update Home Assistant CLI to 4.12.1

--- a/git_pull/build.json
+++ b/git_pull/build.json
@@ -7,6 +7,6 @@
     "i386": "ghcr.io/home-assistant/i386-base:3.13"
   },
   "args": {
-    "CLI_VERSION": "4.12.1"
+    "CLI_VERSION": "4.12.2"
   }
 }

--- a/git_pull/config.json
+++ b/git_pull/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Git pull",
-  "version": "7.13.0",
+  "version": "7.13.1",
   "slug": "git_pull",
   "description": "Simple git pull to update the local configuration",
   "url": "https://github.com/home-assistant/hassio-addons/tree/master/git_pull",


### PR DESCRIPTION
# Changelog

## 7.13.1

- Update Home Assistant CLI to 4.12.2

Upstream release notes: <https://github.com/home-assistant/cli/releases/tag/4.12.2>