### PR TITLE
Add remote IP/CIDR allowlisting for Cloudflare and static entries

### DIFF
--- a/nginx_proxy/CHANGELOG.md
+++ b/nginx_proxy/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.2.0
+
+- Added remote IP/CIDR allowlisting for Cloudflare and static entries
+
 ## 3.1.1
 
 - Hide server version banner

--- a/nginx_proxy/DOCS.md
+++ b/nginx_proxy/DOCS.md
@@ -38,6 +38,10 @@ The NGINX Proxy add-on is commonly used in conjunction with the [Duck DNS](https
 Add-on configuration:
 
 ```yaml
+allowlist:
+  active: false
+  cloudflare: false
+  entries: []
 domain: home.example.com
 certfile: fullchain.pem
 keyfile: privkey.pem
@@ -79,8 +83,20 @@ The filename(s) of the NGINX configuration for the additional servers, found in 
 
 ### Option `cloudflare` (optional)
 
-If enabled, configure Nginx with a list of IP addresses directly from Cloudflare that will be used for `set_real_ip_from` directive Nginx config.
+If enabled, configure NGINX with a list of IP addresses directly from Cloudflare that will be used for `set_real_ip_from` directive Nginx config.
 This is so the `ip_ban_enabled` feature can be used and work correctly in /config/customize.yaml.
+
+### Option `allowlist.active` (required)
+
+If true, configure NGINX to allow only connections from the remote IP addresses listed in `allowlist.entries` or from the Cloudflare IP addresses if `allowlist.cloudflare` is set to true.
+
+### Option `allowlist.cloudflare` (required)
+
+Include Cloudflare IP addresses in the allowlist.
+
+### Option `allowlist.entries` (required)
+
+List of IP addresses or CIDRs to be included in the allowlist.
 
 ## Known issues and limitations
 

--- a/nginx_proxy/config.yaml
+++ b/nginx_proxy/config.yaml
@@ -1,4 +1,4 @@
-version: 3.1.1
+version: 3.2.0
 hassio_api: true
 slug: nginx_proxy
 name: NGINX Home Assistant SSL proxy
@@ -15,6 +15,10 @@ map:
   - ssl
   - share
 options:
+  allowlist:
+    active: false
+    cloudflare: false
+    entries: []
   certfile: fullchain.pem
   cloudflare: false
   customize:
@@ -28,6 +32,11 @@ ports:
   443/tcp: 443
   80/tcp: null
 schema:
+  allowlist:
+    active: bool
+    cloudflare: bool
+    entries:
+      - str
   certfile: str
   cloudflare: bool
   customize:

--- a/nginx_proxy/data/nginx.conf
+++ b/nginx_proxy/data/nginx.conf
@@ -15,9 +15,11 @@ http {
     server_tokens off;
 
     server_names_hash_bucket_size 64;
-	
+
     #include /data/cloudflare.conf;
-	
+
+    #include /data/remotes_allowlist.conf;
+
     server {
         server_name _;
         listen 80 default_server;
@@ -49,13 +51,15 @@ http {
 
         listen 443 ssl http2;
         %%HSTS%%
-        
+
         # intermediate configuration
         ssl_protocols TLSv1.2 TLSv1.3;
         ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
         ssl_prefer_server_ciphers off;
 
         proxy_buffering off;
+
+        %%ALLOWLIST_IF%%
 
         #include /share/nginx_proxy_default*.conf;
 

--- a/nginx_proxy/data/run.sh
+++ b/nginx_proxy/data/run.sh
@@ -8,6 +8,8 @@ SNAKEOIL_KEY=/data/ssl-cert-snakeoil.key
 
 CLOUDFLARE_CONF=/data/cloudflare.conf
 
+ALLOWLIST_CONF=/data/remotes_allowlist.conf
+
 DOMAIN=$(bashio::config 'domain')
 KEYFILE=$(bashio::config 'keyfile')
 CERTFILE=$(bashio::config 'certfile')
@@ -26,6 +28,16 @@ if ! bashio::fs.file_exists "${SNAKEOIL_CERT}"; then
     openssl req -x509 -nodes -days 3650 -newkey rsa:2048 -keyout $SNAKEOIL_KEY -out $SNAKEOIL_CERT -subj '/CN=localhost'
 fi
 
+# Fetch Cloudflare IPs if neeeded for proxy trusting or allowlist filtering
+CF_IPV4_LIST=""
+CF_IPV6_LIST=""
+
+if bashio::config.true 'cloudflare' || bashio::config.true 'allowlist.cloudflare'; then
+    CF_IPV4_LIST=$(curl https://www.cloudflare.com/ips-v4)
+    CF_IPV6_LIST=$(curl https://www.cloudflare.com/ips-v6)
+fi
+
+# Configure nginx for trusting client IPs from Cloudflare headers
 if bashio::config.true 'cloudflare'; then
     sed -i "s|#include /data/cloudflare.conf;|include /data/cloudflare.conf;|" /etc/nginx.conf
     # Generate cloudflare.conf
@@ -35,13 +47,13 @@ if bashio::config.true 'cloudflare'; then
         echo "" >> $CLOUDFLARE_CONF;
 
         echo "# - IPv4" >> $CLOUDFLARE_CONF;
-        for i in $(curl https://www.cloudflare.com/ips-v4); do
+        for i in $CF_IPV4_LIST; do
             echo "set_real_ip_from ${i};" >> $CLOUDFLARE_CONF;
         done
 
         echo "" >> $CLOUDFLARE_CONF;
         echo "# - IPv6" >> $CLOUDFLARE_CONF;
-        for i in $(curl https://www.cloudflare.com/ips-v6); do
+        for i in $CF_IPV6_LIST; do
             echo "set_real_ip_from ${i};" >> $CLOUDFLARE_CONF;
         done
 
@@ -49,6 +61,50 @@ if bashio::config.true 'cloudflare'; then
         echo "real_ip_header CF-Connecting-IP;" >> $CLOUDFLARE_CONF;
     fi
 fi
+
+ALLOWLIST_IF=""
+if bashio::config.true 'allowlist.active'; then
+    sed -i "s|#include /data/remotes_allowlist.conf;|include /data/remotes_allowlist.conf;|" /etc/nginx.conf
+    ALLOWLIST_IF="if (\$allowed_ip != 1) { return 403; }"
+
+    bashio::log.info "Creating 'remotes_allowlist.conf' for filtering allowed remote IPs..."
+    {
+        echo "geo \$realip_remote_addr \$allowed_ip {"
+        echo "    default 0;"
+
+        # Add static entries from config
+        if bashio::config.has_value 'allowlist.entries'; then
+            echo ""
+            echo "    # Static entries"
+            echo ""
+
+            for i in $(bashio::config 'allowlist.entries'); do
+                echo "    ${i} 1;"
+            done
+        fi
+
+        # Add Cloudflare IPs if enabled
+        if bashio::config.true 'allowlist.cloudflare'; then
+            echo ""
+            echo "    # Cloudflare IP addresses"
+            echo ""
+
+            echo "    # - IPv4"
+            for i in $CF_IPV4_LIST; do
+                echo "    ${i} 1;"
+            done
+
+            echo ""
+            echo "    # - IPv6"
+            for i in $CF_IPV6_LIST; do
+                echo "    ${i} 1;"
+            done
+        fi
+
+        echo "}"
+    } > $ALLOWLIST_CONF
+fi
+sed -i "s|%%ALLOWLIST_IF%%|$ALLOWLIST_IF|g" /etc/nginx.conf
 
 # Prepare config file
 sed -i "s#%%FULLCHAIN%%#$CERTFILE#g" /etc/nginx.conf


### PR DESCRIPTION
This PR includes a method of allowlisting IPs and CIDRs to limit the remotes that can connect. It can be a static list of entries or Cloudflare's IP ranges fetched automatically.

Filtering by using the `geo` block instead using plain `allow`/`deny` is needed to filter by Cloudflare's IPs instead of the client's IP when using `set_real_ip_from`. This way you can filter requests not coming from Cloudflare (direct connections).