### PR TITLE
Bump zwave-js to 8.11.5

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.53
+
+- Bump Z-Wave JS to 8.11.5
+
 ## 0.1.52
 
 - Bump Z-Wave JS to 8.10.2

--- a/zwave_js/build.yaml
+++ b/zwave_js/build.yaml
@@ -9,4 +9,4 @@ codenotary:
   base_image: notary@home-assistant.io
 args:
   ZWAVEJS_SERVER_VERSION: 1.14.1
-  ZWAVEJS_VERSION: 8.10.2
+  ZWAVEJS_VERSION: 8.11.5

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -1,4 +1,4 @@
-version: 0.1.52
+version: 0.1.53
 slug: zwave_js
 name: Z-Wave JS
 description: Control a ZWave network with Home Assistant Z-Wave JS


### PR DESCRIPTION
Main change is the addition of the Humidity CC's which will be needed for [this PR](https://github.com/home-assistant/core/pull/65847#pullrequestreview-874796418)

Changelog:
- https://github.com/zwave-js/node-zwave-js/releases/tag/v8.11.0
- https://github.com/zwave-js/node-zwave-js/releases/tag/v8.11.1
- https://github.com/zwave-js/node-zwave-js/releases/tag/v8.11.2
- https://github.com/zwave-js/node-zwave-js/releases/tag/v8.11.3
- https://github.com/zwave-js/node-zwave-js/releases/tag/v8.11.4
- https://github.com/zwave-js/node-zwave-js/releases/tag/v8.11.5