### PR TITLE
Bump zwave-js-server to 1.10.6

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.43
+
+- Bump Z-Wave JS Server to 1.10.6
+
 ## 0.1.42
 
 - Retain legacy network_key config option to stay backwards compatible.

--- a/zwave_js/build.json
+++ b/zwave_js/build.json
@@ -7,7 +7,7 @@
     "aarch64": "homeassistant/aarch64-base:3.13"
   },
   "args": {
-    "ZWAVEJS_SERVER_VERSION": "1.10.5",
+    "ZWAVEJS_SERVER_VERSION": "1.10.6",
     "ZWAVEJS_VERSION": "8.4.1"
   }
 }

--- a/zwave_js/config.json
+++ b/zwave_js/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Z-Wave JS",
-  "version": "0.1.42",
+  "version": "0.1.43",
   "slug": "zwave_js",
   "description": "Control a ZWave network with Home Assistant Z-Wave JS",
   "arch": ["amd64", "i386", "armhf", "armv7", "aarch64"],


### PR DESCRIPTION
https://github.com/zwave-js/zwave-js-server/releases/tag/1.10.6