### PR TITLE
Bump zwave-js to 8.8.3

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.50
+
+- Bump Z-Wave JS to 8.8.3
+
 ## 0.1.49
 
 - Bump Z-Wave JS to 8.7.7

--- a/zwave_js/build.yaml
+++ b/zwave_js/build.yaml
@@ -9,4 +9,4 @@ codenotary:
   base_image: notary@home-assistant.io
 args:
   ZWAVEJS_SERVER_VERSION: 1.12.0
-  ZWAVEJS_VERSION: 8.7.7
+  ZWAVEJS_VERSION: 8.8.3

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -1,4 +1,4 @@
-version: 0.1.49
+version: 0.1.50
 slug: zwave_js
 name: Z-Wave JS
 description: Control a ZWave network with Home Assistant Z-Wave JS


### PR DESCRIPTION
Changelogs:
- https://github.com/zwave-js/node-zwave-js/releases/tag/v8.8.0
- https://github.com/zwave-js/node-zwave-js/releases/tag/v8.8.1
- https://github.com/zwave-js/node-zwave-js/releases/tag/v8.8.2
- https://github.com/zwave-js/node-zwave-js/releases/tag/v8.8.3