### PR TITLE
homematic: use cp instead of mv for crRFD files to avoid mv subdir error

### DIFF
--- a/homematic/CHANGELOG.md
+++ b/homematic/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 #### WARNING: This add-on is considered to be obsolete/retired in favor of the much more advanced third-party [RaspberryMatic CCU](https://github.com/jens-maus/RaspberryMatic/tree/master/home-assistant-addon) add-on for running a HomeMatic/homematicIP smart home central within HomeAssistant. If you want to migrate to the new add-on, please make sure to update to the latest version of this old "HomeMatic CCU" add-on first and then use the WebUI-based backup routines to export a `*.sbk` config backup file which you can then restore in the new "RaspberryMatic CCU" add-on afterwards (cf. [RaspberryMatic Documentation](https://github.com/jens-maus/RaspberryMatic/wiki/Installation-HomeAssistant))
 
+## 99.0.5
+
+- integrated yet another backup script fix to avoid errors on backup creation.
+
 ## 99.0.4
 
 - integrated another backup script fix to avoid errors on backup creation.

--- a/homematic/config.yaml
+++ b/homematic/config.yaml
@@ -1,4 +1,4 @@
-version: 99.0.4
+version: 99.0.5
 slug: homematic
 name: HomeMatic CCU
 description: HomeMatic central based on OCCU

--- a/homematic/rootfs/opt/hm/bin/createBackup.sh
+++ b/homematic/rootfs/opt/hm/bin/createBackup.sh
@@ -68,8 +68,9 @@ if [[ -d "${TMPDIR}" ]]; then
   cp -a /data/* "${TMPDIR}/usr/local/etc/config/"
 
   # move crRFD files to data sub-dir to be compatible
-  mkdir -p "${TMPDIR}/usr/local/etc/config/crRFD/data"
-  mv "${TMPDIR}/usr/local/etc/config/crRFD/*" "${TMPDIR}/usr/local/etc/config/crRFD/data/" 2>/dev/null || true
+  rm -rf "${TMPDIR}/usr/local/etc/config/crRFD"
+  mkdir -p "${TMPDIR}/usr/local/etc/config/crRFD"
+  cp -a /data/crRFD "${TMPDIR}/usr/local/etc/config/crRFD/data"
 
   # cleanup
   rm -f "${TMPDIR}/usr/local/etc/config/options.json"


### PR DESCRIPTION
mv "${TMPDIR}/usr/local/etc/config/crRFD/*" does not expand the glob and fails.
Due to the previous change we also ignored the globbing error.
Let's clean the directory up, copy from the source and avoid globbing errors.
By doing it this way we can also drop the ugly "|| true".

related: https://github.com/jens-maus/RaspberryMatic/issues/1681
cc @jens-maus 