### PR TITLE
Bump zwave-js-server to 1.10.7

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-# 0.1.45
+## 0.1.45
 
 - Bump Z-Wave JS Server to 1.10.7
 

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 0.1.45
+
+- Bump Z-Wave JS Server to 1.10.7
+
 ## 0.1.44
 
 - Fix casing issues with security keys

--- a/zwave_js/build.json
+++ b/zwave_js/build.json
@@ -7,7 +7,7 @@
     "aarch64": "homeassistant/aarch64-base:3.13"
   },
   "args": {
-    "ZWAVEJS_SERVER_VERSION": "1.10.6",
+    "ZWAVEJS_SERVER_VERSION": "1.10.7",
     "ZWAVEJS_VERSION": "8.4.1"
   }
 }

--- a/zwave_js/config.json
+++ b/zwave_js/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Z-Wave JS",
-  "version": "0.1.44",
+  "version": "0.1.45",
   "slug": "zwave_js",
   "description": "Control a ZWave network with Home Assistant Z-Wave JS",
   "arch": ["amd64", "i386", "armhf", "armv7", "aarch64"],


### PR DESCRIPTION
https://github.com/zwave-js/zwave-js-server/releases/tag/1.10.7

Note that we are bumping the schema one more time to force users onto the latest to use the new compression option