### PR TITLE
Add posibility to generate pkcs12 certificates

### DIFF
--- a/duckdns/data/run.sh
+++ b/duckdns/data/run.sh
@@ -61,7 +61,6 @@ if bashio::config.true 'lets_encrypt.accept_terms'; then
         touch "${WORK_DIR}/config"
 
         dehydrated --register --accept-terms --config "${WORK_DIR}/config"
-        if [ "$PKCS12_NEEDED" = true ]; then openssl pkcs12 -export -out ${CERT_DIR}/certificate.pfx -inkey ${CERT_DIR}/privkey.pem -in ${CERT_DIR}/fullchain.pem -passout "pass:${PKCS12_PASSWORD}";fi
     fi
 fi
 
@@ -80,6 +79,8 @@ while true; do
     now="$(date +%s)"
     if bashio::config.true 'lets_encrypt.accept_terms' && [ $((now - LE_UPDATE)) -ge 43200 ]; then
         le_renew
+        if [ "$PKCS12_NEEDED" = true ]; then openssl pkcs12 -export -out /ssl/certificate.pfx -inkey /ssl/privkey.pem -in /ssl/fullchain.pem -passout "pass:${PKCS12_PASSWORD}";fi
+
     fi
 
     sleep "${WAIT_TIME}"

--- a/duckdns/data/run.sh
+++ b/duckdns/data/run.sh
@@ -13,6 +13,8 @@ TOKEN=$(bashio::config 'token')
 DOMAINS=$(bashio::config 'domains | join(",")')
 WAIT_TIME=$(bashio::config 'seconds')
 ALGO=$(bashio::config 'lets_encrypt.algo')
+PKCS12_NEEDED=$(bashio::config 'pkcs12_needed')
+PKCS12_PASSWORD=$(bashio::config 'pkcs12_password')
 
 # Function that performe a renew
 function le_renew() {
@@ -59,6 +61,7 @@ if bashio::config.true 'lets_encrypt.accept_terms'; then
         touch "${WORK_DIR}/config"
 
         dehydrated --register --accept-terms --config "${WORK_DIR}/config"
+        if [ "$PKCS12_NEEDED" = true ]; then openssl pkcs12 -export -out ${CERT_DIR}/certificate.pfx -inkey ${CERT_DIR}/privkey.pem -in ${CERT_DIR}/fullchain.pem -passout "pass:${PKCS12_PASSWORD}";fi
     fi
 fi
 


### PR DESCRIPTION
Hi

I am trying to add support to generate also .pkcs12 certificate based on privkey.pem and fullchain.pem in DuckDNS addon.
In my case, it is needed for securing Plex addon for HA.

Added 2 configurations:
- pkcs12_needed : true/false
- pkcs12_password : any string (later used for opening the certificate store)

Also added one liner in renew part, once certificates are generated, run openssl command to generate .pkcs12 with provided password

Kind regards,
Mateo