### PR TITLE
Bump zwave-js to 8.7.5

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.1.46
 
-- Bump Z-Wave JS to 8.7.2
+- Bump Z-Wave JS to 8.7.3
 
 ## 0.1.45
 

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.1.46
 
 - Bump Z-Wave JS to 8.7.5
+- Bump Z-Wave JS Server to 1.10.8
 
 ## 0.1.45
 

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.1.46
 
-- Bump Z-Wave JS to 8.7.3
+- Bump Z-Wave JS to 8.7.4
 
 ## 0.1.45
 

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.46
+
+- Bump Z-Wave JS to 8.7.2
+
 ## 0.1.45
 
 - Bump Z-Wave JS Server to 1.10.7

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.1.46
 
-- Bump Z-Wave JS to 8.7.4
+- Bump Z-Wave JS to 8.7.5
 
 ## 0.1.45
 

--- a/zwave_js/build.json
+++ b/zwave_js/build.json
@@ -8,6 +8,6 @@
   },
   "args": {
     "ZWAVEJS_SERVER_VERSION": "1.10.7",
-    "ZWAVEJS_VERSION": "8.7.2"
+    "ZWAVEJS_VERSION": "8.7.3"
   }
 }

--- a/zwave_js/build.json
+++ b/zwave_js/build.json
@@ -7,7 +7,7 @@
     "aarch64": "homeassistant/aarch64-base:3.13"
   },
   "args": {
-    "ZWAVEJS_SERVER_VERSION": "1.10.7",
+    "ZWAVEJS_SERVER_VERSION": "1.10.8",
     "ZWAVEJS_VERSION": "8.7.5"
   }
 }

--- a/zwave_js/build.json
+++ b/zwave_js/build.json
@@ -8,6 +8,6 @@
   },
   "args": {
     "ZWAVEJS_SERVER_VERSION": "1.10.7",
-    "ZWAVEJS_VERSION": "8.7.4"
+    "ZWAVEJS_VERSION": "8.7.5"
   }
 }

--- a/zwave_js/build.json
+++ b/zwave_js/build.json
@@ -8,6 +8,6 @@
   },
   "args": {
     "ZWAVEJS_SERVER_VERSION": "1.10.7",
-    "ZWAVEJS_VERSION": "8.7.3"
+    "ZWAVEJS_VERSION": "8.7.4"
   }
 }

--- a/zwave_js/build.json
+++ b/zwave_js/build.json
@@ -8,6 +8,6 @@
   },
   "args": {
     "ZWAVEJS_SERVER_VERSION": "1.10.7",
-    "ZWAVEJS_VERSION": "8.4.1"
+    "ZWAVEJS_VERSION": "8.7.2"
   }
 }

--- a/zwave_js/config.json
+++ b/zwave_js/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Z-Wave JS",
-  "version": "0.1.45",
+  "version": "0.1.46",
   "slug": "zwave_js",
   "description": "Control a ZWave network with Home Assistant Z-Wave JS",
   "arch": ["amd64", "i386", "armhf", "armv7", "aarch64"],


### PR DESCRIPTION
Lots of releases since we last bumped zwave-js:
- https://github.com/zwave-js/node-zwave-js/releases/tag/v8.5.0
- https://github.com/zwave-js/node-zwave-js/releases/tag/v8.5.1
- https://github.com/zwave-js/node-zwave-js/releases/tag/v8.6.0
- https://github.com/zwave-js/node-zwave-js/releases/tag/v8.6.1
- https://github.com/zwave-js/node-zwave-js/releases/tag/v8.7.0
- https://github.com/zwave-js/node-zwave-js/releases/tag/v8.7.1
- https://github.com/zwave-js/node-zwave-js/releases/tag/v8.7.2
- https://github.com/zwave-js/node-zwave-js/releases/tag/v8.7.3
- https://github.com/zwave-js/node-zwave-js/releases/tag/v8.7.4
- https://github.com/zwave-js/node-zwave-js/releases/tag/v8.7.5

There was a critical bug fix in 8.7.0 that gives the user more time to enter the DSK PIN when doing S2 pairing. 8.7.5 also fixes a bug that was introduced with 500 series sticks after soft reset was introduced.

zwave-js-server was also updated:
- https://github.com/zwave-js/zwave-js-server/releases/tag/1.10.8

Main changes to highlight in the server are automatically lower casing OZW style keys so that the transform works and properly handling `Driver_Failed` errors