### PR TITLE
Properly handle security key casing in zwave_js

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.44
+
+- Fix casing issues with security keys
+
 ## 0.1.43
 
 - Bump Z-Wave JS Server to 1.10.6

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.1.44
 
 - Fix casing issues with security keys
+- Fix `emulate_hardware` configuration option
 
 ## 0.1.43
 

--- a/zwave_js/config.json
+++ b/zwave_js/config.json
@@ -22,8 +22,7 @@
     "s2_access_control_key": "",
     "s2_authenticated_key": "",
     "s2_unauthenticated_key": "",
-    "log_level": "info",
-    "network_key": ""
+    "log_level": "info"
   },
   "schema": {
     "device": "device(subsystem=tty)",

--- a/zwave_js/config.json
+++ b/zwave_js/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Z-Wave JS",
-  "version": "0.1.43",
+  "version": "0.1.44",
   "slug": "zwave_js",
   "description": "Control a ZWave network with Home Assistant Z-Wave JS",
   "arch": ["amd64", "i386", "armhf", "armv7", "aarch64"],

--- a/zwave_js/rootfs/etc/cont-init.d/config.sh
+++ b/zwave_js/rootfs/etc/cont-init.d/config.sh
@@ -45,7 +45,7 @@ fi
 # Validate that no keys are using the example from the docs and generate new random
 # keys for any missing keys.
 for key in "s0_legacy_key" "s2_access_control_key" "s2_authenticated_key" "s2_unauthenticated_key"; do
-    network_key="$(bashio::config "${key}")"
+    network_key=$(bashio::config "${key}")
     network_key_upper=$(bashio::string.upper "${network_key}")
     if [ "${network_key_upper}" == "${DOCS_EXAMPLE_KEY_1}" ] || [ "${network_key_upper}" == "${DOCS_EXAMPLE_KEY_2}" ] || [ "${network_key_upper}" == "${DOCS_EXAMPLE_KEY_3}" ] || [ "${network_key_upper}" == "${DOCS_EXAMPLE_KEY_4}" ]; then
         bashio::log.fatal

--- a/zwave_js/rootfs/etc/cont-init.d/config.sh
+++ b/zwave_js/rootfs/etc/cont-init.d/config.sh
@@ -75,6 +75,12 @@ if [[ ${flush_to_disk:+x} ]]; then
     bashio::addon.options > "/data/options.json"
 fi
 
+# We have to reflush the config to disk if we have set the network_key
+if ! bashio::config.has_value 'network_key'; then
+    bashio::addon.option 'network_key' "$(bashio::config 's0_legacy_key')"
+    bashio::addon.options > "/data/options.json"
+fi
+
 s0_legacy=$(bashio::config "s0_legacy_key")
 s2_access_control=$(bashio::config "s2_access_control_key")
 s2_authenticated=$(bashio::config "s2_authenticated_key")

--- a/zwave_js/rootfs/etc/cont-init.d/config.sh
+++ b/zwave_js/rootfs/etc/cont-init.d/config.sh
@@ -3,6 +3,12 @@
 # Generate Z-Wave JS config file
 # ==============================================================================
 declare network_key
+declare s0_legacy_key
+declare s0_legacy
+declare s2_access_control
+declare s2_unauthenticated
+declare log_level
+declare flush_to_disk
 
 readonly DOCS_EXAMPLE_KEY_1="2232666D100F795E5BB17F0A1BB7A146"
 readonly DOCS_EXAMPLE_KEY_2="A97D2A51A6D4022998BEFC7B5DAE8EA1"

--- a/zwave_js/rootfs/etc/cont-init.d/config.sh
+++ b/zwave_js/rootfs/etc/cont-init.d/config.sh
@@ -6,6 +6,7 @@ declare network_key
 declare s0_legacy_key
 declare s0_legacy
 declare s2_access_control
+declare s2_authenticated
 declare s2_unauthenticated
 declare log_level
 declare flush_to_disk

--- a/zwave_js/rootfs/etc/cont-init.d/config.sh
+++ b/zwave_js/rootfs/etc/cont-init.d/config.sh
@@ -14,7 +14,9 @@ if bashio::config.has_value 'network_key'; then
     # we don't know which one to pick so we have to exit. If they are both set
     # and do match, we don't need to do anything
     if bashio::config.has_value 's0_legacy_key'; then
-        if bashio::config.equals 's0_legacy_key' "$(bashio::config \"network_key\")"; then
+        network_key=$(bashio::string.upper "$(bashio::config 'network_key')")
+        s0_legacy_key=$(bashio::string.upper "$(bashio::config 's0_legacy_key')")
+        if [ "${network_key}" == "${s0_legacy_key}" ]; then
             bashio::log.info "Both 'network_key' and 's0_legacy_key' are set and match. All ok."
         else
             bashio::log.fatal "Both 'network_key' and 's0_legacy_key' are set to different values "
@@ -26,8 +28,7 @@ if bashio::config.has_value 'network_key'; then
     # to migrate the key from 'network_key' to 's0_legacy_key'
     else
         bashio::log.info "Migrating \"network_key\" option to \"s0_legacy_key\"..."
-        network_key=$(bashio::string.upper "$(bashio::config 'network_key')")
-        bashio::addon.option s0_legacy_key "${network_key}"
+        bashio::addon.option s0_legacy_key "$(bashio::config 'network_key')"
         bashio::log.info "Flushing config to disk due to key migration..."
         bashio::addon.options > "/data/options.json"
     fi
@@ -36,7 +37,7 @@ fi
 # Validate that no keys are using the example from the docs and generate new random
 # keys for any missing keys.
 for key in "s0_legacy_key" "s2_access_control_key" "s2_authenticated_key" "s2_unauthenticated_key"; do
-    network_key=$(bashio::config "${key}")
+    network_key=$(bashio::string.upper "$(bashio::config \"${key}\")")
     if [ "${network_key}" == "${DOCS_EXAMPLE_KEY_1}" ] || [ "${network_key}" == "${DOCS_EXAMPLE_KEY_2}" ] || [ "${network_key}" == "${DOCS_EXAMPLE_KEY_3}" ] || [ "${network_key}" == "${DOCS_EXAMPLE_KEY_4}" ]; then
         bashio::log.fatal
         bashio::log.fatal "The add-on detected that the Z-Wave network key used"

--- a/zwave_js/rootfs/etc/services.d/zwave_js/run
+++ b/zwave_js/rootfs/etc/services.d/zwave_js/run
@@ -6,7 +6,7 @@ SERIAL_DEVICE=$(bashio::config 'device')
 
 # Emulate serial Hardware for test & development
 if bashio::config.true 'emulate_hardware'; then
-    SERIAL_DEVICE="--mock"
+    SERIAL_DEVICE="--mock-driver"
 fi
 
 # Send out discovery information to Home Assistant


### PR DESCRIPTION
Fixes https://github.com/home-assistant/core/issues/56810#issuecomment-931399748

Basically we were transforming the key from lower case to upper case but that caused a mismatch. Now we don't transform the config, but we do a case insensitive match between keys (`s0_legacy_key` and `network_key` as well as all keys against the documented examples)