### PR TITLE
ssh: Upgrade CLI to 4.12.3

### DIFF
--- a/ssh/CHANGELOG.md
+++ b/ssh/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 9.1.3
+
+- Upgrade Home Assistant CLI to 4.12.3
+
 ## 9.1.2
 
 - Upgrade Home Assistant CLI to 4.12.2

--- a/ssh/build.json
+++ b/ssh/build.json
@@ -7,7 +7,7 @@
     "i386": "ghcr.io/home-assistant/i386-base:3.13"
   },
   "args": {
-    "CLI_VERSION": "4.12.2",
+    "CLI_VERSION": "4.12.3",
     "LIBWEBSOCKETS_VERSION": "4.1.4",
     "TTYD_VERSION": "1.6.3"
   }

--- a/ssh/config.json
+++ b/ssh/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Terminal & SSH",
-  "version": "9.1.2",
+  "version": "9.1.3",
   "slug": "ssh",
   "description": "Allow logging in remotely to Home Assistant using SSH",
   "url": "https://github.com/home-assistant/hassio-addons/tree/master/ssh",


### PR DESCRIPTION
## 9.1.3

- Upgrade Home Assistant CLI to 4.12.3

Upstream release notes: <https://github.com/home-assistant/cli/releases/tag/4.12.3>