### PR TITLE
Reset Authorization header on proxied request

### DIFF
--- a/mosquitto/CHANGELOG.md
+++ b/mosquitto/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.0.2
+
+- Fix authorization of MQTT devices using colon in username (issue: #2014)
+
 ## 6.0.1
 
 - Fix loading custom mosquitto configuration

--- a/mosquitto/config.yaml
+++ b/mosquitto/config.yaml
@@ -1,4 +1,4 @@
-version: 6.0.1
+version: 6.0.2
 slug: mosquitto
 name: Mosquitto broker
 description: An Open Source MQTT broker

--- a/mosquitto/rootfs/usr/share/tempio/nginx.gtpl
+++ b/mosquitto/rootfs/usr/share/tempio/nginx.gtpl
@@ -35,6 +35,7 @@ http {
 
     location /authentication {
       proxy_set_header        X-Supervisor-Token "{{ env "SUPERVISOR_TOKEN" }}";
+      proxy_set_header        Authorization "";
       proxy_pass              http://supervisor/auth;
     }
 


### PR DESCRIPTION
Home Assistant allows a much richer set of characters for username, however the Mosquitto auth plugin sends both Basic Auth and a URL encoded parameter string.

HA will parse the Basic Authentication header first and fail, while the later URL encoded string authorization will not.

In order to skip the more restrictive Basic Authentication check, I've updated the Nginx proxying to remove that header.

This fixes #2014 