### PR TITLE
Bump zwave-js and zwave-js-server

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# 0.1.28
+
+- Bump Z-Wave JS to 7.10.0
+- Bump Z-Wave JS Server to 1.8.0
+
 ## 0.1.27
 
 - Bump Z-Wave JS to 7.9.0

--- a/zwave_js/build.json
+++ b/zwave_js/build.json
@@ -7,7 +7,7 @@
     "aarch64": "homeassistant/aarch64-base:3.13"
   },
   "args": {
-    "ZWAVEJS_SERVER_VERSION": "1.7.0",
-    "ZWAVEJS_VERSION": "7.9.0"
+    "ZWAVEJS_SERVER_VERSION": "1.8.0",
+    "ZWAVEJS_VERSION": "7.10.0"
   }
 }

--- a/zwave_js/config.json
+++ b/zwave_js/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Z-Wave JS",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "slug": "zwave_js",
   "description": "Control a ZWave network with Home Assistant Z-Wave JS",
   "arch": ["amd64", "i386", "armhf", "armv7", "aarch64"],


### PR DESCRIPTION
https://github.com/home-assistant-libs/zwave-js-server-python/releases/tag/0.27.0
https://github.com/zwave-js/zwave-js-server/releases/tag/1.8.0
https://github.com/zwave-js/node-zwave-js/releases/tag/v7.10.0