### PR TITLE
integrated fix to create sbk backup compatible to a standard CCU.

### DIFF
--- a/homematic/CHANGELOG.md
+++ b/homematic/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 #### WARNING: This add-on is considered to be obsolete/retired in favor of the much more advanced third-party [RaspberryMatic CCU](https://github.com/jens-maus/RaspberryMatic/tree/master/home-assistant-addon) add-on for running a HomeMatic/homematicIP smart home central within HomeAssistant. If you want to migrate to the new add-on, please make sure to update to the latest version of this old "HomeMatic CCU" add-on first and then use the WebUI-based backup routines to export a `*.sbk` config backup file which you can then restore in the new "RaspberryMatic CCU" add-on afterwards (cf. [RaspberryMatic Documentation](https://github.com/jens-maus/RaspberryMatic/wiki/Installation-HomeAssistant))
 
+## 99.0.3
+
+- integrated backup script fix to generate .sbk backups more
+  compatible to a standard CCU.
+
 ## 99.0.2
 
 - disabled hmip rf-firmware update to prevent accidently performed

--- a/homematic/config.yaml
+++ b/homematic/config.yaml
@@ -1,4 +1,4 @@
-version: 99.0.2
+version: 99.0.3
 slug: homematic
 name: HomeMatic CCU
 description: HomeMatic central based on OCCU

--- a/homematic/rootfs/opt/hm/bin/createBackup.sh
+++ b/homematic/rootfs/opt/hm/bin/createBackup.sh
@@ -67,6 +67,10 @@ if [[ -d "${TMPDIR}" ]]; then
   rm -f "${TMPDIR}/usr/local/etc/config/groups.gson" "${TMPDIR}/usr/local/etc/config/userprofiles"
   cp -a /data/* "${TMPDIR}/usr/local/etc/config/"
 
+  # move crRFD files to data sub-dir to be compatible
+  mkdir -p "${TMPDIR}/usr/local/etc/config/crRFD/data"
+  mv "${TMPDIR}/usr/local/etc/config/crRFD/*" "${TMPDIR}/usr/local/etc/config/crRFD/data/" 2>/dev/null
+
   # cleanup
   rm -f "${TMPDIR}/usr/local/etc/config/options.json"
   rm -f "${TMPDIR}/usr/local/etc/config/groups.json"


### PR DESCRIPTION
@pvizeli @agners 

Hopefully this is the last PR on the old homematic add-on. I just fixed a problem with the backup create script which did not generate sbk backups which were fully compatible, thus the HmIP devices were missing.

So please merge this PR again ASAP so that users can migrate more easily.