### PR TITLE
deCONZ 2.13.04, add-on version 6.11.1

### DIFF
--- a/deconz/CHANGELOG.md
+++ b/deconz/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 6.11.1
+
+- Add missing libqt5qml5 dependency
+- Do not force install of deCONZ packages
+
+## 6.11.0
+
+- Bump deCONZ to 2.13.4
+
 ## 6.10.0
 
 - Bump deCONZ to 2.12.6

--- a/deconz/Dockerfile
+++ b/deconz/Dockerfile
@@ -22,6 +22,7 @@ RUN \
         libqt5sql5 \
         libqt5websockets5 \
         libqt5widgets5 \
+        libqt5qml5 \
         lsof \
         netcat \
         nginx \
@@ -68,11 +69,11 @@ RUN \
             curl -q -L -o /deconz.deb http://deconz.dresden-elektronik.de/raspbian/stable/deconz-${DECONZ_VERSION}-qt5.deb; \
         elif [ "${BUILD_ARCH}" = "aarch64" ]; \
         then \
-            curl -q -L -o /deconz.deb http://deconz.dresden-elektronik.de/debian/stable/deconz_${DECONZ_VERSION}-debian-stretch-stable_arm64.deb; \
+            curl -q -L -o /deconz.deb http://deconz.dresden-elektronik.de/debian/stable/deconz_${DECONZ_VERSION}-debian-buster-stable_arm64.deb; \
         else \
             curl -q -L -o /deconz.deb http://deconz.dresden-elektronik.de/ubuntu/stable/deconz-${DECONZ_VERSION}-qt5.deb; \
         fi \
-    && dpkg --force-all -i /deconz.deb \
+    && dpkg -i /deconz.deb \
     && rm -f /deconz.deb \
     && chown root:root /usr/bin/deCONZ* \
     && sed -i 's/\/root/\/data/' /etc/passwd

--- a/deconz/build.yaml
+++ b/deconz/build.yaml
@@ -6,4 +6,4 @@ codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
 args:
-  DECONZ_VERSION: 2.12.06
+  DECONZ_VERSION: 2.13.04

--- a/deconz/config.yaml
+++ b/deconz/config.yaml
@@ -1,4 +1,4 @@
-version: 6.10.0
+version: 6.11.1
 slug: deconz
 name: deCONZ
 description: Control a Zigbee network with ConBee or RaspBee by Dresden Elektronik


### PR DESCRIPTION
# deCONZ 2.13.04, add-on version 6.11.1

- Reverts the revert of 6.11.0 in #2318
- Add missing dependency causing the REST API not to load
- Removes force install of the package, to prevent issues like this in the future

Changelog updated, add-on version bumped to 6.11.1
Tested on `amd64` architecture.

fixes #2317
fixes home-assistant/core#62388