### PR TITLE
Hide server version banner from nginx_proxy

### DIFF
--- a/nginx_proxy/CHANGELOG.md
+++ b/nginx_proxy/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.1.1
+
+- Hide server version banner
+
 ## 3.1.0
 
 - Allow use of ports other than 8123 in Home Assistant Core

--- a/nginx_proxy/config.yaml
+++ b/nginx_proxy/config.yaml
@@ -1,4 +1,4 @@
-version: 3.1.0
+version: 3.1.1
 hassio_api: true
 slug: nginx_proxy
 name: NGINX Home Assistant SSL proxy

--- a/nginx_proxy/data/nginx.conf
+++ b/nginx_proxy/data/nginx.conf
@@ -11,7 +11,9 @@ http {
         default upgrade;
         ''      close;
     }
-    
+
+    server_tokens off;
+
     server_names_hash_bucket_size 64;
 	
     #include /data/cloudflare.conf;


### PR DESCRIPTION
Adds an option to hide Nginx version banner from the headers and error pages.