### PR TITLE
Bump zwave-js to 8.1.1

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.1.36
 
-- Bump Z-Wave JS to 8.1.0
+- Bump Z-Wave JS to 8.1.1
 
 ## 0.1.35
 

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.36
+
+- Bump Z-Wave JS to 8.1.0
+
 ## 0.1.35
 
 - Bump Z-Wave JS Server to 1.9.3

--- a/zwave_js/build.json
+++ b/zwave_js/build.json
@@ -8,6 +8,6 @@
   },
   "args": {
     "ZWAVEJS_SERVER_VERSION": "1.9.3",
-    "ZWAVEJS_VERSION": "8.1.0"
+    "ZWAVEJS_VERSION": "8.1.1"
   }
 }

--- a/zwave_js/build.json
+++ b/zwave_js/build.json
@@ -8,6 +8,6 @@
   },
   "args": {
     "ZWAVEJS_SERVER_VERSION": "1.9.3",
-    "ZWAVEJS_VERSION": "8.0.8"
+    "ZWAVEJS_VERSION": "8.1.0"
   }
 }

--- a/zwave_js/config.json
+++ b/zwave_js/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Z-Wave JS",
-  "version": "0.1.35",
+  "version": "0.1.36",
   "slug": "zwave_js",
   "description": "Control a ZWave network with Home Assistant Z-Wave JS",
   "arch": ["amd64", "i386", "armhf", "armv7", "aarch64"],


### PR DESCRIPTION
- https://github.com/zwave-js/node-zwave-js/releases/tag/v8.1.0
- https://github.com/zwave-js/node-zwave-js/releases/tag/v8.1.1