### PR TITLE
Bump zwave-js to 7.9.0

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.27
+
+- Bump Z-Wave JS to 7.9.0
+
 ## 0.1.26
 
 - Bump Z-Wave JS to 7.7.4

--- a/zwave_js/build.json
+++ b/zwave_js/build.json
@@ -8,6 +8,6 @@
   },
   "args": {
     "ZWAVEJS_SERVER_VERSION": "1.7.0",
-    "ZWAVEJS_VERSION": "7.7.4"
+    "ZWAVEJS_VERSION": "7.9.0"
   }
 }

--- a/zwave_js/config.json
+++ b/zwave_js/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Z-Wave JS",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "slug": "zwave_js",
   "description": "Control a ZWave network with Home Assistant Z-Wave JS",
   "arch": ["amd64", "i386", "armhf", "armv7", "aarch64"],


### PR DESCRIPTION
Changelogs:
- https://github.com/zwave-js/node-zwave-js/releases/tag/v7.7.5
- https://github.com/zwave-js/node-zwave-js/releases/tag/v7.8.0
- https://github.com/zwave-js/node-zwave-js/releases/tag/v7.9.0