### PR TITLE
Use `=` instead of deprecated `:` as security option separator

### DIFF
--- a/.devcontainer/supervisor.sh
+++ b/.devcontainer/supervisor.sh
@@ -81,7 +81,7 @@ function run_supervisor() {
         --name hassio_supervisor \
         --privileged \
         --security-opt seccomp=unconfined \
-        --security-opt apparmor:unconfined \
+        --security-opt apparmor=unconfined \
         -v /run/docker.sock:/run/docker.sock:rw \
         -v /run/dbus:/run/dbus:ro \
         -v /run/udev:/run/udev:ro \


### PR DESCRIPTION
Docker reports:
Security options with `:` as a separator are deprecated and will be completely unsupported in 17.04, use `=` instead.

Since it seems that Docker supports `=` since quite a while, we should
use `=` only.