### PR TITLE
Bump zwave-js to 7.12.0

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -2,11 +2,9 @@
 
 ## 0.1.29
 
-
 - Bump Z-Wave JS to 7.12.0
 
 ## 0.1.28
-
 
 - Bump Z-Wave JS to 7.10.0
 - Bump Z-Wave JS Server to 1.8.0

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Changelog
 
-# 0.1.29
+## 0.1.29
+
 
 - Bump Z-Wave JS to 7.12.0
 
-# 0.1.28
+## 0.1.28
+
 
 - Bump Z-Wave JS to 7.10.0
 - Bump Z-Wave JS Server to 1.8.0

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 0.1.29
+
+- Bump Z-Wave JS to 7.12.0
+
 # 0.1.28
 
 - Bump Z-Wave JS to 7.10.0

--- a/zwave_js/build.json
+++ b/zwave_js/build.json
@@ -8,6 +8,6 @@
   },
   "args": {
     "ZWAVEJS_SERVER_VERSION": "1.8.0",
-    "ZWAVEJS_VERSION": "7.10.0"
+    "ZWAVEJS_VERSION": "7.12.0"
   }
 }

--- a/zwave_js/config.json
+++ b/zwave_js/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Z-Wave JS",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "slug": "zwave_js",
   "description": "Control a ZWave network with Home Assistant Z-Wave JS",
   "arch": ["amd64", "i386", "armhf", "armv7", "aarch64"],


### PR DESCRIPTION
https://github.com/zwave-js/node-zwave-js/releases/tag/v7.11.0
https://github.com/zwave-js/node-zwave-js/releases/tag/v7.12.0

closes #2115