### PR TITLE
Add documentation for configuring RFC2136 provider

### DIFF
--- a/letsencrypt/DOCS.md
+++ b/letsencrypt/DOCS.md
@@ -377,24 +377,31 @@ transip_api_key: ''
   <summary>RFC2136</summary>
 
   You will need to set up a server with RFC2136 (Dynamic Update) support with a TKEY (to authenticate the updates).  How to do this will vary depending on the DNS server software in use.  For Bind9, you first need to first generate an authentication key by running
+  
   ```
-  # dnssec-keygen -a HMAC-SHA512 -b 512 -n HOST letsencrypt
+  $ dnssec-keygen -a HMAC-SHA512 -b 512 -n HOST letsencrypt
   Kletsencrypt.+165+20675
   ```
+  
   The key file (Kletsencrypt.+165+20675.key in this example) looks like the following:
+  
   ```
-  # cat Kletsencrypt.+165+20675.key
+  $ cat Kletsencrypt.+165+20675.key
   letsencrypt. IN KEY 512 3 165 Cj2SJThIYZqZO39HIOA8dYryzsLT3CI+m43m3yfGfTMvpyYw5DXjn5da hokrwyLe3MTboGkloKIsT6DUcTSdEA==
+  
   ```
   You don't need to publish this; just copy the key data into your named.conf file:
   ```
+  
   key "letsencrypt" {
     algorithm hmac-sha512;
     secret "Cj2SJThIYZqZO39HIOA8dYryzsLT3CI+m43m3yfGfTMvpyYw5DXjn5da hokrwyLe3MTboGkloKIsT6DUcTSdEA==";
   };
+  
   ```
   And ensure you have an update policy in place in the zone that uses this key to enable update of the correct domain (which must match the domain in your yaml configuration):
   ```
+  
      update-policy {
         grant letsencrypt name _acme-challenge.home-assistant.io. txt;
      };
@@ -419,6 +426,7 @@ transip_api_key: ''
     rfc2136_secret: "secret-key"
     rfc2136_algorithm: HMAC-SHA512
   ```
+  
 </details>
 
 

--- a/letsencrypt/DOCS.md
+++ b/letsencrypt/DOCS.md
@@ -373,6 +373,55 @@ transip_api_key: ''
 
 </details>
 
+<details>
+  <summary>RFC2136</summary>
+
+  You will need to set up a server with RFC2136 (Dynamic Update) support with a TKEY (to authenticate the updates).  How to do this will vary depending on the DNS server software in use.  For Bind9, you first need to first generate an authentication key by running
+  ```
+  # dnssec-keygen -a HMAC-SHA512 -b 512 -n HOST letsencrypt
+  Kletsencrypt.+165+20675
+  ```
+  The key file (Kletsencrypt.+165+20675.key in this example) looks like the following:
+  ```
+  # cat Kletsencrypt.+165+20675.key
+  letsencrypt. IN KEY 512 3 165 Cj2SJThIYZqZO39HIOA8dYryzsLT3CI+m43m3yfGfTMvpyYw5DXjn5da hokrwyLe3MTboGkloKIsT6DUcTSdEA==
+  ```
+  You don't need to publish this; just copy the key data into your named.conf file:
+  ```
+  key "letsencrypt" {
+    algorithm hmac-sha512;
+    secret "Cj2SJThIYZqZO39HIOA8dYryzsLT3CI+m43m3yfGfTMvpyYw5DXjn5da hokrwyLe3MTboGkloKIsT6DUcTSdEA==";
+  };
+  ```
+  And ensure you have an update policy in place in the zone that uses this key to enable update of the correct domain (which must match the domain in your yaml configuration):
+  ```
+     update-policy {
+        grant letsencrypt name _acme-challenge.home-assistant.io. txt;
+     };
+  ```
+
+  For this provider, you will need to supply all the `rfc2136_*` options. Note that the `rfc2136_port` item is required (there is no default port in the add-on) and, most importantly, the port number must be quoted.  Also, be sure to copy in the key so certbot can authenticate to the DNS server.  Finally, the algorithm should be in all caps.
+
+  An example configuration:
+
+  ```yaml
+  email: your.email@example.com
+  domains:
+    - home-assistant.io
+  certfile: fullchain.pem
+  keyfile: privkey.pem
+  challenge: dns
+  dns:
+    provider: dns-rfc2136
+    rfc2136_server: dns-server.dom.ain
+    rfc2136_port: '53'
+    rfc2136_name: letsencrypt
+    rfc2136_secret: "secret-key"
+    rfc2136_algorithm: HMAC-SHA512
+  ```
+</details>
+
+
 ## Certificate files
 
 The certificate files will be available within the "ssl" share after successful request of the certificates.


### PR DESCRIPTION
Fix for Issue #1529 for LetsEncrypt Add-On; Replacement for PR#1763

This PR adds documentation for how to properly configure RFC2136 DNS-based certbot using a DNS server you control. The documentation is necessary because there are a few "gotchas" in the implementation, namely:

    The port specification is required (even if you're using the default port)
    The port specification schema is expecting a string, not a number, so it must be quoted
    In some cases some users have reported that using the FQDN for the DNS server does not work properly.

Improving the documentation will improve the user experience and save users time when trying to configure this mode of operation.

NB: changing the schema could be a breaking change to all existing users, so documenting the current behavior is IMHO safer.