### PR TITLE
git_pull: Use ff-only when pulling

### DIFF
--- a/git_pull/CHANGELOG.md
+++ b/git_pull/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 7.14.0
+
+- Use ff-only when pulling to avoid superflous warning logs
+
 ## 7.13.1
 
 - Update Home Assistant CLI to 4.12.2

--- a/git_pull/config.json
+++ b/git_pull/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Git pull",
-  "version": "7.13.1",
+  "version": "7.14.0",
   "slug": "git_pull",
   "description": "Simple git pull to update the local configuration",
   "url": "https://github.com/home-assistant/hassio-addons/tree/master/git_pull",

--- a/git_pull/data/run.sh
+++ b/git_pull/data/run.sh
@@ -151,7 +151,7 @@ function git-synchronize {
             case "$GIT_COMMAND" in
                 pull)
                     echo "[Info] Start git pull..."
-                    git pull || { echo "[Error] Git pull failed"; return 1; }
+                    git pull --ff-only || { echo "[Error] Git pull failed"; return 1; }
                     ;;
                 reset)
                     echo "[Info] Start git reset..."


### PR DESCRIPTION
Fixes hint showing up in the logs on every pull. We can use ff-only since no local commits are to be expected.