### PR TITLE
Bump zwave-js to 8.10.2 and zwave-js-server to 1.14.1

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.1.52
+
+- Bump Z-Wave JS to 8.10.2
+- Bump Z-Wave JS Server to 1.14.1
+
 ## 0.1.51
 
 - Bump Z-Wave JS to 8.9.2

--- a/zwave_js/build.yaml
+++ b/zwave_js/build.yaml
@@ -8,5 +8,5 @@ codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
 args:
-  ZWAVEJS_SERVER_VERSION: 1.14.0
-  ZWAVEJS_VERSION: 8.9.2
+  ZWAVEJS_SERVER_VERSION: 1.14.1
+  ZWAVEJS_VERSION: 8.10.2

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -1,4 +1,4 @@
-version: 0.1.51
+version: 0.1.52
 slug: zwave_js
 name: Z-Wave JS
 description: Control a ZWave network with Home Assistant Z-Wave JS


### PR DESCRIPTION
Server update is pretty much a no-op change for the addon since the fixed bug would not occur in the addon:
- https://github.com/zwave-js/zwave-js-server/releases/tag/1.14.1

zwave-js updates:
- https://github.com/zwave-js/node-zwave-js/releases/tag/v8.10.0
- https://github.com/zwave-js/node-zwave-js/releases/tag/v8.10.1
- https://github.com/zwave-js/node-zwave-js/releases/tag/v8.10.2