### PR TITLE
Let Mosquitto use SQLite over password file for auth

### DIFF
--- a/mosquitto/Dockerfile
+++ b/mosquitto/Dockerfile
@@ -8,18 +8,22 @@ RUN apk add --no-cache \
         mosquitto \
         nginx \
         pwgen \
+        sqlite \
+        sqlite-libs \
     && apk add --no-cache --virtual .build-dependencies \
         build-base \
         curl-dev \
         git \
         mosquitto-dev \
         openssl-dev \
+        sqlite-dev \
     \
     && git clone --depth 1 -b "${MOSQUITTO_AUTH_VERSION}" \
         https://github.com/pvizeli/mosquitto-auth-plug \
     \
     && cd mosquitto-auth-plug \
     && cp config.mk.in config.mk \
+    && sed -i 's/BACKEND_SQLITE ?= no/BACKEND_SQLITE ?= yes/g' config.mk \
     && make \
     && mkdir -p /usr/share/mosquitto \
     && cp -f auth-plug.so /usr/share/mosquitto \

--- a/mosquitto/rootfs/usr/share/tempio/mosquitto.gtpl
+++ b/mosquitto/rootfs/usr/share/tempio/mosquitto.gtpl
@@ -10,7 +10,7 @@ persistence_location /data/
 
 # Authentication plugin
 auth_plugin /usr/share/mosquitto/auth-plug.so
-auth_opt_backends files,http
+auth_opt_backends sqlite,http
 auth_opt_cache true
 auth_opt_auth_cacheseconds 300
 auth_opt_auth_cachejitter 30
@@ -18,9 +18,9 @@ auth_opt_acl_cacheseconds 300
 auth_opt_acl_cachejitter 30
 auth_opt_log_quiet true
 
-# HTTP backend for the authentication plugin
-auth_opt_password_file /etc/mosquitto/pw
-auth_opt_acl_file /etc/mosquitto/acl
+# SQLITE backend for the authentication plugin
+auth_opt_dbpath /etc/mosquitto/mosquitto.sqlite
+auth_opt_sqliteuserquery SELECT pw FROM users WHERE username = ?
 
 # HTTP backend for the authentication plugin
 auth_opt_http_ip 127.0.0.1


### PR DESCRIPTION
The SQLite approach allows more flexibility when it comes
to special characters, e.g. colon in username. The additional libs
are minimal and changes to the existing code are just a few lines.

Fixes https://github.com/home-assistant/addons/issues/2020
Replaces https://github.com/home-assistant/addons/pull/2137