### PR TITLE
Avoid propagation of error status on clean shutdown

### DIFF
--- a/mariadb/rootfs/etc/services.d/mariadb/run
+++ b/mariadb/rootfs/etc/services.d/mariadb/run
@@ -126,6 +126,8 @@ fi
 function stop_mariadb() {
     bashio::services.delete "mysql"
     mysqladmin shutdown
+    # Successful exit, avoid wait exit status to propagate
+    exit 0
 }
 trap "stop_mariadb" SIGTERM SIGHUP
 


### PR DESCRIPTION
When shutting down the MariaDB Add-on sometimes the following message is
printed by s6-svscanctl in the finish script:
s6-svscanctl: fatal: unable to control /var/run/s6/services: supervisor not listening

The purpose of the finish script is to cleanup the service in case the
run script returned with an error (see [1]). However, the intention is
a clean shutdown, so why is the finish script even running s6-svscanctl?

The reason is that the run script actually returns with an error status
of 143. This comes from the wait bash built-in, which returns 128+15
(SIGTERM) on reception of a signal. From TLDP (see [2]):
> When Bash is waiting for an asynchronous command via the wait
> built-in, the reception of a signal for which a trap has been set will
> cause the wait built-in to return immediately with an exit status
> greater than 128, immediately after which the trap is executed.

We usually want the return code of wait to propagate (in case the main
mariadb process exits with an error), however not in that particular
case. Use exit 0 to make the run script return success on clean
shutdown.

[1] https://github.com/just-containers/s6-overlay#writing-an-optional-finish-script
[2] https://tldp.org/LDP/Bash-Beginners-Guide/html/sect_12_02.html