### PR TITLE
mosquitto: disallow anonymous logins and reduce logging

### DIFF
--- a/mosquitto/rootfs/etc/services.d/mosquitto/run
+++ b/mosquitto/rootfs/etc/services.d/mosquitto/run
@@ -17,4 +17,4 @@ fi
 ./discovery &
 
 bashio::log.info "Starting mosquitto MQTT broker..."
-exec mosquitto "${options[@]}"
+exec mosquitto "${options[@]}" | sed 's/{"result": "ok", "data": {}}//g'

--- a/mosquitto/rootfs/usr/share/tempio/mosquitto.gtpl
+++ b/mosquitto/rootfs/usr/share/tempio/mosquitto.gtpl
@@ -1,10 +1,6 @@
 protocol mqtt
 user root
 log_dest stdout
-log_type error
-log_type warning
-log_type notice
-log_type information
 persistence true
 persistence_location /data/
 
@@ -28,6 +24,8 @@ auth_opt_http_port 80
 auth_opt_http_getuser_uri /authentication
 auth_opt_http_superuser_uri /superuser
 auth_opt_http_aclcheck_uri /acl
+
+allow_anonymous false
 
 {{ if .customize }}
 include_dir /share/{{ .customize_folder }}


### PR DESCRIPTION
- allow_anonymous false to fix #2337  #2091
- remove log_type which are already set by default. This was preventing
  users from reducing log level to a less verbose setting through
  customize.active settings.
- filter spew from auth-plug.so: the auth_plugin does not redirect home
  assistant supervisor's auth api output, so it goes to stdout
  (https://github.com/pvizeli/mosquitto-auth-plug/blob/56b428f00eefc1b1ca5b848776da1d89e20bc216/src/be-http.c#L199)