### PR TITLE
Update base and allow stable/beta/dev

### DIFF
--- a/check_config/CHANGELOG.md
+++ b/check_config/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.8.0
+
+- Update base image to 2021.07.0
+- Allow using `stable`, `beta` and `dev` as target versions
+- Add translation file for English
+
 ## 3.7.1
 
 - Update base image to 2021.04.3

--- a/check_config/DOCS.md
+++ b/check_config/DOCS.md
@@ -34,8 +34,12 @@ version: latest
 
 The version of Home Assistant that want to check your configuration against.
 
-Setting this option to `latest` will result in checking your configuration
+- Setting this option to `latest` or `stable` will result in checking your configuration
 against the latest stable release of Home Assistant.
+- Setting this option to `beta` will result in checking your configuration
+against the latest beta release of Home Assistant.
+- Setting this option to `dev` will result in checking your configuration
+against the current dev branch of Home Assistant.
 
 ## Known issues and limitations
 

--- a/check_config/build.json
+++ b/check_config/build.json
@@ -1,9 +1,9 @@
 {
   "build_from": {
-    "aarch64": "ghcr.io/home-assistant/aarch64-homeassistant-base:2021.04.3",
-    "amd64": "ghcr.io/home-assistant/amd64-homeassistant-base:2021.04.3",
-    "armhf": "ghcr.io/home-assistant/armhf-homeassistant-base:2021.04.3",
-    "armv7": "ghcr.io/home-assistant/armv7-homeassistant-base:2021.04.3",
-    "i386": "ghcr.io/home-assistant/i386-homeassistant-base:2021.04.3"
+    "aarch64": "ghcr.io/home-assistant/aarch64-homeassistant-base:2021.07.0",
+    "amd64": "ghcr.io/home-assistant/amd64-homeassistant-base:2021.07.0",
+    "armhf": "ghcr.io/home-assistant/armhf-homeassistant-base:2021.07.0",
+    "armv7": "ghcr.io/home-assistant/armv7-homeassistant-base:2021.07.0",
+    "i386": "ghcr.io/home-assistant/i386-homeassistant-base:2021.07.0"
   }
 }

--- a/check_config/config.json
+++ b/check_config/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Check Home Assistant configuration",
-  "version": "3.7.1",
+  "version": "3.8.0",
   "slug": "check_config",
   "description": "Check current Home Assistant configuration against a new version",
   "url": "https://github.com/home-assistant/hassio-addons/tree/master/check_config",

--- a/check_config/rootfs/etc/services.d/check-config/run
+++ b/check_config/rootfs/etc/services.d/check-config/run
@@ -4,10 +4,18 @@
 # ==============================================================================
 VERSION=$(bashio::config 'version')
 
+CMD_OPTIONS=("--disable-pip-version-check" "--find-links" "${WHEELS_LINKS}")
+
 # Generate install string
-CMD="homeassistant"
-if [ "${VERSION}" != "latest" ]; then
-    CMD="homeassistant==${VERSION}"
+if [[ "${VERSION}" =~ latest|stable ]]; then
+    CMD_OPTIONS+=("homeassistant")
+elif [ "${VERSION}" == "beta" ]; then
+    CMD_OPTIONS+=("--pre")
+    CMD_OPTIONS+=("homeassistant")
+elif [ "${VERSION}" == "dev" ]; then
+    CMD_OPTIONS+=("git+git://github.com/home-assistant/core.git@dev")
+else
+    CMD_OPTIONS+=("homeassistant==${VERSION}")
 fi
 
 bashio::log.info "Don't worry, this temporary installation is not overwriting your current one."
@@ -15,7 +23,7 @@ bashio::log.info "Installing Home Assistant: ${VERSION}..."
 bashio::log.info "Please be patient, this might take a few minutes..."
 
 # Install Home Assistant with the requested version
-if ! PIP_OUTPUT="$(pip3 install --disable-pip-version-check --find-links "${WHEELS_LINKS}" "${CMD}" 2>&1)"; then
+if ! PIP_OUTPUT=$(pip3 install "${CMD_OPTIONS[@]}" 2>&1); then
     bashio::log.error "An error occurred while installing Home Assistant:"
     bashio::log "${PIP_OUTPUT}"
     bashio::exit.nok

--- a/check_config/translations/en.yaml
+++ b/check_config/translations/en.yaml
@@ -1,0 +1,4 @@
+configuration:
+  version:
+    name: Version
+    description: The version of Home Assistant to check against, you can use `stable` , `latest`, `dev` and a version,

--- a/check_config/translations/en.yaml
+++ b/check_config/translations/en.yaml
@@ -1,4 +1,4 @@
 configuration:
   version:
     name: Version
-    description: The version of Home Assistant to check against, you can use `stable` , `latest`, `dev` and a version,
+    description: The version of Home Assistant to check against, you can use `stable` , `latest`, `dev` and a version


### PR DESCRIPTION
- Update base image to 2021.07.0
- Allow using `stable`, `beta` and `dev` as target versions
- Add translation file for English