### PR TITLE
Added info about homeassistant user in ACL config to mosquitto documentation

### DIFF
--- a/mosquitto/DOCS.md
+++ b/mosquitto/DOCS.md
@@ -116,6 +116,10 @@ Add the following configuration to enable **unrestricted** access to all topics.
 3. Create `/share/mosquitto/accesscontrollist` with the contents:
 
     ```text
+    user homeassistant
+    topic readwrite #
+
+    
     user [YOUR_MQTT_USER]
     topic readwrite #
     ```


### PR DESCRIPTION
Adds info about homeassistant user in ACL config to mosquitto documentation as reported in home-assistant/addons#2222

I have verified this with Mosquitto broker  6.0.1 on Home Assistant core 2021.10.0