### PR TITLE
Bump zwave-js-server to 1.11.0 and zwave-js to 8.7.6

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.1.48
+
+- Bump Z-Wave JS to 8.7.6
+- Bump Z-Wave JS Server to 1.11.0
+
 ## 0.1.47
 
 - Disable soft-reset if VM is detected

--- a/zwave_js/build.json
+++ b/zwave_js/build.json
@@ -7,7 +7,7 @@
     "aarch64": "homeassistant/aarch64-base:3.13"
   },
   "args": {
-    "ZWAVEJS_SERVER_VERSION": "1.10.8",
-    "ZWAVEJS_VERSION": "8.7.5"
+    "ZWAVEJS_SERVER_VERSION": "1.11.0",
+    "ZWAVEJS_VERSION": "8.7.6"
   }
 }

--- a/zwave_js/config.json
+++ b/zwave_js/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Z-Wave JS",
-  "version": "0.1.47",
+  "version": "0.1.48",
   "slug": "zwave_js",
   "description": "Control a ZWave network with Home Assistant Z-Wave JS",
   "arch": ["amd64", "i386", "armhf", "armv7", "aarch64"],


### PR DESCRIPTION
Changelogs:
- https://github.com/zwave-js/zwave-js-server/releases/tag/1.11.0
- https://github.com/zwave-js/node-zwave-js/releases/tag/v8.7.6

I did not test inclusion but I did test the addon otherwise and everything appears to work as expected

Opened to replace https://github.com/home-assistant/addons/pull/2269 because my editor was doing something strange to the file