### PR TITLE
Roll back zwave_js to 0.1.48

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.48
+
+- Roll back add-on to 0.1.48 as a temporary fix for build issues with 0.1.49.
+
 ## 0.1.49
 
 - Bump Z-Wave JS to 8.7.7

--- a/zwave_js/config.json
+++ b/zwave_js/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Z-Wave JS",
-  "version": "0.1.49",
+  "version": "0.1.48",
   "slug": "zwave_js",
   "description": "Control a ZWave network with Home Assistant Z-Wave JS",
   "arch": ["amd64", "i386", "armhf", "armv7", "aarch64"],


### PR DESCRIPTION
- This is a temporary fix so that new users can install the add-on and we don't show the 0.1.49 update for existing users.