### PR TITLE
Added options to configure DHCP failover with a seconds DHCP server

### DIFF
--- a/dhcp_server/CHANGELOG.md
+++ b/dhcp_server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.3
+
+- Added options to configure failover with a second DHCP server
+
 ## 1.2
 
 - Fixes crash when using FQDN as domain

--- a/dhcp_server/README.md
+++ b/dhcp_server/README.md
@@ -1,12 +1,14 @@
 # Home Assistant Add-on: DHCP server
 
-A simple DHCP server.
+A simple DHCP server albeit with failover capabilities.
 
 ![Supports aarch64 Architecture][aarch64-shield] ![Supports amd64 Architecture][amd64-shield] ![Supports armhf Architecture][armhf-shield] ![Supports armv7 Architecture][armv7-shield] ![Supports i386 Architecture][i386-shield]
 
 This add-on provides a simple DHCP server for your network.
 It provides some basic needs, like, reserving IP addresses for your devices
 to ensure they always get assigned the same IP address.
+
+It also allows to configure DHCP failover with a second DHCP server on your network.
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg

--- a/dhcp_server/config.json
+++ b/dhcp_server/config.json
@@ -19,7 +19,6 @@
     "max_lease": 172800,
     "domain": null,
     "dns": ["8.8.8.8", "8.8.4.4"],
-    "enable_failover": false,
     "networks": [
       {
         "subnet": "192.168.1.0",
@@ -28,23 +27,10 @@
         "range_end": "192.168.1.200",
         "broadcast": "192.168.1.255",
         "gateway": "192.168.1.1",
-        "interface": "eth0",
-        "failover_peer": "failover_partner"
+        "interface": "eth0"
       }
     ],
-    "failover_peers": [
-      {
-        "name": "failover_partner",
-        "role": "primary",
-        "mclt": 60,
-        "split": 128,
-        "peer_address": "192.168.1.2",
-        "peer_port": 647,
-        "max_response_delay": 60,
-        "max_unacked_updates": 10,
-        "load_balance_max_seconds": 3
-      }
-    ],
+    "failover_peers": [],
     "hosts": []
   },
   "schema": {
@@ -52,7 +38,6 @@
     "max_lease": "int",
     "domain": "str",
     "dns": ["str"],
-    "enable_failover": "bool?",
     "networks": [
       {
         "subnet": "str",
@@ -68,7 +53,6 @@
     "failover_peers": [
       {
         "name": "str",
-        "role": "list(primary|secondary)",
         "mclt": "int?",
         "split": "int(0,256)?",
         "peer_address": "str",

--- a/dhcp_server/config.json
+++ b/dhcp_server/config.json
@@ -1,18 +1,25 @@
 {
   "name": "DHCP server",
-  "version": "1.2",
+  "version": "1.3",
   "slug": "dhcp_server",
-  "description": "A simple DHCP server",
+  "description": "A simple DHCP server with failover capability",
   "url": "https://home-assistant.io/addons/dhcp_server/",
   "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],
   "advanced": true,
   "startup": "system",
   "host_network": true,
+  "ports": {
+    "647/tcp": 647
+  },
+  "ports_description": {
+    "647/tcp": "DHCP failover handshake"
+  },
   "options": {
     "default_lease": 86400,
     "max_lease": 172800,
     "domain": null,
     "dns": ["8.8.8.8", "8.8.4.4"],
+    "enable_failover": false,
     "networks": [
       {
         "subnet": "192.168.1.0",
@@ -21,7 +28,21 @@
         "range_end": "192.168.1.200",
         "broadcast": "192.168.1.255",
         "gateway": "192.168.1.1",
-        "interface": "eth0"
+        "interface": "eth0",
+        "failover_peer": "failover_partner"
+      }
+    ],
+    "failover_peers": [
+      {
+        "name": "failover_partner",
+        "role": "primary",
+        "mclt": 60,
+        "split": 128,
+        "peer_address": "192.168.1.2",
+        "peer_port": 647,
+        "max_response_delay": 60,
+        "max_unacked_updates": 10,
+        "load_balance_max_seconds": 3
       }
     ],
     "hosts": []
@@ -31,6 +52,7 @@
     "max_lease": "int",
     "domain": "str",
     "dns": ["str"],
+    "enable_failover": "bool?",
     "networks": [
       {
         "subnet": "str",
@@ -39,7 +61,21 @@
         "range_end": "str",
         "broadcast": "str",
         "gateway": "str",
-        "interface": "str"
+        "interface": "str",
+        "failover_peer": "str?"
+      }
+    ],
+    "failover_peers": [
+      {
+        "name": "str",
+        "role": "list(primary|secondary)",
+        "mclt": "int?",
+        "split": "int(0,256)?",
+        "peer_address": "str",
+        "peer_port": "port",
+        "max_response_delay": "int",
+        "max_unacked_updates": "int",
+        "load_balance_max_seconds": "int"
       }
     ],
     "hosts": [

--- a/dhcp_server/data/run.sh
+++ b/dhcp_server/data/run.sh
@@ -20,6 +20,43 @@ MAX_LEASE=$(bashio::config 'max_lease')
     echo "authoritative;"
 } > "${CONFIG}"
 
+ENABLE_FAILOVER=$(bashio::config 'enable_failover')
+if bashio::var.true "${ENABLE_FAILOVER}"
+then
+    # Create fail over peers
+    for peer in $(bashio::config 'failover_peers|keys'); do
+        NAME=$(bashio::config "failover_peers[${peer}].name")
+        ROLE=$(bashio::config "failover_peers[${peer}].role")
+        MCLT=$(bashio::config "failover_peers[${peer}].mclt")
+        SPLIT=$(bashio::config "failover_peers[${peer}].split")
+        PEER_ADDRESS=$(bashio::config "failover_peers[${peer}].peer_address")
+        PEER_PORT=$(bashio::config "failover_peers[${peer}].peer_port")
+        MAX_RESPONSE_DELAY=$(bashio::config "failover_peers[${peer}].max_response_delay")
+        MAX_UNACKED_UPDATES=$(bashio::config "failover_peers[${peer}].max_unacked_updates")
+        LOAD_BALANCE_MAX_SECONDS=$(bashio::config "failover_peers[${peer}].load_balance_max_seconds")
+
+        {
+            echo "failover peer \"${NAME}\" {"
+            if bashio::var.equals "${ROLE}" "secondary"
+            then
+                echo "  secondary;"
+            else
+                echo "  primary;"
+                echo "  mclt ${MCLT};"
+                echo "  split ${SPLIT};"
+            fi
+            echo "  address $(bashio::addon.ip_address);"
+            echo "  port 647;"
+            echo "  peer address ${PEER_ADDRESS};"
+            echo "  peer port ${PEER_PORT:-647};"
+            echo "  max-response-delay ${MAX_RESPONSE_DELAY};"
+            echo "  max-unacked-updates ${MAX_UNACKED_UPDATES};"
+            echo "  load balance max seconds ${LOAD_BALANCE_MAX_SECONDS};"
+            echo "}"
+        } >> "${CONFIG}"
+    done
+fi
+
 # Create networks
 for network in $(bashio::config 'networks|keys'); do
     BROADCAST=$(bashio::config "networks[${network}].broadcast")
@@ -29,13 +66,24 @@ for network in $(bashio::config 'networks|keys'); do
     RANGE_END=$(bashio::config "networks[${network}].range_end")
     RANGE_START=$(bashio::config "networks[${network}].range_start")
     SUBNET=$(bashio::config "networks[${network}].subnet")
+    FAILOVER_PEER=$(bashio::config "networks[${network}].failover_peer")
 
     {
         echo "subnet ${SUBNET} netmask ${NETMASK} {"
         echo "  interface ${INTERFACE};"
-        echo "  range ${RANGE_START} ${RANGE_END};"
         echo "  option routers ${GATEWAY};"
         echo "  option broadcast-address ${BROADCAST};"
+        if bashio::var.equals "${FAILOVER_PEER}" "null" || \
+           bashio::var.is_empty "${FAILOVER_PEER}" || \
+           bashio::var.false "${ENABLE_FAILOVER}"
+        then
+            echo "  range ${RANGE_START} ${RANGE_END};"
+        else
+            echo "  pool {"
+            echo "    failover peer \"${FAILOVER_PEER}\";"
+            echo "    range ${RANGE_START} ${RANGE_END};"
+            echo "  }"
+        fi
         echo "}"
     } >> "${CONFIG}"
 done
@@ -60,8 +108,11 @@ if ! bashio::fs.file_exists "${LEASES}"; then
     touch "${LEASES}"
 fi
 
-# Start DHCP server
-bashio::log.info "Starting DHCP server..."
+# Write configuration to log and start DHCP server
+bashio::log.info "Starting DHCP server with the following configuration:"
+cat "${CONFIG}"
+echo ""
+
 exec /usr/sbin/dhcpd \
     -4 -f -d --no-pid \
     -lf "${LEASES}" \

--- a/dhcp_server/data/run.sh
+++ b/dhcp_server/data/run.sh
@@ -20,42 +20,49 @@ MAX_LEASE=$(bashio::config 'max_lease')
     echo "authoritative;"
 } > "${CONFIG}"
 
-ENABLE_FAILOVER=$(bashio::config 'enable_failover')
-if bashio::var.true "${ENABLE_FAILOVER}"
-then
-    # Create fail over peers
-    for peer in $(bashio::config 'failover_peers|keys'); do
-        NAME=$(bashio::config "failover_peers[${peer}].name")
-        ROLE=$(bashio::config "failover_peers[${peer}].role")
-        MCLT=$(bashio::config "failover_peers[${peer}].mclt")
-        SPLIT=$(bashio::config "failover_peers[${peer}].split")
-        PEER_ADDRESS=$(bashio::config "failover_peers[${peer}].peer_address")
-        PEER_PORT=$(bashio::config "failover_peers[${peer}].peer_port")
-        MAX_RESPONSE_DELAY=$(bashio::config "failover_peers[${peer}].max_response_delay")
-        MAX_UNACKED_UPDATES=$(bashio::config "failover_peers[${peer}].max_unacked_updates")
-        LOAD_BALANCE_MAX_SECONDS=$(bashio::config "failover_peers[${peer}].load_balance_max_seconds")
+# Create fail over peers
+declare -A peer_names
+for peer in $(bashio::config 'failover_peers|keys'); do
+    NAME=$(bashio::config "failover_peers[${peer}].name")
+    MCLT=$(bashio::config "failover_peers[${peer}].mclt")
+    SPLIT=$(bashio::config "failover_peers[${peer}].split")
+    PEER_ADDRESS=$(bashio::config "failover_peers[${peer}].peer_address")
+    PEER_PORT=$(bashio::config "failover_peers[${peer}].peer_port")
+    MAX_RESPONSE_DELAY=$(bashio::config "failover_peers[${peer}].max_response_delay")
+    MAX_UNACKED_UPDATES=$(bashio::config "failover_peers[${peer}].max_unacked_updates")
+    LOAD_BALANCE_MAX_SECONDS=$(bashio::config "failover_peers[${peer}].load_balance_max_seconds")
 
-        {
-            echo "failover peer \"${NAME}\" {"
-            if bashio::var.equals "${ROLE}" "secondary"
-            then
-                echo "  secondary;"
-            else
+    {
+        peer_names[${NAME}]="defined"
+
+        echo "failover peer \"${NAME}\" {"
+        if bashio::var.has_value "${MCLT}" && ! bashio::var.equals "${MCLT}" "null"; then
+	    if bashio::var.has_value "${SPLIT}" && ! bashio::var.equals "${SPLIT}" "null"; then
                 echo "  primary;"
                 echo "  mclt ${MCLT};"
                 echo "  split ${SPLIT};"
+            else
+                bashio::log.error "Invalid failover configuration!"
+                bashio::log.error "failover_peers.mclt can only be specified together with failover_peers.split"
+                exit 1
             fi
-            echo "  address $(bashio::addon.ip_address);"
-            echo "  port 647;"
-            echo "  peer address ${PEER_ADDRESS};"
-            echo "  peer port ${PEER_PORT:-647};"
-            echo "  max-response-delay ${MAX_RESPONSE_DELAY};"
-            echo "  max-unacked-updates ${MAX_UNACKED_UPDATES};"
-            echo "  load balance max seconds ${LOAD_BALANCE_MAX_SECONDS};"
-            echo "}"
-        } >> "${CONFIG}"
-    done
-fi
+	elif bashio::var.has_value "${SPLIT}" && ! bashio::var.equals "${SPLIT}" "null"; then
+            bashio::log.error "Invalid failover configuration!"
+            bashio::log.error "failover_peers.split can only be specified together with failover_peers.mclt"
+            exit 1
+        else
+            echo "  secondary;"
+        fi
+        echo "  address $(bashio::addon.ip_address);"
+        echo "  port 647;"
+        echo "  peer address ${PEER_ADDRESS};"
+        echo "  peer port ${PEER_PORT:-647};"
+        echo "  max-response-delay ${MAX_RESPONSE_DELAY};"
+        echo "  max-unacked-updates ${MAX_UNACKED_UPDATES};"
+        echo "  load balance max seconds ${LOAD_BALANCE_MAX_SECONDS};"
+        echo "}"
+    } >> "${CONFIG}"
+done
 
 # Create networks
 for network in $(bashio::config 'networks|keys'); do
@@ -74,19 +81,40 @@ for network in $(bashio::config 'networks|keys'); do
         echo "  option routers ${GATEWAY};"
         echo "  option broadcast-address ${BROADCAST};"
         if bashio::var.equals "${FAILOVER_PEER}" "null" || \
-           bashio::var.is_empty "${FAILOVER_PEER}" || \
-           bashio::var.false "${ENABLE_FAILOVER}"
-        then
+           bashio::var.is_empty "${FAILOVER_PEER}"; then 
             echo "  range ${RANGE_START} ${RANGE_END};"
-        else
+        elif [ ${peer_names[${FAILOVER_PEER}]+_} ]; then
+            peer_names[${FAILOVER_PEER}]="referenced"
             echo "  pool {"
             echo "    failover peer \"${FAILOVER_PEER}\";"
             echo "    range ${RANGE_START} ${RANGE_END};"
             echo "  }"
+        else
+            bashio::log.error "Invalid failover configuration!"
+            bashio::log.error "failover_peer ${FAILOVER_PEER} is referenced but not defined."
+            exit 1
         fi
         echo "}"
     } >> "${CONFIG}"
 done
+
+failover_config_error=false
+for peer in "${!peer_names[@]}"; do
+    if bashio::var.equals "${peer_names[${peer}]}" "defined"
+    then
+        if bashio::var.false "${failover_config_error}"
+        then
+            failover_config_error=true
+            bashio::log.error "Invalid failover configuration!"
+        fi
+        bashio::log.error "failover peer ${peer} was defined but not refrenced"
+    fi
+done
+
+if bashio::var.true "${failover_config_error}"
+then
+    exit 1
+fi
 
 # Create hosts
 for host in $(bashio::config 'hosts|keys'); do
@@ -110,8 +138,9 @@ fi
 
 # Write configuration to log and start DHCP server
 bashio::log.info "Starting DHCP server with the following configuration:"
+echo " "
 cat "${CONFIG}"
-echo ""
+echo " "
 
 exec /usr/sbin/dhcpd \
     -4 -f -d --no-pid \


### PR DESCRIPTION
This pull request just changes the way the options are processed in run.sh.
I added options to allow run.sh to generate a dhcpd.conf that contains all necessary definitions to have the DHCP server run in failover mode.

The way the options are added makes sure, that updating an already running addon of version 1.2 will change the user's configuration in a way, that the addon will work as before without needing any manual changes to the configuration, even though the default configuration will be added to the existing configuration automatically. Only if the user changes the option 'enable_failover' from its default value of 'false' to 'true' will the failover-options be taken into consideration by runs.sh when generating the dhcpd.conf. 

The addon documentation is updated accordingly and contains links to further information about DHCP failover configuration.
