### PR TITLE
Bump zwave-js-server to 1.10.0

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 0.1.37
+
+- Bump Z-Wave JS Server to 1.10.0
+
 ## 0.1.36
 
 - Bump Z-Wave JS to 8.1.1

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-# 0.1.37
+## 0.1.37
 
 - Bump Z-Wave JS Server to 1.10.0
 

--- a/zwave_js/build.json
+++ b/zwave_js/build.json
@@ -7,7 +7,7 @@
     "aarch64": "homeassistant/aarch64-base:3.13"
   },
   "args": {
-    "ZWAVEJS_SERVER_VERSION": "1.9.3",
+    "ZWAVEJS_SERVER_VERSION": "1.10.0",
     "ZWAVEJS_VERSION": "8.1.1"
   }
 }

--- a/zwave_js/config.json
+++ b/zwave_js/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Z-Wave JS",
-  "version": "0.1.36",
+  "version": "0.1.37",
   "slug": "zwave_js",
   "description": "Control a ZWave network with Home Assistant Z-Wave JS",
   "arch": ["amd64", "i386", "armhf", "armv7", "aarch64"],


### PR DESCRIPTION
https://github.com/zwave-js/zwave-js-server/releases/tag/1.10.0

We have added support for the new inclusion methods in this PR but the changes are backwards compatible with the existing lib