### PR TITLE
remove redundant log_type settings to allow customization

### DIFF
--- a/mosquitto/rootfs/usr/share/tempio/mosquitto.gtpl
+++ b/mosquitto/rootfs/usr/share/tempio/mosquitto.gtpl
@@ -1,10 +1,6 @@
 protocol mqtt
 user root
 log_dest stdout
-log_type error
-log_type warning
-log_type notice
-log_type information
 persistence true
 persistence_location /data/
 


### PR DESCRIPTION
Fix for https://github.com/home-assistant/addons/issues/2022 .
No change to existing behavior since the previously configured log_types are the defaults.
User can now customize log_types using the customize feature. Before, log_types could only be added to, not removed.

Thanks for considering this PR,

- Benjamin