### PR TITLE
homematic: fix backup mv

### DIFF
--- a/homematic/CHANGELOG.md
+++ b/homematic/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 #### WARNING: This add-on is considered to be obsolete/retired in favor of the much more advanced third-party [RaspberryMatic CCU](https://github.com/jens-maus/RaspberryMatic/tree/master/home-assistant-addon) add-on for running a HomeMatic/homematicIP smart home central within HomeAssistant. If you want to migrate to the new add-on, please make sure to update to the latest version of this old "HomeMatic CCU" add-on first and then use the WebUI-based backup routines to export a `*.sbk` config backup file which you can then restore in the new "RaspberryMatic CCU" add-on afterwards (cf. [RaspberryMatic Documentation](https://github.com/jens-maus/RaspberryMatic/wiki/Installation-HomeAssistant))
 
+## 99.0.4
+
+- integrated another backup script fix to avoid errors on backup creation.
+
 ## 99.0.3
 
 - integrated backup script fix to generate .sbk backups more

--- a/homematic/config.yaml
+++ b/homematic/config.yaml
@@ -1,4 +1,4 @@
-version: 99.0.3
+version: 99.0.4
 slug: homematic
 name: HomeMatic CCU
 description: HomeMatic central based on OCCU

--- a/homematic/rootfs/opt/hm/bin/createBackup.sh
+++ b/homematic/rootfs/opt/hm/bin/createBackup.sh
@@ -69,7 +69,7 @@ if [[ -d "${TMPDIR}" ]]; then
 
   # move crRFD files to data sub-dir to be compatible
   mkdir -p "${TMPDIR}/usr/local/etc/config/crRFD/data"
-  mv "${TMPDIR}/usr/local/etc/config/crRFD/*" "${TMPDIR}/usr/local/etc/config/crRFD/data/" 2>/dev/null
+  mv "${TMPDIR}/usr/local/etc/config/crRFD/*" "${TMPDIR}/usr/local/etc/config/crRFD/data/" 2>/dev/null || true
 
   # cleanup
   rm -f "${TMPDIR}/usr/local/etc/config/options.json"


### PR DESCRIPTION
The recent backup fix introduced another error:
mv complains about us trying to move a folder into its own subfolder.
The script then aborts due to set -e. By ignoring the exit code of mv here
we get the desired result (complete backup and no error in ui)

cc @jens-maus 