### PR TITLE
Correct port to 4212 for VLC discovery service

### DIFF
--- a/vlc/CHANGELOG.md
+++ b/vlc/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.3
+
+- Correct port on discovery
+
 ## 0.1.2
 
 - Revert restart nginx service on error

--- a/vlc/config.json
+++ b/vlc/config.json
@@ -1,6 +1,6 @@
 {
   "name": "VLC",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "slug": "vlc",
   "description": "Turn your device into a Media Player with VLC",
   "arch": ["amd64", "i386", "armv7", "aarch64"],

--- a/vlc/rootfs/etc/services.d/vlc/discovery
+++ b/vlc/rootfs/etc/services.d/vlc/discovery
@@ -8,7 +8,7 @@ declare ha_config
 ha_config=$(\
     bashio::var.json \
         host "$(hostname)" \
-        port "^3000" \
+        port "^4212" \
         password "$(cat /data/secret)" \
 )
 


### PR DESCRIPTION
The default port for telnet interface of VLC is 4212, those this should be used for the discovery.
btw. I'm working on the config flow for the [`vlc_telnet`](https://www.home-assistant.io/integrations/vlc_telnet) integration incl. the discovery step via hassio, so that the discovery via this addon will work ... will link the PR soon here