### PR TITLE
Bump zwave-js to 8.2.1 and zwave-js-server to 1.10.3

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.38
+
+- Bump Z-Wave JS Server to 1.10.1
+- Bump Z-Wave JS to 8.2.0
+- Added configuration option for new S2 keys
+
 ## 0.1.37
 
 - Bump Z-Wave JS Server to 1.10.0

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -4,8 +4,6 @@
 
 - Bump Z-Wave JS Server to 1.10.3
 - Bump Z-Wave JS to 8.2.1
-- Deprecate `network_key` configuration option (Check documentation for more details)
-- Add configuration options for new S2 keys (Check documentation for more details)
 
 ## 0.1.37
 

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Bump Z-Wave JS Server to 1.10.2
 - Bump Z-Wave JS to 8.2.1
 - Deprecate `network_key` configuration option (Check documentation for more details)
-- Added configuration options for new S2 keys (Check documentatation for more details)
+- Add configuration options for new S2 keys (Check documentation for more details)
 
 ## 0.1.37
 

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.1.38
 
-- Bump Z-Wave JS Server to 1.10.1
+- Bump Z-Wave JS Server to 1.10.2
 - Bump Z-Wave JS to 8.2.0
 - Deprecate `network_key` configuration option (Check documenation for more details)
 - Added configuration options for new S2 keys (Check documentatation for more details)

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 - Bump Z-Wave JS Server to 1.10.1
 - Bump Z-Wave JS to 8.2.0
-- Added configuration option for new S2 keys
+- Deprecate `network_key` configuration option (Check documenation for more details)
+- Added configuration options for new S2 keys (Check documentatation for more details)
 
 ## 0.1.37
 

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.1.38
 
 - Bump Z-Wave JS Server to 1.10.2
-- Bump Z-Wave JS to 8.2.0
+- Bump Z-Wave JS to 8.2.1
 - Deprecate `network_key` configuration option (Check documenation for more details)
 - Added configuration options for new S2 keys (Check documentatation for more details)
 

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.1.38
 
-- Bump Z-Wave JS Server to 1.10.2
+- Bump Z-Wave JS Server to 1.10.3
 - Bump Z-Wave JS to 8.2.1
 - Deprecate `network_key` configuration option (Check documentation for more details)
 - Add configuration options for new S2 keys (Check documentation for more details)

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Bump Z-Wave JS Server to 1.10.2
 - Bump Z-Wave JS to 8.2.1
-- Deprecate `network_key` configuration option (Check documenation for more details)
+- Deprecate `network_key` configuration option (Check documentation for more details)
 - Added configuration options for new S2 keys (Check documentatation for more details)
 
 ## 0.1.37

--- a/zwave_js/build.json
+++ b/zwave_js/build.json
@@ -7,7 +7,7 @@
     "aarch64": "homeassistant/aarch64-base:3.13"
   },
   "args": {
-    "ZWAVEJS_SERVER_VERSION": "1.10.1",
+    "ZWAVEJS_SERVER_VERSION": "1.10.2",
     "ZWAVEJS_VERSION": "8.2.1"
   }
 }

--- a/zwave_js/build.json
+++ b/zwave_js/build.json
@@ -8,6 +8,6 @@
   },
   "args": {
     "ZWAVEJS_SERVER_VERSION": "1.10.1",
-    "ZWAVEJS_VERSION": "8.2.0"
+    "ZWAVEJS_VERSION": "8.2.1"
   }
 }

--- a/zwave_js/build.json
+++ b/zwave_js/build.json
@@ -7,7 +7,7 @@
     "aarch64": "homeassistant/aarch64-base:3.13"
   },
   "args": {
-    "ZWAVEJS_SERVER_VERSION": "1.10.0",
-    "ZWAVEJS_VERSION": "8.1.1"
+    "ZWAVEJS_SERVER_VERSION": "1.10.1",
+    "ZWAVEJS_VERSION": "8.2.0"
   }
 }

--- a/zwave_js/build.json
+++ b/zwave_js/build.json
@@ -7,7 +7,7 @@
     "aarch64": "homeassistant/aarch64-base:3.13"
   },
   "args": {
-    "ZWAVEJS_SERVER_VERSION": "1.10.2",
+    "ZWAVEJS_SERVER_VERSION": "1.10.3",
     "ZWAVEJS_VERSION": "8.2.1"
   }
 }

--- a/zwave_js/config.json
+++ b/zwave_js/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Z-Wave JS",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "slug": "zwave_js",
   "description": "Control a ZWave network with Home Assistant Z-Wave JS",
   "arch": ["amd64", "i386", "armhf", "armv7", "aarch64"],


### PR DESCRIPTION
zwave-js-server:
- https://github.com/zwave-js/zwave-js-server/releases/tag/1.10.1
- https://github.com/zwave-js/zwave-js-server/releases/tag/1.10.2
- https://github.com/zwave-js/zwave-js-server/releases/tag/1.10.3

zwave-js:
- https://github.com/zwave-js/node-zwave-js/releases/tag/v8.2.0
- https://github.com/zwave-js/node-zwave-js/releases/tag/v8.2.1

This PR assumes #2157 gets merged first before this one. If we decide to hold off on that PR, I will update the changelog here accordingly