### PR TITLE
Add Zwave JS disable_soft_reset

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.47
+
+- Add disable_soft_reset option
+
 ## 0.1.46
 
 - Bump Z-Wave JS to 8.7.5

--- a/zwave_js/config.json
+++ b/zwave_js/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Z-Wave JS",
-  "version": "0.1.46",
+  "version": "0.1.47",
   "slug": "zwave_js",
   "description": "Control a ZWave network with Home Assistant Z-Wave JS",
   "arch": ["amd64", "i386", "armhf", "armv7", "aarch64"],
@@ -22,7 +22,8 @@
     "s2_access_control_key": "",
     "s2_authenticated_key": "",
     "s2_unauthenticated_key": "",
-    "log_level": "info"
+    "log_level": "info",
+    "disable_soft_reset": false
   },
   "schema": {
     "device": "device(subsystem=tty)",
@@ -32,6 +33,7 @@
     "s2_unauthenticated_key": "match(|[0-9a-fA-F]{32,32})?",
     "log_level": "list(silly|debug|verbose|http|info|warn|error)?",
     "emulate_hardware": "bool?",
+    "disable_soft_reset": "bool?",
     "network_key": "match(|[0-9a-fA-F]{32,32})?"
   },
   "image": "homeassistant/{arch}-addon-zwave_js"

--- a/zwave_js/rootfs/etc/services.d/zwave_js/run
+++ b/zwave_js/rootfs/etc/services.d/zwave_js/run
@@ -9,6 +9,11 @@ if bashio::config.true 'emulate_hardware'; then
     SERIAL_DEVICE="--mock-driver"
 fi
 
+# Set ZWAVEJS_DISABLE_SOFT_RESET environment variable based on user config
+if bashio::config.true 'disable_soft_reset'; then
+    export ZWAVEJS_DISABLE_SOFT_RESET=true
+fi
+
 # Send out discovery information to Home Assistant
 ./discovery &
 


### PR DESCRIPTION
Fixes: https://github.com/home-assistant/addons/issues/2252

It adds a configuration option to be able to disable the Zwave-JS soft reset. I am unable to test it, it's based on the documentation:

```
	/**
	 * Soft Reset is required after some commands like changing the RF region or restoring an NVM backup.
	 * Because it may be problematic in certain environments, we provide the user with an option to opt out.
	 * Default: `true,` except when ZWAVEJS_DISABLE_SOFT_RESET env variable is set.
	 */
	enableSoftReset?: boolean;
```

My first contribution to an open source project, please be gentle :)