### PR TITLE
Bump versions for zwave_js addon

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# 0.1.22
+
+- Bump Z-Wave JS Server to 1.6.0
+- Pin Z-Wave JS to 7.5.2
+
 # 0.1.21
 
 - Pin Z-Wave JS to 7.3.0

--- a/zwave_js/build.json
+++ b/zwave_js/build.json
@@ -7,7 +7,7 @@
     "aarch64": "homeassistant/aarch64-base:3.13"
   },
   "args": {
-    "ZWAVEJS_SERVER_VERSION": "1.5.0",
-    "ZWAVEJS_VERSION": "7.3.0"
+    "ZWAVEJS_SERVER_VERSION": "1.6.0",
+    "ZWAVEJS_VERSION": "7.5.2"
   }
 }

--- a/zwave_js/config.json
+++ b/zwave_js/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Z-Wave JS",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "slug": "zwave_js",
   "description": "Control a ZWave network with Home Assistant Z-Wave JS",
   "arch": ["amd64", "i386", "armhf", "armv7", "aarch64"],


### PR DESCRIPTION
Changelogs:
- Server: https://github.com/zwave-js/zwave-js-server/releases/tag/1.6.0
- zwave-js
    - https://github.com/zwave-js/node-zwave-js/releases/tag/v7.4.0
    - https://github.com/zwave-js/node-zwave-js/releases/tag/v7.5.0
    - https://github.com/zwave-js/node-zwave-js/releases/tag/v7.5.1
    - https://github.com/zwave-js/node-zwave-js/releases/tag/v7.5.2