### PR TITLE
Disable zwave-js soft-reset on vm

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.47
+
+- Disable soft-reset if VM is detected
+
 ## 0.1.46
 
 - Bump Z-Wave JS to 8.7.5

--- a/zwave_js/config.json
+++ b/zwave_js/config.json
@@ -8,6 +8,7 @@
   "startup": "services",
   "init": false,
   "stage": "stable",
+  "hassio_api": true,
   "homeassistant": "2021.2.0b0",
   "ports": {
     "3000/tcp": null

--- a/zwave_js/config.json
+++ b/zwave_js/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Z-Wave JS",
-  "version": "0.1.46",
+  "version": "0.1.47",
   "slug": "zwave_js",
   "description": "Control a ZWave network with Home Assistant Z-Wave JS",
   "arch": ["amd64", "i386", "armhf", "armv7", "aarch64"],

--- a/zwave_js/rootfs/etc/cont-init.d/config.sh
+++ b/zwave_js/rootfs/etc/cont-init.d/config.sh
@@ -11,6 +11,8 @@ declare s2_authenticated
 declare s2_unauthenticated
 declare log_level
 declare flush_to_disk
+declare host_chassis
+declare soft_reset
 
 readonly DOCS_EXAMPLE_KEY_1="2232666D100F795E5BB17F0A1BB7A146"
 readonly DOCS_EXAMPLE_KEY_2="A97D2A51A6D4022998BEFC7B5DAE8EA1"
@@ -98,6 +100,16 @@ else
     log_level=$(bashio::config 'log_level')
 fi
 
+host_chassis=$(bashio::host.chassis)
+
+if [ "${host_chassis}" == "vm" ]; then
+    soft_reset=false
+    bashio::log.info "Virtual Machine detected, disabling soft-reset"
+else
+    soft_reset=true
+    bashio::log.info "Virtual Machine not detected, enabling soft-reset"
+fi
+
 
 # Generate config
 bashio::var.json \
@@ -106,6 +118,7 @@ bashio::var.json \
     s2_authenticated "${s2_authenticated}" \
     s2_unauthenticated "${s2_unauthenticated}" \
     log_level "${log_level}" \
+    soft_reset "^${soft_reset}" \
     | tempio \
         -template /usr/share/tempio/zwave_config.conf \
         -out /etc/zwave_config.json

--- a/zwave_js/rootfs/usr/share/tempio/zwave_config.conf
+++ b/zwave_js/rootfs/usr/share/tempio/zwave_config.conf
@@ -13,5 +13,6 @@
         "S2_AccessControl": "{{ .s2_access_control }}",
         "S2_Authenticated": "{{ .s2_authenticated }}",
         "S2_Unauthenticated": "{{ .s2_unauthenticated }}"
-    }
+    },
+    "enableSoftReset": {{ .soft_reset }}
 }


### PR DESCRIPTION
- Check host chassis if vm is detected and in that case disable soft-reset in zwave-js.
- We want to avoid forcing users to configure options as far as possible. An option to allow advanced users running on VM to enable soft-reset may be added in the future but should then be compatible with the automatic disable mechanism. Ie we still want to disable soft-reset automatically unless the user has enabled the option specifically.