### PR TITLE
Remove confusion

### DIFF
--- a/mosquitto/DOCS.md
+++ b/mosquitto/DOCS.md
@@ -16,11 +16,11 @@ The add-on has a couple of options available. To get the add-on running:
 2. Have some patience and wait a couple of minutes.
 3. Check the add-on log output to see the result.
 
-Create a new user for MQTT via the **Configuration** -> **Users (manage users)**.
+Create a new user for MQTT via your Home Assistant's frontend **Configuration** -> **Users (manage users)** , (i.e. not on Mosquitto's **Configuration** tab).
 Notes:
 
 1. This name cannot be `homeassistant` or `addon`, those are reserved usernames.
-2. If you do not see the option to create a new user, ensure that **Advanced Mode** is enabled in your profile.
+2. If you do not see the option to create a new user, ensure that **Advanced Mode** is enabled in your Home Assistant profile.
 
 To use the Mosquitto as a broker, go to the integration page and install the configuration with one click:
 


### PR DESCRIPTION
Remove confusion about which configuration option (HA or Mosquitto) to use for adding a new user.