### PR TITLE
Bump zwave-js and zwave-js-server versions

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.1.41
 
 - Bump Z-Wave JS Server to 1.10.5
-- Bump Z-Wave JS to 8.3.1
+- Bump Z-Wave JS to 8.4.1
 - Add support for S2 keys in the addon configuration (check the Security Keys section of the configuration docs for more details)
 
 ## 0.1.40

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.41
+
+- Bump Z-Wave JS Server to 1.10.4
+- Bump Z-Wave JS to 8.3.1
+- Add support for S2 keys in the addon configuration (check the Security Keys section of the configuration docs for more details)
+
 ## 0.1.40
 
 - Bump Z-Wave JS to 8.3.0

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.1.41
 
-- Bump Z-Wave JS Server to 1.10.4
+- Bump Z-Wave JS Server to 1.10.5
 - Bump Z-Wave JS to 8.3.1
 - Add support for S2 keys in the addon configuration (check the Security Keys section of the configuration docs for more details)
 

--- a/zwave_js/build.json
+++ b/zwave_js/build.json
@@ -7,7 +7,7 @@
     "aarch64": "homeassistant/aarch64-base:3.13"
   },
   "args": {
-    "ZWAVEJS_SERVER_VERSION": "1.10.3",
-    "ZWAVEJS_VERSION": "8.3.0"
+    "ZWAVEJS_SERVER_VERSION": "1.10.4",
+    "ZWAVEJS_VERSION": "8.3.1"
   }
 }

--- a/zwave_js/build.json
+++ b/zwave_js/build.json
@@ -8,6 +8,6 @@
   },
   "args": {
     "ZWAVEJS_SERVER_VERSION": "1.10.5",
-    "ZWAVEJS_VERSION": "8.3.1"
+    "ZWAVEJS_VERSION": "8.4.1"
   }
 }

--- a/zwave_js/build.json
+++ b/zwave_js/build.json
@@ -7,7 +7,7 @@
     "aarch64": "homeassistant/aarch64-base:3.13"
   },
   "args": {
-    "ZWAVEJS_SERVER_VERSION": "1.10.4",
+    "ZWAVEJS_SERVER_VERSION": "1.10.5",
     "ZWAVEJS_VERSION": "8.3.1"
   }
 }

--- a/zwave_js/config.json
+++ b/zwave_js/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Z-Wave JS",
-  "version": "0.1.40",
+  "version": "0.1.41",
   "slug": "zwave_js",
   "description": "Control a ZWave network with Home Assistant Z-Wave JS",
   "arch": ["amd64", "i386", "armhf", "armv7", "aarch64"],


### PR DESCRIPTION
This PR assumes https://github.com/home-assistant/addons/pull/2157 is merged first

Changelogs:
- https://github.com/zwave-js/node-zwave-js/releases/tag/v8.3.1
- https://github.com/zwave-js/node-zwave-js/releases/tag/v8.4.0
- https://github.com/zwave-js/node-zwave-js/releases/tag/v8.4.1
- https://github.com/zwave-js/zwave-js-server/releases/tag/1.10.4
- https://github.com/zwave-js/zwave-js-server/releases/tag/1.10.5