### PR TITLE
dnsmasq: enable dnssec, increase cache

### DIFF
--- a/dnsmasq/rootfs/usr/share/tempio/dnsmasq.config
+++ b/dnsmasq/rootfs/usr/share/tempio/dnsmasq.config
@@ -6,6 +6,7 @@ keep-in-foreground
 log-queries
 log-facility=-
 no-poll
+bogus-priv
 user=root
 
 # Default forward servers

--- a/dnsmasq/rootfs/usr/share/tempio/dnsmasq.config
+++ b/dnsmasq/rootfs/usr/share/tempio/dnsmasq.config
@@ -3,7 +3,6 @@
 no-resolv
 no-hosts
 keep-in-foreground
-log-queries
 log-facility=-
 no-poll
 bogus-priv

--- a/dnsmasq/rootfs/usr/share/tempio/dnsmasq.config
+++ b/dnsmasq/rootfs/usr/share/tempio/dnsmasq.config
@@ -7,6 +7,8 @@ log-facility=-
 no-poll
 bogus-priv
 cache-size=100000
+dnssec
+dnssec-check-unsigned
 user=root
 
 # Default forward servers

--- a/dnsmasq/rootfs/usr/share/tempio/dnsmasq.config
+++ b/dnsmasq/rootfs/usr/share/tempio/dnsmasq.config
@@ -7,6 +7,7 @@ log-queries
 log-facility=-
 no-poll
 bogus-priv
+cache-size=100000
 user=root
 
 # Default forward servers


### PR DESCRIPTION
- the dnssec validation in dnsmasq makes sure signed domains are validated before handed to the requesting clients.
- the dnssec-check-unsigned makes sure that responses that are unsigned are validated from the root to make sure that there's no signature available
- the change in cache size from 150 to 100K leverages the large amount of memory a HA computer usually has, to reduce the response times and reduce the overhead of dnssec by caching much more requests
- skip the log of queries
- filters out queries for the non-routed address space (e.g. private networks)

