### PR TITLE
Update nginx.conf

### DIFF
--- a/nginx_proxy/data/nginx.conf
+++ b/nginx_proxy/data/nginx.conf
@@ -22,6 +22,9 @@ http {
         listen 443 ssl http2 default_server;
         ssl_certificate /data/ssl-cert-snakeoil.pem;
         ssl_certificate_key /data/ssl-cert-snakeoil.key;
+        ssl_protocols TLSv1.2 TLSv1.3;
+        ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+        ssl_prefer_server_ciphers off;
         return 444;
     }
 


### PR DESCRIPTION
The default virtual server is serving insecure protocols.
Although this is only a redirect, it's causing my internal vulnerability scanner to flag it.