### PR TITLE
Clarify DuckDNS alias instructions

### DIFF
--- a/duckdns/DOCS.md
+++ b/duckdns/DOCS.md
@@ -115,6 +115,8 @@ aliases:
     alias: my-domain.duckdns.org
 ```
 
+> Note that the `domain` key should receive **your custom domain name** and the `alias` key should rececive the DuckDNS domain name
+
 Don't add your custom domain name to the `domains` array. For certificate creation, all unique domains and aliases are used.
 
 Also, don't forget to make sure the dns-01 challenge can reach Duckdns. It might be required to add a specific CNAME for that:


### PR DESCRIPTION
Since we place DuckDNS names on the `domains` key, users who don't pay attention to the domain names used in the example (like me) are lead to think the should put the DuckDNS domain in the `domain` key of the alias object.
This PR adds an observation noting that the `domain` key should receive the custom domain name, and not the DuckDNS domain