### PR TITLE
Update base and dehydrated

### DIFF
--- a/duckdns/CHANGELOG.md
+++ b/duckdns/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.13.0
+
+- Update base to 3.14
+- Use images from ghcr
+- Update dehydrated to 0.7.0
+
 ## 1.12.5
 
 - Fix bug causing DuckDNS to return KO, when aliases were configured

--- a/duckdns/build.json
+++ b/duckdns/build.json
@@ -1,12 +1,12 @@
 {
   "build_from": {
-    "aarch64": "homeassistant/aarch64-base:3.10",
-    "amd64": "homeassistant/amd64-base:3.10",
-    "armhf": "homeassistant/armhf-base:3.10",
-    "armv7": "homeassistant/armv7-base:3.10",
-    "i386": "homeassistant/i386-base:3.10"
+    "aarch64": "ghcr.io/home-assistant/aarch64-base:3.14",
+    "amd64": "ghcr.io/home-assistant/amd64-base:3.14",
+    "armhf": "ghcr.io/home-assistant/armhf-base:3.14",
+    "armv7": "ghcr.io/home-assistant/armv7-base:3.14",
+    "i386": "ghcr.io/home-assistant/i386-base:3.14"
   },
   "args": {
-    "DEHYDRATED_VERSION": "0.6.5"
+    "DEHYDRATED_VERSION": "0.7.0"
   }
 }

--- a/duckdns/config.json
+++ b/duckdns/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Duck DNS",
-  "version": "1.12.5",
+  "version": "1.13.0",
   "slug": "duckdns",
   "description": "Free Dynamic DNS (DynDNS or DDNS) service with Let's Encrypt support",
   "url": "https://github.com/home-assistant/hassio-addons/tree/master/duckdns",


### PR DESCRIPTION
- Update base to 3.14
- Use images from ghcr
- Update dehydrated to 0.7.0

https://github.com/dehydrated-io/dehydrated/releases/tag/v0.7.0