### PR TITLE
Add option to add advanced configuration for dnsmasq

### DIFF
--- a/dnsmasq/DOCS.md
+++ b/dnsmasq/DOCS.md
@@ -38,6 +38,12 @@ services:
     port: 389
     priority: 0
     weight: 100
+advanced: |
+  ptr-record=10.1.168.192.in-addr.arpa,home.mydomain.io
+  host-record=server.example.org,172.16.1.1
+  txt-record=example.org,"Some text"
+  cname=mymail.example.org,server.example.org
+  mx-host=example.org,mymail.example.org,50
 ```
 
 ### Option: `defaults` (required)
@@ -105,6 +111,14 @@ The priority for the service.
 #### Option: `services.weight`
 
 The weight for the service.
+
+### Option: `advanced` (optional)
+
+This option allows you to provide advanced configuration, see https://thekelleys.org.uk/dnsmasq/docs/dnsmasq-man.html.
+
+#### Option: `services.srv`
+
+The service to resolve.
 
 ## Support
 

--- a/dnsmasq/config.json
+++ b/dnsmasq/config.json
@@ -16,7 +16,8 @@
     "defaults": ["8.8.8.8", "8.8.4.4"],
     "forwards": [],
     "hosts": [],
-    "services": []
+    "services": [],
+    "advanced": ""
   },
   "schema": {
     "defaults": ["str"],
@@ -40,7 +41,8 @@
         "priority": "int",
         "weight": "int"
       }
-    ]
+    ],
+    "advanced": "str"
   },
   "image": "homeassistant/{arch}-addon-dnsmasq"
 }

--- a/dnsmasq/rootfs/usr/share/tempio/dnsmasq.config
+++ b/dnsmasq/rootfs/usr/share/tempio/dnsmasq.config
@@ -28,3 +28,6 @@ address=/{{ .host }}/{{ .ip }}
 srv-host={{ .srv }},{{ .host }},{{ .port }},{{ .priority }},{{ .weight }}
 {{ end }}
 
+# Advanced config, see https://thekelleys.org.uk/dnsmasq/docs/dnsmasq-man.html
+{{ .advanced }}
+


### PR DESCRIPTION
Add a simple `advanced` option that basically allows adding free-format configuration text for advanced use-cases. For details about which dnsmasq configuration options can be added I linked to https://thekelleys.org.uk/dnsmasq/docs/dnsmasq-man.html.
Fixes #818 and possibly #628