### PR TITLE
Add S2 keys support to zwave_js config

### DIFF
--- a/zwave_js/DOCS.md
+++ b/zwave_js/DOCS.md
@@ -65,6 +65,10 @@ You must configure four different keys via `s0_legacy_key`, `s2_access_control_k
 `s2_authenticated_key`, and `s2_unauthenticated_key` in order to use all of the secure
 inclusion methods (S0 and S2).
 
+If you are coming from a previous version of `zwave-js`, your key is likely stored in the
+`network_key` configuration option. When the addon is first started, the key will be migrated
+from `network_key` to `s0_legacy_key`.
+
 If any of these keys are missing on startup, the addon will autogenerate one for you.
 
 o generate a network key manually, you can use the following script in, e.g.,

--- a/zwave_js/DOCS.md
+++ b/zwave_js/DOCS.md
@@ -59,15 +59,15 @@ In most cases this looks like one of the following:
 - `"/dev/ttyAMA0"`
 - `"/dev/ttyACM0"`
 
-### Option `network_key`
+### Keys
 
-Security Z-Wave devices require a network key before being added to the network.
-You must set the `network_key` configuration option to use a network key before
-adding these devices.
+You must configure four different keys via `s0_legacy_key`, `s2_access_control_key`,
+`s2_authenticated_key`, and `s2_unauthenticated_key` in order to use all of the secure
+inclusion methods (S0 and S2).
 
-If you don't add a network key, it will autogenerate one for you.
+If any of these keys are missing on startup, the addon will autogenerate one for you.
 
-To generate a network key manually, you can use the following script in, e.g.,
+o generate a network key manually, you can use the following script in, e.g.,
 the SSH add-on:
 
 ```bash
@@ -78,10 +78,34 @@ You can also use sites like this one to generate the required data:
 
 <https://www.random.org/cgi-bin/randbyte?nbytes=16&format=h>
 
-Ensure you keep a backup of this key. If you have to rebuild your system and
-don't have a backup of this key, you won't be able to reconnect to any securely
+Ensure you keep a backup of these key. If you have to rebuild your system and
+don't have a backup of these keys, you won't be able to reconnect to any securely
 included devices. This may mean you have to do a factory reset on those devices
 and your controller, before rebuilding your Z-Wave network.
+
+#### Option `s0_legacy_key`
+
+S0 Security Z-Wave devices require a network key before being added to the network.
+You must set the `s0_legacy_key` configuration option to use a network key before
+adding these devices.
+
+### Option `s2_access_control_key`
+
+S2 Security Z-Wave devices require three network keys before being added to the
+network. You must set this configuration option along with `s2_authenticated_key`
+and `s2_unauthenticated_key` before adding these devices.
+
+### Option `s2_authenticated_key`
+
+S2 Security Z-Wave devices require three network keys before being added to the
+network. You must set this configuration option along with `s2_access_control_key`
+and `s2_unauthenticated_key` before adding these devices.
+
+### Option `s2_unauthenticated_key`
+
+S2 Security Z-Wave devices require three network keys before being added to the
+network. You must set this configuration option along with `s2_access_control_key`
+and `s2_authenticated_key` before adding these devices.
 
 ### Option `log_level` (optional)
 
@@ -101,6 +125,13 @@ the Supervisor.
 
 If you don't have a USB stick, you can use a fake stick for testing purposes.
 It will not be able to control any real devices.
+
+### Option `network_key` (deprecated)
+
+In previous versions of the addon, this was the only key that needed to be configured.
+With the introduction of S2 security inclusion in zwave-js, this option has been
+deprecated in favor of `s0_legacy_key`. If still set, the `network_key` value will be
+migrated to `s0_legacy_key` on first startup.
 
 ## Known issues and limitations
 

--- a/zwave_js/DOCS.md
+++ b/zwave_js/DOCS.md
@@ -63,7 +63,10 @@ In most cases this looks like one of the following:
 
 You must configure four different security keys via `s0_legacy_key`,
 `s2_access_control_key`, `s2_authenticated_key`, and `s2_unauthenticated_key` in order
-to use all of the secure inclusion methods (S0 and S2).
+to use all of the secure inclusion methods (S0 and S2). If you plan to only use S0
+security (not recommended if you have devices that support S2), only the
+`s0_legacy_key` is necessary. If your network doesn't require security at all, these
+configuration options are not needed at all.
 
 If you are coming from a previous version of `zwave-js`, your key is likely stored in the
 `network_key` configuration option. When the addon is first started, the key will be migrated

--- a/zwave_js/DOCS.md
+++ b/zwave_js/DOCS.md
@@ -96,20 +96,23 @@ adding these devices.
 ### Option `s2_access_control_key`
 
 S2 Security Z-Wave devices require three network keys before being added to the
-network. You must set this configuration option along with `s2_authenticated_key`
-and `s2_unauthenticated_key` before adding these devices.
+network. In order to use S2 Security, you must set this configuration option along
+with `s2_authenticated_key` and `s2_unauthenticated_key` before adding these devices.
+This key has no impact on unsecured devices or devices that are using S0 Security.
 
 ### Option `s2_authenticated_key`
 
 S2 Security Z-Wave devices require three network keys before being added to the
-network. You must set this configuration option along with `s2_access_control_key`
-and `s2_unauthenticated_key` before adding these devices.
+network. In order to use S2 Security, you must set this configuration option along
+with `s2_access_control_key` and `s2_unauthenticated_key` before adding these devices.
+This key has no impact on unsecured devices or devices that are using S0 Security.
 
 ### Option `s2_unauthenticated_key`
 
 S2 Security Z-Wave devices require three network keys before being added to the
-network. You must set this configuration option along with `s2_access_control_key`
-and `s2_authenticated_key` before adding these devices.
+network. In order to use S2 Security, you must set this configuration option along
+with `s2_access_control_key` and `s2_authenticated_key` before adding these devices.
+This key has no impact on unsecured devices or devices that are using S0 Security.
 
 ### Option `log_level` (optional)
 

--- a/zwave_js/DOCS.md
+++ b/zwave_js/DOCS.md
@@ -40,7 +40,10 @@ Add-on configuration:
 
 ```yaml
 device: /dev/ttyUSB0
-network_key: 2232666D100F795E5BB17F0A1BB7A146
+s0_legacy_key: 2232666D100F795E5BB17F0A1BB7A146
+s2_access_control_key: A97D2A51A6D4022998BEFC7B5DAE8EA1
+s2_authenticated_key: 309D4AAEF63EFD85967D76ECA014D1DF
+s2_unauthenticated_key: CF338FE0CB99549F7C0EA96308E5A403
 ```
 
 ### Option `device`

--- a/zwave_js/DOCS.md
+++ b/zwave_js/DOCS.md
@@ -61,21 +61,18 @@ In most cases this looks like one of the following:
 
 ### Security Keys
 
-You must configure four different security keys via `s0_legacy_key`,
-`s2_access_control_key`, `s2_authenticated_key`, and `s2_unauthenticated_key` in order
-to use all of the secure inclusion methods (S0 and S2). If you plan to only use S0
-security (not recommended if you have devices that support S2), only the
-`s0_legacy_key` is necessary. If your network doesn't require security at all, these
-configuration options are not needed at all.
+There are four different security keys required to take full advantage of the
+different inclusion methods that Z-Wave JS supports: `s0_legacy_key`,
+`s2_access_control_key`, `s2_authenticated_key`, and `s2_unauthenticated_key`.
 
-If you are coming from a previous version of `zwave-js`, your key is likely stored in the
-`network_key` configuration option. When the addon is first started, the key will be migrated
-from `network_key` to `s0_legacy_key`.
+If you are coming from a previous version of `zwave-js`, you likely have a key
+stored in the `network_key` configuration option. When the addon is first
+started, the key will be migrated from `network_key` to `s0_legacy_key` which
+will ensure that your S0 secured devices will continue to function.
 
-If any of these keys are missing on startup, the addon will autogenerate one for you.
-
-o generate a network key manually, you can use the following script in, e.g.,
-the SSH add-on:
+If any of these keys are missing on startup, the addon will autogenerate one for
+you. To generate a network key manually, you can use the following script in,
+e.g., the SSH add-on:
 
 ```bash
 hexdump -n 16 -e '4/4 "%08X" 1 "\n"' /dev/random
@@ -85,37 +82,43 @@ You can also use sites like this one to generate the required data:
 
 <https://www.random.org/cgi-bin/randbyte?nbytes=16&format=h>
 
-Ensure you keep a backup of these key. If you have to rebuild your system and
-don't have a backup of these keys, you won't be able to reconnect to any securely
-included devices. This may mean you have to do a factory reset on those devices
-and your controller, before rebuilding your Z-Wave network.
+Ensure you keep a backup of these keys. If you have to rebuild your system and
+don't have a backup of these keys, you won't be able to communicate to any
+securely included devices. This may mean you have to do a factory reset on
+those devices and your controller, before rebuilding your Z-Wave network.
+
+> NOTE: Sharing keys between multiple security classes is a security risk, so
+> if you choose to configure these keys on your own, be sure to make them
+> unique!
 
 #### Option `s0_legacy_key`
 
 S0 Security Z-Wave devices require a network key before being added to the network.
-You must set the `s0_legacy_key` configuration option to use a network key before
-adding these devices.
+This configuration option is required, but if it is unset the addon will generate
+a new one automatically on startup.
 
 #### Option `s2_access_control_key`
 
-S2 Security Z-Wave devices require three network keys before being added to the
-network. In order to use S2 Security, you must set this configuration option along
-with `s2_authenticated_key` and `s2_unauthenticated_key` before adding these devices.
-This key has no impact on unsecured devices or devices that are using S0 Security.
+The `s2_access_control_key` must be provided in order to include devices with the
+S2 Access Control security class. This security class is needed by devices such
+as door locks and garage door openers. This configuration option is required,
+but if it is unset the addon will generate a new one automatically on startup.
 
 #### Option `s2_authenticated_key`
 
-S2 Security Z-Wave devices require three network keys before being added to the
-network. In order to use S2 Security, you must set this configuration option along
-with `s2_access_control_key` and `s2_unauthenticated_key` before adding these devices.
-This key has no impact on unsecured devices or devices that are using S0 Security.
+The `s2_authenticated_key` must be provided in order to include devices with
+the S2 Authenticated security class. Devices such as security systems, sensors,
+lighting, etc. can request this security class. This configuration option is
+required, but if it is unset the addon will generate a new one automatically
+on startup.
 
 ### Option `s2_unauthenticated_key`
 
-S2 Security Z-Wave devices require three network keys before being added to the
-network. In order to use S2 Security, you must set this configuration option along
-with `s2_access_control_key` and `s2_authenticated_key` before adding these devices.
-This key has no impact on unsecured devices or devices that are using S0 Security.
+The `s2_unauthenticated_key` must be provided in order to include devices with
+the S2 Unauthenticated security class. This is similar to S2 Authenticated, but
+without verification that the correct device was included. This configuration
+option is required, but if it is unset the addon will generate a new one
+automatically on startup.
 
 ### Option `log_level` (optional)
 
@@ -138,8 +141,8 @@ It will not be able to control any real devices.
 
 ### Option `network_key` (deprecated)
 
-In previous versions of the addon, this was the only key that needed to be configured.
-With the introduction of S2 security inclusion in zwave-js, this option has been
+In previous versions of the addon, this was the only key that was needed. With
+the introduction of S2 security inclusion in zwave-js, this option has been
 deprecated in favor of `s0_legacy_key`. If still set, the `network_key` value will be
 migrated to `s0_legacy_key` on first startup.
 

--- a/zwave_js/DOCS.md
+++ b/zwave_js/DOCS.md
@@ -59,11 +59,11 @@ In most cases this looks like one of the following:
 - `"/dev/ttyAMA0"`
 - `"/dev/ttyACM0"`
 
-### Keys
+### Security Keys
 
-You must configure four different keys via `s0_legacy_key`, `s2_access_control_key`,
-`s2_authenticated_key`, and `s2_unauthenticated_key` in order to use all of the secure
-inclusion methods (S0 and S2).
+You must configure four different security keys via `s0_legacy_key`,
+`s2_access_control_key`, `s2_authenticated_key`, and `s2_unauthenticated_key` in order
+to use all of the secure inclusion methods (S0 and S2).
 
 If you are coming from a previous version of `zwave-js`, your key is likely stored in the
 `network_key` configuration option. When the addon is first started, the key will be migrated
@@ -93,14 +93,14 @@ S0 Security Z-Wave devices require a network key before being added to the netwo
 You must set the `s0_legacy_key` configuration option to use a network key before
 adding these devices.
 
-### Option `s2_access_control_key`
+#### Option `s2_access_control_key`
 
 S2 Security Z-Wave devices require three network keys before being added to the
 network. In order to use S2 Security, you must set this configuration option along
 with `s2_authenticated_key` and `s2_unauthenticated_key` before adding these devices.
 This key has no impact on unsecured devices or devices that are using S0 Security.
 
-### Option `s2_authenticated_key`
+#### Option `s2_authenticated_key`
 
 S2 Security Z-Wave devices require three network keys before being added to the
 network. In order to use S2 Security, you must set this configuration option along

--- a/zwave_js/DOCS.md
+++ b/zwave_js/DOCS.md
@@ -22,12 +22,12 @@ change if other devices are added to the system.
    the device name in quotes: e.g., something like
    `"/dev/serial/by-id/usb-0658_0200-if00"`,
    `"/dev/ttyUSB0"`, `"/dev/ttyAMA0"`, or `"/dev/ttyACM0"`.
-2. Set your 16-byte (32 character hex) network key in the form `2232666D1...`
-   used in order to connect securely to compatible devices. It is recommended
-   that a network key is configured as some security enabled devices (locks, etc)
+2. Set your 16-byte (32 character hex) security keys in the form `2232666D1...`
+   in order to connect securely to compatible devices. It is recommended
+   that all four network keys are configured as some security enabled devices (locks, etc)
    may not function correctly if they are not added securely.
-     * As a note, it is not recommended to securely connect *all* devices unless
-       necessary as it triples the amount of messages sent on the mesh.
+     * As a note, it is not recommended to securely connect *all* devices unless they support S2 security
+       as the S0 security triples the amount of messages sent on the mesh.
 3. Click on "SAVE" to save the add-on configuration.
 4. Start the add-on.
 5. Add the Z-Wave JS integration to Home Assistant, see documentation:

--- a/zwave_js/config.json
+++ b/zwave_js/config.json
@@ -18,14 +18,21 @@
   "discovery": ["zwave_js"],
   "options": {
     "device": null,
-    "network_key": "",
+    "s0_legacy_key": "",
+    "s2_accesscontrol_key": "",
+    "s2_authenticated_key": "",
+    "s2_unauthenticated_key": "",
     "log_level": "info"
   },
   "schema": {
     "device": "device(subsystem=tty)",
-    "network_key": "match(|[0-9a-fA-F]{32,32})",
+    "s0_legacy_key": "match(|[0-9a-fA-F]{32,32})?",
+    "s2_accesscontrol_key": "match(|[0-9a-fA-F]{32,32})?",
+    "s2_authenticated_key": "match(|[0-9a-fA-F]{32,32})?",
+    "s2_unauthenticated_key": "match(|[0-9a-fA-F]{32,32})?",
     "log_level": "list(silly|debug|verbose|http|info|warn|error)?",
-    "emulate_hardware": "bool?"
+    "emulate_hardware": "bool?",
+    "network_key": "match(|[0-9a-fA-F]{32,32})?"
   },
   "image": "homeassistant/{arch}-addon-zwave_js"
 }

--- a/zwave_js/config.json
+++ b/zwave_js/config.json
@@ -19,7 +19,7 @@
   "options": {
     "device": null,
     "s0_legacy_key": "",
-    "s2_accesscontrol_key": "",
+    "s2_access_control_key": "",
     "s2_authenticated_key": "",
     "s2_unauthenticated_key": "",
     "log_level": "info"
@@ -27,7 +27,7 @@
   "schema": {
     "device": "device(subsystem=tty)",
     "s0_legacy_key": "match(|[0-9a-fA-F]{32,32})?",
-    "s2_accesscontrol_key": "match(|[0-9a-fA-F]{32,32})?",
+    "s2_access_control_key": "match(|[0-9a-fA-F]{32,32})?",
     "s2_authenticated_key": "match(|[0-9a-fA-F]{32,32})?",
     "s2_unauthenticated_key": "match(|[0-9a-fA-F]{32,32})?",
     "log_level": "list(silly|debug|verbose|http|info|warn|error)?",

--- a/zwave_js/rootfs/etc/cont-init.d/config.sh
+++ b/zwave_js/rootfs/etc/cont-init.d/config.sh
@@ -6,6 +6,7 @@ declare network_key
 
 readonly DOCS_EXAMPLE_KEY="2232666D100F795E5BB17F0A1BB7A146"
 
+# Migrate old 'network_key' config option to 's0_legacy_key'
 if bashio::config.has_value 'network_key'; then
     bashio::log.info "Migrating \"network_key\" option to \"s0_legacy_key\"..."
     network_key=$(bashio::string.upper "$(bashio::config 'network_key')")
@@ -15,6 +16,8 @@ if bashio::config.has_value 'network_key'; then
     bashio::addon.options > "/data/options.json"
 fi
 
+# Validate that no keys are using the example from the docs and generate new random
+# keys for any missing keys.
 for key in "s0_legacy_key" "s2_access_control_key" "s2_authenticated_key" "s2_unauthenticated_key"; do
     network_key=$(bashio::config "${key}")
     if [[ "${DOCS_EXAMPLE_KEY}" == "${network_key}" ]]; then
@@ -40,7 +43,8 @@ for key in "s0_legacy_key" "s2_access_control_key" "s2_authenticated_key" "s2_un
     fi
 done
 
-# We need to restart if we created new key(s) so they get flushed to disk
+# If flush_to_disk is set, it means we have generated new key(s) and they need to get
+# flushed to disk
 if [[ ${flush_to_disk:+x} ]]; then
     bashio::log.info "Flushing config to disk due to creation of new key(s)..."
     bashio::addon.options > "/data/options.json"

--- a/zwave_js/rootfs/etc/cont-init.d/config.sh
+++ b/zwave_js/rootfs/etc/cont-init.d/config.sh
@@ -15,9 +15,9 @@ if bashio::config.has_value 'network_key'; then
             bashio::log.info "Both 'network_key' and 's0_legacy_key' are set and match. Dropping 'network_key' value..."
             bashio::addon.option network_key
         else
-            bashio::log.fatal "Both 'network_key' and 's0_legacy_key' are set to different values."
-            bashio::log.fatal "Both keys are used for the same purpose so one needs to be removed "
-            bashio::log.fatal "in order to start the addon."
+            bashio::log.fatal "Both 'network_key' and 's0_legacy_key' are set to different values "
+            bashio::log.fatal "so we are unsure which one to use. One needs to be removed from the "
+            bashio::log.fatal "configuration in order to start the addon."
             bashio::exit.nok
         fi
     # If we get here, 'network_key' is set and 's0_legacy_key' is not set so we need

--- a/zwave_js/rootfs/etc/cont-init.d/config.sh
+++ b/zwave_js/rootfs/etc/cont-init.d/config.sh
@@ -6,29 +6,41 @@ declare network_key
 
 readonly DOCS_EXAMPLE_KEY="2232666D100F795E5BB17F0A1BB7A146"
 
-if [[ "${DOCS_EXAMPLE_KEY}" == "$(bashio::config 'network_key')" ]]; then
-    bashio::log.fatal
-    bashio::log.fatal 'The add-on detected that the Z-Wave network key used'
-    bashio::log.fatal 'is from the documented example.'
-    bashio::log.fatal
-    bashio::log.fatal 'Using this key is insecure, because it is publicly'
-    bashio::log.fatal 'listed in the documentation.'
-    bashio::log.fatal
-    bashio::log.fatal 'Please check the add-on documentation on how to'
-    bashio::log.fatal 'create your own, secret, "network_key" and replace'
-    bashio::log.fatal 'the one you have configured.'
-    bashio::log.fatal
-    bashio::log.fatal 'Click on the "Documentation" tab in the Z-Wave JS'
-    bashio::log.fatal 'add-on panel for more information.'
-    bashio::log.fatal
-    bashio::exit.nok
-elif ! bashio::config.has_value 'network_key'; then
-    bashio::log.info "No Network Key is set, generate one..."
-    network_key=$(hexdump -n 16 -e '4/4 "%08X" 1 "\n"' /dev/random)
-    bashio::addon.option network_key "${network_key}"
-else
+if bashio::config.has_value 'network_key'; then
+    bashio::log.info "Migrating \"network_key\" option to \"s0_legacy_key\"..."
     network_key=$(bashio::config 'network_key')
+    bashio::addon.option s0_legacy_key "$(bashio::string.upper ${network_key})"
+    bashio::addon.option network_key
 fi
+
+for key in "s0_legacy_key" "s2_accesscontrol_key" "s2_authenticated_key" "s2_unauthenticated_key"; do
+    network_key=$(bashio::jq "$(bashio::addon.options)" .${key})
+    if [[ "${DOCS_EXAMPLE_KEY}" == "${network_key}" ]]; then
+        bashio::log.fatal
+        bashio::log.fatal "The add-on detected that the Z-Wave network key used"
+        bashio::log.fatal "is from the documented example."
+        bashio::log.fatal
+        bashio::log.fatal "Using this key is insecure, because it is publicly"
+        bashio::log.fatal "listed in the documentation."
+        bashio::log.fatal
+        bashio::log.fatal "Please check the add-on documentation on how to"
+        bashio::log.fatal "create your own, secret, \"${key}\" and replace"
+        bashio::log.fatal "the one you have configured."
+        bashio::log.fatal
+        bashio::log.fatal "Click on the \"Documentation\" tab in the Z-Wave JS"
+        bashio::log.fatal "add-on panel for more information."
+        bashio::log.fatal
+        bashio::exit.nok
+    elif ! bashio::var.has_value "${network_key}"; then
+        bashio::log.info "No ${key} is set, generating one..."
+        bashio::addon.option ${key} "$(hexdump -n 16 -e '4/4 "%08X" 1 "\n"' /dev/random)"
+    fi
+done
+options="$(bashio::addon.options)"
+s0_legacy=$(bashio::jq "${options}" .s0_legacy_key)
+s2_accesscontrol=$(bashio::jq "${options}" .s2_accesscontrol_key)
+s2_authenticated=$(bashio::jq "${options}" .s2_authenticated_key)
+s2_unauthenticated=$(bashio::jq "${options}" .s2_unauthenticated_key)
 
 if  ! bashio::config.has_value 'log_level'; then
     log_level=$(bashio::info.logging)
@@ -41,7 +53,10 @@ fi
 
 # Generate config
 bashio::var.json \
-    network_key "${network_key}" \
+    s0_legacy "${s0_legacy}" \
+    s2_accesscontrol "${s2_accesscontrol}" \
+    s2_authenticated "${s2_authenticated}" \
+    s2_unauthenticated "${s2_unauthenticated}" \
     log_level "${log_level}" \
     | tempio \
         -template /usr/share/tempio/zwave_config.conf \

--- a/zwave_js/rootfs/etc/cont-init.d/config.sh
+++ b/zwave_js/rootfs/etc/cont-init.d/config.sh
@@ -8,8 +8,8 @@ readonly DOCS_EXAMPLE_KEY="2232666D100F795E5BB17F0A1BB7A146"
 
 if bashio::config.has_value 'network_key'; then
     bashio::log.info "Migrating \"network_key\" option to \"s0_legacy_key\"..."
-    network_key=$(bashio::config 'network_key')
-    bashio::addon.option s0_legacy_key "$(bashio::string.upper ${network_key})"
+    network_key=$(bashio::string.upper "$(bashio::config 'network_key')")
+    bashio::addon.option s0_legacy_key "${network_key}"
     bashio::addon.option network_key
 fi
 

--- a/zwave_js/rootfs/etc/cont-init.d/config.sh
+++ b/zwave_js/rootfs/etc/cont-init.d/config.sh
@@ -4,7 +4,10 @@
 # ==============================================================================
 declare network_key
 
-readonly DOCS_EXAMPLE_KEY="2232666D100F795E5BB17F0A1BB7A146"
+readonly DOCS_EXAMPLE_KEY_1="2232666D100F795E5BB17F0A1BB7A146"
+readonly DOCS_EXAMPLE_KEY_2="A97D2A51A6D4022998BEFC7B5DAE8EA1"
+readonly DOCS_EXAMPLE_KEY_3="309D4AAEF63EFD85967D76ECA014D1DF"
+readonly DOCS_EXAMPLE_KEY_4="CF338FE0CB99549F7C0EA96308E5A403"
 
 if bashio::config.has_value 'network_key'; then
     # If both 'network_key' and 's0_legacy_key' are set and keys don't match,
@@ -36,7 +39,7 @@ fi
 # keys for any missing keys.
 for key in "s0_legacy_key" "s2_access_control_key" "s2_authenticated_key" "s2_unauthenticated_key"; do
     network_key=$(bashio::config "${key}")
-    if [[ "${DOCS_EXAMPLE_KEY}" == "${network_key}" ]]; then
+    if [ "${network_key}" == "${DOCS_EXAMPLE_KEY_1}" ] || [ "${network_key}" == "${DOCS_EXAMPLE_KEY_2}" ] || [ "${network_key}" == "${DOCS_EXAMPLE_KEY_3}" ] || [ "${network_key}" == "${DOCS_EXAMPLE_KEY_4}" ]; then
         bashio::log.fatal
         bashio::log.fatal "The add-on detected that the Z-Wave network key used"
         bashio::log.fatal "is from the documented example."

--- a/zwave_js/rootfs/etc/cont-init.d/config.sh
+++ b/zwave_js/rootfs/etc/cont-init.d/config.sh
@@ -3,7 +3,6 @@
 # Generate Z-Wave JS config file
 # ==============================================================================
 declare network_key
-declare flush_to_disk
 
 flush_to_disk=false
 

--- a/zwave_js/rootfs/etc/cont-init.d/config.sh
+++ b/zwave_js/rootfs/etc/cont-init.d/config.sh
@@ -13,7 +13,7 @@ if bashio::config.has_value 'network_key'; then
     bashio::addon.option network_key
 fi
 
-for key in "s0_legacy_key" "s2_accesscontrol_key" "s2_authenticated_key" "s2_unauthenticated_key"; do
+for key in "s0_legacy_key" "s2_access_control_key" "s2_authenticated_key" "s2_unauthenticated_key"; do
     network_key=$(bashio::jq "$(bashio::addon.options)" .${key})
     if [[ "${DOCS_EXAMPLE_KEY}" == "${network_key}" ]]; then
         bashio::log.fatal
@@ -38,7 +38,7 @@ for key in "s0_legacy_key" "s2_accesscontrol_key" "s2_authenticated_key" "s2_una
 done
 options="$(bashio::addon.options)"
 s0_legacy=$(bashio::jq "${options}" .s0_legacy_key)
-s2_accesscontrol=$(bashio::jq "${options}" .s2_accesscontrol_key)
+s2_access_control=$(bashio::jq "${options}" .s2_access_control_key)
 s2_authenticated=$(bashio::jq "${options}" .s2_authenticated_key)
 s2_unauthenticated=$(bashio::jq "${options}" .s2_unauthenticated_key)
 
@@ -54,7 +54,7 @@ fi
 # Generate config
 bashio::var.json \
     s0_legacy "${s0_legacy}" \
-    s2_accesscontrol "${s2_accesscontrol}" \
+    s2_access_control "${s2_access_control}" \
     s2_authenticated "${s2_authenticated}" \
     s2_unauthenticated "${s2_unauthenticated}" \
     log_level "${log_level}" \

--- a/zwave_js/rootfs/usr/share/tempio/zwave_config.conf
+++ b/zwave_js/rootfs/usr/share/tempio/zwave_config.conf
@@ -10,7 +10,7 @@
     },
     "securityKeys": {
         "S0_Legacy": "{{ .s0_legacy_key }}",
-        "S2_AccessControl": "{{ .s2_accesscontrol_key }}",
+        "S2_AccessControl": "{{ .s2_access_control_key }}",
         "S0_Authenticated": "{{ .s2_authenticated_key }}",
         "S0_Unauthenticated": "{{ .s2_unauthenticated_key }}"
     }

--- a/zwave_js/rootfs/usr/share/tempio/zwave_config.conf
+++ b/zwave_js/rootfs/usr/share/tempio/zwave_config.conf
@@ -9,9 +9,9 @@
         "throttle": "slow"
     },
     "securityKeys": {
-        "S0_Legacy": "{{ .s0_legacy_key }}",
-        "S2_AccessControl": "{{ .s2_access_control_key }}",
-        "S2_Authenticated": "{{ .s2_authenticated_key }}",
-        "S2_Unauthenticated": "{{ .s2_unauthenticated_key }}"
+        "S0_Legacy": "{{ .s0_legacy }}",
+        "S2_AccessControl": "{{ .s2_access_control }}",
+        "S2_Authenticated": "{{ .s2_authenticated }}",
+        "S2_Unauthenticated": "{{ .s2_unauthenticated }}"
     }
 }

--- a/zwave_js/rootfs/usr/share/tempio/zwave_config.conf
+++ b/zwave_js/rootfs/usr/share/tempio/zwave_config.conf
@@ -11,7 +11,7 @@
     "securityKeys": {
         "S0_Legacy": "{{ .s0_legacy_key }}",
         "S2_AccessControl": "{{ .s2_access_control_key }}",
-        "S0_Authenticated": "{{ .s2_authenticated_key }}",
-        "S0_Unauthenticated": "{{ .s2_unauthenticated_key }}"
+        "S2_Authenticated": "{{ .s2_authenticated_key }}",
+        "S2_Unauthenticated": "{{ .s2_unauthenticated_key }}"
     }
 }

--- a/zwave_js/rootfs/usr/share/tempio/zwave_config.conf
+++ b/zwave_js/rootfs/usr/share/tempio/zwave_config.conf
@@ -8,5 +8,10 @@
         "cacheDir": "/data/cache",
         "throttle": "slow"
     },
-    "networkKey": "{{ .network_key }}"
+    "securityKeys": {
+        "S0_Legacy": "{{ .s0_legacy_key }}",
+        "S2_AccessControl": "{{ .s2_accesscontrol_key }}",
+        "S0_Authenticated": "{{ .s2_authenticated_key }}",
+        "S0_Unauthenticated": "{{ .s2_unauthenticated_key }}"
+    }
 }


### PR DESCRIPTION
In order to support the new key structure for zwave-js, we need to add three new keys as inputs. We will also migrate keys out of `network_key` into `s0_legacy_key` to better align with this new structure.

This can't be merged until https://github.com/zwave-js/zwave-js-server/pull/353 is released but opening it as a draft for input

fixes #2182