### PR TITLE
Allow use of ports other than 8123 in HA

### DIFF
--- a/nginx_proxy/CHANGELOG.md
+++ b/nginx_proxy/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.1.0
+
+- Allow use of ports other than 8123 in Home Assistant Core
+
 ## 3.0.2
 
 - Update Alpine to 3.14

--- a/nginx_proxy/config.yaml
+++ b/nginx_proxy/config.yaml
@@ -1,4 +1,4 @@
-version: 3.0.2
+version: 3.1.0
 slug: nginx_proxy
 name: NGINX Home Assistant SSL proxy
 description: An SSL/TLS proxy

--- a/nginx_proxy/config.yaml
+++ b/nginx_proxy/config.yaml
@@ -1,4 +1,5 @@
 version: 3.1.0
+hassio_api: true
 slug: nginx_proxy
 name: NGINX Home Assistant SSL proxy
 description: An SSL/TLS proxy

--- a/nginx_proxy/data/nginx.conf
+++ b/nginx_proxy/data/nginx.conf
@@ -58,7 +58,7 @@ http {
         #include /share/nginx_proxy_default*.conf;
 
         location / {
-            proxy_pass http://homeassistant.local.hass.io:8123;
+            proxy_pass http://homeassistant.local.hass.io:%%HA_PORT%%;
             proxy_set_header Host $host;
             proxy_redirect http:// https://;
             proxy_http_version 1.1;

--- a/nginx_proxy/data/run.sh
+++ b/nginx_proxy/data/run.sh
@@ -13,6 +13,8 @@ KEYFILE=$(bashio::config 'keyfile')
 CERTFILE=$(bashio::config 'certfile')
 HSTS=$(bashio::config 'hsts')
 
+HA_PORT=$(bashio::core.port)
+
 # Generate dhparams
 if ! bashio::fs.file_exists "${DHPARAMS_PATH}"; then
     bashio::log.info  "Generating dhparams (this will take some time)..."
@@ -52,6 +54,7 @@ fi
 sed -i "s#%%FULLCHAIN%%#$CERTFILE#g" /etc/nginx.conf
 sed -i "s#%%PRIVKEY%%#$KEYFILE#g" /etc/nginx.conf
 sed -i "s/%%DOMAIN%%/$DOMAIN/g" /etc/nginx.conf
+sed -i "s/%%HA_PORT%%/$HA_PORT/g" /etc/nginx.conf
 
 [ -n "$HSTS" ] && HSTS="add_header Strict-Transport-Security \"$HSTS\" always;"
 sed -i "s/%%HSTS%%/$HSTS/g" /etc/nginx.conf


### PR DESCRIPTION
I'm setting up the nginx-proxy in my HA installation just to leverage HTTP/2 because of [LL-HLS](https://www.home-assistant.io/integrations/stream/#ll-hls).

I, however, use port 8123 for external HTTPS access because my ISP blocks me from using port 443.

While I could map the nginx-proxy 443 port to something like 8124, I would prefer to maintain the 8123 port for HTTPS access, so that I don't need to re-configure all my devices.

In order to achieve that, I'm removing the hardcoded 8123 port from nginx.conf and fetching the correct port instead. So that, I would set:

HA's `http.server_port` to `8124`, and map nginx-proxy 443 port to 8123.