### PR TITLE
Fixed bash PS1 escaping

### DIFF
--- a/ssh/CHANGELOG.md
+++ b/ssh/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 9.2.2
+
+- Fix escape codes in color bash prompt
+
 ## 9.2.1
 
 - Upgrade Home Assistant CLI to 4.14.0

--- a/ssh/config.yaml
+++ b/ssh/config.yaml
@@ -1,4 +1,4 @@
-version: 9.2.1
+version: 9.2.2
 slug: ssh
 name: Terminal & SSH
 description: Allow logging in remotely to Home Assistant using SSH

--- a/ssh/rootfs/usr/share/tempio/homeassistant.profile
+++ b/ssh/rootfs/usr/share/tempio/homeassistant.profile
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-export PS1="\e[0;32m[\h \W]\$ \e[m"
+export PS1="\[\e[0;32m\][\h \W]\$ \[\e[m\]"
 export SUPERVISOR_TOKEN={{ .supervisor_token }}
 
 ha banner


### PR DESCRIPTION
Fixes the bash prompt so it ignores non-printable characters (the color escape sequence in the PS1), which allows it to correctly calculates the size of the prompt. Without this fix, on longer lines pressing the home key, and cycling through the bash history is buggy.

Replicating: Type a long line like `echo abcdefghijklmnopqrstuvwxyz`, press enter, arrow up, then the home key. Note the cursor does not go all the way back to the start of the line.

ref: https://stackoverflow.com/questions/19092488/custom-bash-prompt-is-overwriting-itself