### PR TITLE
Add translation files to all add-ons

### DIFF
--- a/ada/DOCS.md
+++ b/ada/DOCS.md
@@ -35,7 +35,7 @@ Home Assistant before using it with this add-on!
 ### Option: `tts` (required)
 
 The Home Assistant TTS (Text-to-Speech) integration to use when converting
-the response from Almond back to audio.
+the response from Almond to audio.
 
 Please note, this TTS integration has to be configured and active in
 Home Assistant before using it with this add-on!

--- a/ada/translations/en.yaml
+++ b/ada/translations/en.yaml
@@ -1,12 +1,12 @@
 ---
 configuration:
-  tts:
-    name: Text-to-Speech Integration
-    description: >-
-      The Home Assistant TTS (Text-to-Speech) integration to use when converting
-      the response from Almond to audio.
   stt:
     name: Speech-to-Text Integration
     description: >-
       The Home Assistant STT (Speech-to-Text) integration to use when converting
       detected audio to text for Almond to process.
+  tts:
+    name: Text-to-Speech Integration
+    description: >-
+      The Home Assistant TTS (Text-to-Speech) integration to use when converting
+      the response from Almond to audio.

--- a/ada/translations/en.yaml
+++ b/ada/translations/en.yaml
@@ -1,0 +1,12 @@
+---
+configuration:
+  tts:
+    name: Text-to-Speech Integration
+    description: >-
+      The Home Assistant TTS (Text-to-Speech) integration to use when converting
+      the response from Almond back to audio.
+  stt:
+    name: Speech-to-Text Integration
+    description: >-
+      The Home Assistant STT (Speech-to-Text) integration to use when converting
+      detected audio to text for Almond to process.

--- a/ada/translations/en.yaml
+++ b/ada/translations/en.yaml
@@ -4,7 +4,7 @@ configuration:
     name: Text-to-Speech Integration
     description: >-
       The Home Assistant TTS (Text-to-Speech) integration to use when converting
-      the response from Almond back to audio.
+      the response from Almond to audio.
   stt:
     name: Speech-to-Text Integration
     description: >-

--- a/configurator/translations/en.yaml
+++ b/configurator/translations/en.yaml
@@ -1,0 +1,27 @@
+---
+configuration:
+  dirsfirst:
+    name: Directories First
+    description: >-
+      This option allows you to list directories before files in the file
+      browser tree.
+  enforce_basepath:
+    name: Enforce Basepath
+    description: >-
+      If set to `true`, access is limited to files within the `/config`
+      directory.
+  git:
+    name: Git
+    description: >-
+      If set to `true`, add-on will initialize git for directories which support
+      it.
+  ignore_pattern:
+    name: Ignore Pattern
+    description: >-
+      This option allows you to hide files and folders from the file browser
+      tree.
+  ssh_keys:
+    name: SSH Keys
+    description: >-
+      A list of filenames containing SSH private keys. These can be used to
+      allow for access to remote git repositories.

--- a/deconz/config.yaml
+++ b/deconz/config.yaml
@@ -30,19 +30,15 @@ ports:
   40850/tcp: null
   5900/tcp: null
   8081/tcp: null
-ports_description:
-  40850/tcp: deCONZ API backend (Not required for Ingress)
-  5900/tcp: deCONZ via VNC (Not required for Ingress. Not secure!)
-  8081/tcp: deCONZ WebSocket (Not required for Ingress)
 privileged:
   - SYS_RAWIO
 schema:
+  device: device(subsystem=tty)
   dbg_aps: int?
   dbg_info: int?
   dbg_otau: int?
   dbg_zcl: int?
   dbg_zdp: int?
-  device: device(subsystem=tty)
 startup: services
 udev: true
 usb: true

--- a/deconz/translations/en.yaml
+++ b/deconz/translations/en.yaml
@@ -1,0 +1,19 @@
+---
+configuration:
+  device:
+    name: Device
+    description: The device address of your ConBee/RaspBee.
+  dbg_aps:
+    name: Debug aps
+  dbg_info:
+    name: Debug info
+  dbg_otau:
+    name: Debug otau
+  dbg_zcl:
+    name: Debug zcl
+  dbg_zdp:
+    name: Debug zdp
+network:
+  40850/tcp: deCONZ API backend (Not required for Ingress)
+  5900/tcp: deCONZ via VNC (Not required for Ingress. Not secure!)
+  8081/tcp: deCONZ WebSocket (Not required for Ingress)

--- a/dhcp_server/translations/en.yaml
+++ b/dhcp_server/translations/en.yaml
@@ -1,0 +1,24 @@
+---
+configuration:
+  default_lease:
+    name: Default Least Time
+    description: The default time in seconds that the IP is leased to your client.
+  dns:
+    name: DNS Servers
+    description: The DNS servers your DHCP server gives to your clients.
+  domain:
+    name: Domain
+    description: "Your network domain name, e.g., `mynetwork.local` or `home.local`"
+  hosts:
+    name: Hosts
+    description: >-
+      This option defines settings for one or host definitions for the DHCP
+      server.
+  max_lease:
+    name: Max Lease Time
+    description: The max time in seconds that the IP is leased to your client.
+  networks:
+    name: Networks
+    description: >-
+      This option defines settings for one or multiple networks for the DHCP
+      server to hand out IP addresses for.

--- a/dhcp_server/translations/en.yaml
+++ b/dhcp_server/translations/en.yaml
@@ -2,13 +2,15 @@
 configuration:
   default_lease:
     name: Default Least Time
-    description: The default time in seconds that the IP is leased to your client.
+    description: >-
+      The default time in seconds that the IP is leased to your client.
   dns:
     name: DNS Servers
     description: The DNS servers your DHCP server gives to your clients.
   domain:
     name: Domain
-    description: "Your network domain name, e.g., `mynetwork.local` or `home.local`"
+    description: >-
+      Your network domain name, e.g., `mynetwork.local` or `home.local`
   hosts:
     name: Hosts
     description: >-

--- a/dnsmasq/translations/en.yaml
+++ b/dnsmasq/translations/en.yaml
@@ -1,0 +1,19 @@
+---
+configuration:
+  defaults:
+    name: Upstream Servers
+    description: The defaults are upstream DNS servers.
+  forwards:
+    name: Forwards
+    description: >-
+      This option allows you to list domain that are forwarded to a different
+      (not the default) upstream DNS server.
+  hosts:
+    name: Hosts
+    description: This option allows you to provide local static answer for your DNS server.
+  services:
+    name: Services
+    description: This option allows you to provide srv-host records.
+network:
+  53/tcp: TCP port for DNS requests.
+  53/udp: UDP port for DNS requests.

--- a/dnsmasq/translations/en.yaml
+++ b/dnsmasq/translations/en.yaml
@@ -10,7 +10,8 @@ configuration:
       (not the default) upstream DNS server.
   hosts:
     name: Hosts
-    description: This option allows you to provide local static answer for your DNS server.
+    description: >-
+      This option allows you to provide local static answer for your DNS server.
   services:
     name: Services
     description: This option allows you to provide srv-host records.

--- a/duckdns/config.yaml
+++ b/duckdns/config.yaml
@@ -15,16 +15,16 @@ image: homeassistant/{arch}-addon-duckdns
 map:
   - ssl:rw
 options:
-  aliases: []
   domains:
     - null
+  token: null
+  aliases: []
   lets_encrypt:
     accept_terms: false
     algo: secp384r1
     certfile: fullchain.pem
     keyfile: privkey.pem
   seconds: 300
-  token: null
 schema:
   domains:
     - match(.+\.duckdns\.org)

--- a/duckdns/config.yaml
+++ b/duckdns/config.yaml
@@ -26,18 +26,18 @@ options:
   seconds: 300
   token: null
 schema:
+  domains:
+    - match(.+\.duckdns\.org)
+  token: str
   aliases:
     - alias: str
       domain: str
-  domains:
-    - match(.+\.duckdns\.org)
-  ipv4: str?
-  ipv6: str?
   lets_encrypt:
     accept_terms: bool
     algo: list(rsa|prime256v1|secp384r1)
     certfile: str
     keyfile: str
   seconds: int
-  token: str
+  ipv4: str?
+  ipv6: str?
 startup: services

--- a/duckdns/translations/en.yaml
+++ b/duckdns/translations/en.yaml
@@ -1,0 +1,36 @@
+---
+configuration:
+  aliases:
+    name: Alias
+    description: A list aliases of domains configured on the `domains` option.
+  domains:
+    name: Domains
+    description: >-
+      A list of DuckDNS subdomains registered under your account. An acceptable
+      naming convention is `my-domain.duckdns.org`.
+  ipv4:
+    name: IPv4
+    description: >-
+      By default, Duck DNS will auto detect your IPv4 address and use that. This
+      option allows you to override the auto-detection and specify an IPv4
+      address manually.
+  ipv6:
+    name: IPv6
+    description: >-
+      By default, Duck DNS will auto detect your IPv6 address and use that. This
+      option allows you to override the auto-detection and specify an IPv6
+      address manually.
+  lets_encrypt:
+    name: Let's Encrypt
+    description: Configure Let's Encrypt options
+  seconds:
+    name: Seconds
+    description: >-
+      The number of seconds to wait before updating DuckDNS subdomains and
+      renewing Let's Encrypt certificates.
+  token:
+    name: Token
+    description: >-
+      The DuckDNS authentication token found at the top of the DuckDNS account
+      landing page. The token is required to make any changes to the subdomains
+      registered to your account.

--- a/duckdns/translations/en.yaml
+++ b/duckdns/translations/en.yaml
@@ -1,13 +1,27 @@
 ---
 configuration:
-  aliases:
-    name: Alias
-    description: A list aliases of domains configured on the `domains` option.
   domains:
     name: Domains
     description: >-
       A list of DuckDNS subdomains registered under your account. An acceptable
       naming convention is `my-domain.duckdns.org`.
+  token:
+    name: Token
+    description: >-
+      The DuckDNS authentication token found at the top of the DuckDNS account
+      landing page. The token is required to make any changes to the subdomains
+      registered to your account.
+  aliases:
+    name: Alias
+    description: A list aliases of domains configured on the `domains` option.
+  lets_encrypt:
+    name: Let's Encrypt
+    description: Configure Let's Encrypt options
+  seconds:
+    name: Seconds
+    description: >-
+      The number of seconds to wait before updating DuckDNS subdomains and
+      renewing Let's Encrypt certificates.
   ipv4:
     name: IPv4
     description: >-
@@ -20,17 +34,3 @@ configuration:
       By default, Duck DNS will auto detect your IPv6 address and use that. This
       option allows you to override the auto-detection and specify an IPv6
       address manually.
-  lets_encrypt:
-    name: Let's Encrypt
-    description: Configure Let's Encrypt options
-  seconds:
-    name: Seconds
-    description: >-
-      The number of seconds to wait before updating DuckDNS subdomains and
-      renewing Let's Encrypt certificates.
-  token:
-    name: Token
-    description: >-
-      The DuckDNS authentication token found at the top of the DuckDNS account
-      landing page. The token is required to make any changes to the subdomains
-      registered to your account.

--- a/git_pull/config.yaml
+++ b/git_pull/config.yaml
@@ -36,20 +36,20 @@ options:
     - ui-lovelace.yaml
     - .gitignore
 schema:
-  auto_restart: bool
-  deployment_key:
-    - str
-  deployment_key_protocol: match(rsa|dsa|ecdsa|ed25519|rsa)
-  deployment_password: password
-  deployment_user: str
+  repository: str
   git_branch: str
+  git_remote: str
+  auto_restart: bool
+  restart_ignore:
+    - str
   git_command: list(pull|reset)
   git_prune: bool
-  git_remote: str
+  deployment_key:
+    - str
+  deployment_user: str
+  deployment_password: password
+  deployment_key_protocol: match(rsa|dsa|ecdsa|ed25519|rsa)
   repeat:
     active: bool
     interval: int
-  repository: str
-  restart_ignore:
-    - str
 startup: services

--- a/git_pull/config.yaml
+++ b/git_pull/config.yaml
@@ -19,22 +19,22 @@ init: false
 map:
   - config:rw
 options:
-  auto_restart: false
-  deployment_key: []
-  deployment_key_protocol: rsa
-  deployment_password: ""
-  deployment_user: ""
-  git_branch: master
-  git_command: pull
-  git_prune: false
-  git_remote: origin
-  repeat:
-    active: false
-    interval: 300
   repository: null
+  git_branch: master
+  git_remote: origin
+  auto_restart: false
   restart_ignore:
     - ui-lovelace.yaml
     - .gitignore
+  git_command: pull
+  git_prune: false
+  deployment_key: []
+  deployment_user: ""
+  deployment_password: ""
+  deployment_key_protocol: rsa
+  repeat:
+    active: false
+    interval: 300
 schema:
   repository: str
   git_branch: str

--- a/git_pull/translations/en.yaml
+++ b/git_pull/translations/en.yaml
@@ -1,0 +1,53 @@
+---
+configuration:
+  auto_restart:
+    name: Auto restart
+    description: Restart Home Assistant when the configuration has changed (and is valid).
+  deployment_key:
+    name: Deployment Key
+    description: >-
+      A private SSH key that will be used for communication during Git
+      operations.
+  deployment_key_protocol:
+    name: Deployment Key Protocol
+    description: The key protocol
+  deployment_password:
+    name: Deployment Password
+    description: >-
+      Password to use when authenticating to a repository.  Ignored if
+      `deployment_user` is not set.
+  deployment_user:
+    name: Deployment User
+    description: >-
+      Username to use when authenticating to a repository with a username and
+      password.
+  git_branch:
+    name: Git Branch
+    description: >-
+      Branch name of the Git repo. If left empty, the currently checked out
+      branch will be updated. Leave this as 'master' if you are unsure.
+  git_command:
+    name: Git Command
+    description: Command to run. Leave this as `pull` if you are unsure.
+  git_prune:
+    name: Git Prune
+    description: >-
+      If enabled, the add-on will clean-up branches that are deleted on the
+      remote repository, but still have cached entries on the local machine.
+      Leave this as `false` if you are unsure.
+  git_remote:
+    name: Git Remote
+    description: Name of the tracked repository. Leave this as `origin` if you are unsure.
+  repeat:
+    name: Polling
+    description: >-
+      Configure the Git pull add-on to poll the repository for updates
+      periodically automatically.
+  repository:
+    name: Repository
+    description: Git URL to your repository.
+  restart_ignore:
+    name: Restart Ignore
+    description: >-
+      When `auto_restart` is enabled, changes to these files will not make HA
+      restart. Full directories to ignore can be specified.

--- a/git_pull/translations/en.yaml
+++ b/git_pull/translations/en.yaml
@@ -1,32 +1,26 @@
 ---
 configuration:
-  auto_restart:
-    name: Auto restart
-    description: >-
-      Restart Home Assistant when the configuration has changed (and is valid).
-  deployment_key:
-    name: Deployment Key
-    description: >-
-      A private SSH key that will be used for communication during Git
-      operations.
-  deployment_key_protocol:
-    name: Deployment Key Protocol
-    description: The key protocol
-  deployment_password:
-    name: Deployment Password
-    description: >-
-      Password to use when authenticating to a repository.  Ignored if
-      `deployment_user` is not set.
-  deployment_user:
-    name: Deployment User
-    description: >-
-      Username to use when authenticating to a repository with a username and
-      password.
+  repository:
+    name: Repository
+    description: Git URL to your repository.
   git_branch:
     name: Git Branch
     description: >-
       Branch name of the Git repo. If left empty, the currently checked out
       branch will be updated. Leave this as 'master' if you are unsure.
+  git_remote:
+    name: Git Remote
+    description: >-
+      Name of the tracked repository. Leave this as `origin` if you are unsure.
+  auto_restart:
+    name: Auto restart
+    description: >-
+      Restart Home Assistant when the configuration has changed (and is valid).
+  restart_ignore:
+    name: Restart Ignore
+    description: >-
+      When `auto_restart` is enabled, changes to these files will not make HA
+      restart. Full directories to ignore can be specified.
   git_command:
     name: Git Command
     description: Command to run. Leave this as `pull` if you are unsure.
@@ -36,20 +30,26 @@ configuration:
       If enabled, the add-on will clean-up branches that are deleted on the
       remote repository, but still have cached entries on the local machine.
       Leave this as `false` if you are unsure.
-  git_remote:
-    name: Git Remote
+  deployment_key:
+    name: Deployment Key
     description: >-
-      Name of the tracked repository. Leave this as `origin` if you are unsure.
+      A private SSH key that will be used for communication during Git
+      operations.
+  deployment_user:
+    name: Deployment User
+    description: >-
+      Username to use when authenticating to a repository with a username and
+      password.
+  deployment_password:
+    name: Deployment Password
+    description: >-
+      Password to use when authenticating to a repository.  Ignored if
+      `deployment_user` is not set.
+  deployment_key_protocol:
+    name: Deployment Key Protocol
+    description: The key protocol
   repeat:
     name: Polling
     description: >-
       Configure the Git pull add-on to poll the repository for updates
       periodically automatically.
-  repository:
-    name: Repository
-    description: Git URL to your repository.
-  restart_ignore:
-    name: Restart Ignore
-    description: >-
-      When `auto_restart` is enabled, changes to these files will not make HA
-      restart. Full directories to ignore can be specified.

--- a/git_pull/translations/en.yaml
+++ b/git_pull/translations/en.yaml
@@ -2,7 +2,8 @@
 configuration:
   auto_restart:
     name: Auto restart
-    description: Restart Home Assistant when the configuration has changed (and is valid).
+    description: >-
+      Restart Home Assistant when the configuration has changed (and is valid).
   deployment_key:
     name: Deployment Key
     description: >-
@@ -37,7 +38,8 @@ configuration:
       Leave this as `false` if you are unsure.
   git_remote:
     name: Git Remote
-    description: Name of the tracked repository. Leave this as `origin` if you are unsure.
+    description: >-
+      Name of the tracked repository. Leave this as `origin` if you are unsure.
   repeat:
     name: Polling
     description: >-

--- a/google_assistant/config.yaml
+++ b/google_assistant/config.yaml
@@ -16,12 +16,12 @@ init: false
 map:
   - share
 options:
+  project_id: null
   client_secrets: google_assistant.json
+  model_id: null
   feedback:
     enable: false
     volume: 80
-  model_id: null
-  project_id: null
 ports:
   9324/tcp: 9324
 schema:

--- a/google_assistant/config.yaml
+++ b/google_assistant/config.yaml
@@ -25,11 +25,11 @@ options:
 ports:
   9324/tcp: 9324
 schema:
+  project_id: str
   client_secrets: str
+  model_id: str
   feedback:
     enable: bool
     volume: int(0,100)
-  model_id: str
-  project_id: str
 stage: experimental
 webui: http://[HOST]:[PORT:9324]

--- a/google_assistant/translations/en.yaml
+++ b/google_assistant/translations/en.yaml
@@ -1,0 +1,18 @@
+---
+configuration:
+  project_id:
+    name: Project ID
+    description: Project ID of the project you've created at Google for this add-on.
+  client_secrets:
+    name: Client Secrets
+    description: >-
+      The name of the client secrets file to you've downloaded from Google and
+      placed in your `/share` folder.
+  model_id:
+    name: Model ID
+    description: The ID of the model you've registered at Google for this add-on.
+  feedback:
+    name: Feedback
+    description: Control feedback options
+network:
+  9324/tcp: The port for the Webserver

--- a/google_assistant/translations/en.yaml
+++ b/google_assistant/translations/en.yaml
@@ -2,7 +2,8 @@
 configuration:
   project_id:
     name: Project ID
-    description: Project ID of the project you've created at Google for this add-on.
+    description: >-
+      Project ID of the project you've created at Google for this add-on.
   client_secrets:
     name: Client Secrets
     description: >-
@@ -10,7 +11,8 @@ configuration:
       placed in your `/share` folder.
   model_id:
     name: Model ID
-    description: The ID of the model you've registered at Google for this add-on.
+    description: >-
+      The ID of the model you've registered at Google for this add-on.
   feedback:
     name: Feedback
     description: Control feedback options

--- a/homematic/config.yaml
+++ b/homematic/config.yaml
@@ -14,12 +14,12 @@ ingress: true
 map:
   - share:rw
 options:
-  hmip: []
   hmip_enable: false
-  rf: []
+  hmip: []
   rf_enable: false
-  wired: []
+  rf: []
   wired_enable: false
+  wired: []
 panel_icon: mdi:router-wireless
 panel_title: HomeMatic
 ports:

--- a/homematic/config.yaml
+++ b/homematic/config.yaml
@@ -27,27 +27,22 @@ ports:
   2001/tcp: null
   2010/tcp: null
   80/tcp: null
-ports_description:
-  2000/tcp: HomematicWire xmlrpc (Extern)
-  2001/tcp: Homematic xmlrpc (Extern)
-  2010/tcp: HomematicIP xmlrpc (Extern)
-  80/tcp: ReGaHss Webinterface (Not required for Ingress)
 schema:
+  hmip_enable: bool
   hmip:
     - device: device
       type: match(HMIP_CCU2)
-  hmip_enable: bool
   regahss_reset: bool?
+  rf_enable: bool
   rf:
     - device: device
       reset: bool?
       type: match(CCU2)
-  rf_enable: bool
+  wired_enable: bool
   wired:
     - ip: str
       key: str
       serial: str
-  wired_enable: bool
 stage: deprecated
 startup: system
 timeout: 15

--- a/homematic/translations/en.yaml
+++ b/homematic/translations/en.yaml
@@ -1,0 +1,27 @@
+---
+configuration:
+  hmip:
+    name: HomematicIP Devices
+    description: List of HMIP devices.
+  hmip_enable:
+    name: Enable HomematicIP
+  regahss_reset:
+    name: ReGaHss Reset
+    description: >-
+      If this is enabled, the ReGaHss setting will be removed before it will be
+      started.
+  rf:
+    name: RF Devices
+    description: List of RF devices.
+  rf_enable:
+    name: Enable RF
+  wired:
+    name: Wired devices
+    description: List of wired devices.
+  wired_enable:
+    name: Enable Wired
+network:
+  2000/tcp: HomematicWire xmlrpc (Extern)
+  2001/tcp: Homematic xmlrpc (Extern)
+  2010/tcp: HomematicIP xmlrpc (Extern)
+  80/tcp: ReGaHss Webinterface (Not required for Ingress)

--- a/homematic/translations/en.yaml
+++ b/homematic/translations/en.yaml
@@ -1,25 +1,25 @@
 ---
 configuration:
+  hmip_enable:
+    name: Enable HomematicIP
   hmip:
     name: HomematicIP Devices
     description: List of HMIP devices.
-  hmip_enable:
-    name: Enable HomematicIP
   regahss_reset:
     name: ReGaHss Reset
     description: >-
       If this is enabled, the ReGaHss setting will be removed before it will be
       started.
+  rf_enable:
+    name: Enable RF
   rf:
     name: RF Devices
     description: List of RF devices.
-  rf_enable:
-    name: Enable RF
+  wired_enable:
+    name: Enable Wired
   wired:
     name: Wired devices
     description: List of wired devices.
-  wired_enable:
-    name: Enable Wired
 network:
   2000/tcp: HomematicWire xmlrpc (Extern)
   2001/tcp: Homematic xmlrpc (Extern)

--- a/letsencrypt/config.yaml
+++ b/letsencrypt/config.yaml
@@ -17,13 +17,13 @@ map:
   - ssl:rw
   - share
 options:
-  certfile: fullchain.pem
-  challenge: http
-  dns: {}
   domains:
     - null
   email: null
   keyfile: privkey.pem
+  certfile: fullchain.pem
+  challenge: http
+  dns: {}
 ports:
   80/tcp: 80
 schema:

--- a/letsencrypt/config.yaml
+++ b/letsencrypt/config.yaml
@@ -26,13 +26,15 @@ options:
   keyfile: privkey.pem
 ports:
   80/tcp: 80
-ports_description:
-  80/tcp: Only needed for http challenge
 schema:
-  acme_root_ca_cert: str?
-  acme_server: url?
+  domains:
+    - str
+  email: email
+  keyfile: str
   certfile: str
   challenge: list(dns|http)
+  acme_root_ca_cert: str?
+  acme_server: url?
   dns:
     aws_access_key_id: str?
     aws_secret_access_key: str?
@@ -68,10 +70,10 @@ schema:
     ovh_endpoint: str?
     propagation_seconds: int(60,3600)?
     provider: "list(dns-cloudflare|dns-cloudxns|dns-digitalocean|\
-               dns-directadmin|dns-dnsimple|dns-dnsmadeeasy|dns-gehirn|\
-               dns-google|dns-linode|dns-luadns|dns-njalla|dns-nsone|dns-ovh|\
-               dns-rfc2136|dns-route53|dns-sakuracloud|dns-netcup|dns-gandi|\
-               dns-transip)?"
+      dns-directadmin|dns-dnsimple|dns-dnsmadeeasy|dns-gehirn|\
+      dns-google|dns-linode|dns-luadns|dns-njalla|dns-nsone|dns-ovh|\
+      dns-rfc2136|dns-route53|dns-sakuracloud|dns-netcup|dns-gandi|\
+      dns-transip)?"
     rfc2136_algorithm: str?
     rfc2136_name: str?
     rfc2136_port: str?
@@ -81,8 +83,4 @@ schema:
     sakuracloud_api_token: str?
     transip_api_key: str?
     transip_username: str?
-  domains:
-    - str
-  email: email
-  keyfile: str
 startup: once

--- a/letsencrypt/translations/en.yaml
+++ b/letsencrypt/translations/en.yaml
@@ -1,0 +1,36 @@
+---
+configuration:
+  domains:
+    name: Domains
+    description: >-
+      The domain names to issue certificates for, use "*.yourdomain.com" for
+      wildcard certificates.
+  email:
+    name: Email
+    description: The email address that will be registered for the certificate.
+  keyfile:
+    name: Private Key File
+    description: Path to where the Private Key File will be placed.
+  certfile:
+    name: Certificate File
+    description: Path to where the Certificate File will be placed.
+  challenge:
+    name: Challenge
+    description: The type of challenge used to validate the domain.
+  acme_root_ca_cert:
+    name: ACME Rott CA Certificate
+    description: >-
+      If your custom ACME server uses a certificate signed by an untrusted
+      certificate authority (CA), you can add the root certificate to the trust
+      store by setting its content.
+  acme_server:
+    name: ACME Server
+    description: >-
+      By default, The addon uses Let's Encrypt's default server at
+      https://acme-v02.api.letsencrypt.org/. You can instruct the addon to use a
+      different ACME server.
+  dns:
+    name: DNS
+    description: DNS Provider configuration
+network:
+  80/tcp: Only needed for http challenge

--- a/mariadb/config.yaml
+++ b/mariadb/config.yaml
@@ -29,14 +29,14 @@ schema:
   databases:
     - str
   logins:
-    - password: password
-      username: str
+    - username: str
+      password: password
   rights:
     - database: str
       privileges:
         - "list(ALTER|CREATE|CREATE ROUTINE|CREATE TEMPORARY TABLES|\
-           CREATE VIEW|DELETE|DELETE HISTORY|DROP|EVENT|GRANT OPTION|INDEX|\
-           INSERT|LOCK TABLES|SELECT|SHOW VIEW|TRIGGER|UPDATE)?"
+          CREATE VIEW|DELETE|DELETE HISTORY|DROP|EVENT|GRANT OPTION|INDEX|\
+          INSERT|LOCK TABLES|SELECT|SHOW VIEW|TRIGGER|UPDATE)?"
       username: str
 services:
   - mysql:provide

--- a/mariadb/translations/en.yaml
+++ b/mariadb/translations/en.yaml
@@ -1,0 +1,13 @@
+---
+configuration:
+  databases:
+    name: Databases
+    description: Database names.
+  logins:
+    name: Logins
+    description: This section defines a create user definition in MariaDB.
+  rights:
+    name: Rights
+    description: This section grant privileges to users in MariaDB.
+network:
+  3306/tcp: The port to access the database engine.

--- a/mosquitto/config.yaml
+++ b/mosquitto/config.yaml
@@ -18,13 +18,13 @@ map:
   - ssl
   - share
 options:
+  logins: []
+  require_certificate: false
   certfile: fullchain.pem
+  keyfile: privkey.pem
   customize:
     active: false
     folder: mosquitto
-  keyfile: privkey.pem
-  logins: []
-  require_certificate: false
 ports:
   1883/tcp: 1883
   1884/tcp: 1884

--- a/mosquitto/config.yaml
+++ b/mosquitto/config.yaml
@@ -30,22 +30,17 @@ ports:
   1884/tcp: 1884
   8883/tcp: 8883
   8884/tcp: 8884
-ports_description:
-  1883/tcp: Normal MQTT
-  1884/tcp: MQTT over WebSocket
-  8883/tcp: Normal MQTT with SSL
-  8884/tcp: MQTT over WebSocket with SSL
 schema:
-  cafile: str?
+  logins:
+    - username: str
+      password: password
+  require_certificate: bool
   certfile: str
+  cafile: str?
+  keyfile: str
   customize:
     active: bool
     folder: str
-  keyfile: str
-  logins:
-    - password: password
-      username: str
-  require_certificate: bool
 services:
   - mqtt:provide
 startup: system

--- a/mosquitto/translations/en.yaml
+++ b/mosquitto/translations/en.yaml
@@ -27,7 +27,8 @@ configuration:
       `ssl` folder.
   customize:
     name: Customize
-    description: See the Documentation tab for more information about these options.
+    description: >-
+      See the Documentation tab for more information about these options.
 network:
   1883/tcp: Normal MQTT
   1884/tcp: MQTT over WebSocket

--- a/mosquitto/translations/en.yaml
+++ b/mosquitto/translations/en.yaml
@@ -1,0 +1,34 @@
+---
+configuration:
+  logins:
+    name: Logins
+    description: >-
+      A list of local users that will be created with username and password. You
+      don't need to do this because you can use Home Assistant users too,
+      without any configuration.
+  require_certificate:
+    name: Require Certificate
+    description: If enabled encryption will be enabled using the cert- and keyfile options.
+  certfile:
+    name: Certificate File
+    description: >-
+      A file containing a certificate, including its chain. Place this file in
+      the Home Assistant `ssl` folder.
+  cafile:
+    name: CA File
+    description: >-
+      A file containing a root certificate. Place this file in the Home
+      Assistant `ssl` folder.
+  keyfile:
+    name: Private Key File
+    description: >-
+      A file containing the private key. Place this file in the Home Assistant
+      `ssl` folder.
+  customize:
+    name: Customize
+    description: Customize options.
+network:
+  1883/tcp: Normal MQTT
+  1884/tcp: MQTT over WebSocket
+  8883/tcp: Normal MQTT with SSL
+  8884/tcp: MQTT over WebSocket with SSL

--- a/mosquitto/translations/en.yaml
+++ b/mosquitto/translations/en.yaml
@@ -27,7 +27,7 @@ configuration:
       `ssl` folder.
   customize:
     name: Customize
-    description: Customize options.
+    description: See the Documentation tab for more information about these options.
 network:
   1883/tcp: Normal MQTT
   1884/tcp: MQTT over WebSocket

--- a/mosquitto/translations/en.yaml
+++ b/mosquitto/translations/en.yaml
@@ -8,7 +8,8 @@ configuration:
       without any configuration.
   require_certificate:
     name: Require Certificate
-    description: If enabled encryption will be enabled using the cert- and keyfile options.
+    description: >-
+      If enabled encryption will be enabled using the cert- and keyfile options.
   certfile:
     name: Certificate File
     description: >-

--- a/nginx_proxy/config.yaml
+++ b/nginx_proxy/config.yaml
@@ -16,15 +16,15 @@ map:
   - ssl
   - share
 options:
+  domain: null
+  hsts: max-age=31536000; includeSubDomains
   certfile: fullchain.pem
+  keyfile: privkey.pem
   cloudflare: false
   customize:
     active: false
     default: nginx_proxy_default*.conf
     servers: nginx_proxy/*.conf
-  domain: null
-  hsts: max-age=31536000; includeSubDomains
-  keyfile: privkey.pem
 ports:
   443/tcp: 443
   80/tcp: null

--- a/nginx_proxy/config.yaml
+++ b/nginx_proxy/config.yaml
@@ -29,12 +29,12 @@ ports:
   443/tcp: 443
   80/tcp: null
 schema:
+  domain: str
+  hsts: str
   certfile: str
+  keyfile: str
   cloudflare: bool
   customize:
     active: bool
     default: str
     servers: str
-  domain: str
-  hsts: str
-  keyfile: str

--- a/nginx_proxy/translations/en.yaml
+++ b/nginx_proxy/translations/en.yaml
@@ -1,0 +1,26 @@
+---
+configuration:
+  domain:
+    name: Domain
+    description: The domain name to use for the proxy.
+  certfile:
+    name: Certificate File
+    description: he certificate file to use in the `/ssl` directory.
+  hsts:
+    name: HSTS
+    description: "Value for the HSTS HTTP header to send. If empty, the header is not sent."
+  keyfile:
+    name: Private Key File
+    description: Private Private Key File to use in the `/ssl` directory.
+  cloudflare:
+    name: CloudFlare
+    description: >-
+      If enabled, configure Nginx with a list of IP addresses directly from
+      Cloudflare that will be used for `set_real_ip_from` directive Nginx
+      config.
+  customize:
+    name: Customize
+    description: Customize options.
+network:
+  443/tcp: HTTPS (SSL) Port
+  80/tcp: HTTP (non-SSL) Port

--- a/nginx_proxy/translations/en.yaml
+++ b/nginx_proxy/translations/en.yaml
@@ -21,7 +21,7 @@ configuration:
       config.
   customize:
     name: Customize
-    description: Customize options.
+    description: See the Documentation tab for more information about these options.
 network:
   443/tcp: HTTPS (SSL) Port
   80/tcp: HTTP (non-SSL) Port

--- a/nginx_proxy/translations/en.yaml
+++ b/nginx_proxy/translations/en.yaml
@@ -3,13 +3,13 @@ configuration:
   domain:
     name: Domain
     description: The domain name to use for the proxy.
-  certfile:
-    name: Certificate File
-    description: he certificate file to use in the `/ssl` directory.
   hsts:
     name: HSTS
     description: >-
       Value for the HSTS HTTP header to send. If empty, the header is not sent.
+  certfile:
+    name: Certificate File
+    description: he certificate file to use in the `/ssl` directory.
   keyfile:
     name: Private Key File
     description: Private Private Key File to use in the `/ssl` directory.

--- a/nginx_proxy/translations/en.yaml
+++ b/nginx_proxy/translations/en.yaml
@@ -8,7 +8,8 @@ configuration:
     description: he certificate file to use in the `/ssl` directory.
   hsts:
     name: HSTS
-    description: "Value for the HSTS HTTP header to send. If empty, the header is not sent."
+    description: >-
+      Value for the HSTS HTTP header to send. If empty, the header is not sent.
   keyfile:
     name: Private Key File
     description: Private Private Key File to use in the `/ssl` directory.

--- a/nginx_proxy/translations/en.yaml
+++ b/nginx_proxy/translations/en.yaml
@@ -9,7 +9,8 @@ configuration:
       Value for the HSTS HTTP header to send. If empty, the header is not sent.
   certfile:
     name: Certificate File
-    description: he certificate file to use in the `/ssl` directory.
+    description: >-
+      The certificate file to use in the `/ssl` directory.
   keyfile:
     name: Private Key File
     description: Private Private Key File to use in the `/ssl` directory.
@@ -21,7 +22,8 @@ configuration:
       config.
   customize:
     name: Customize
-    description: See the Documentation tab for more information about these options.
+    description: >-
+      See the Documentation tab for more information about these options.
 network:
   443/tcp: HTTPS (SSL) Port
   80/tcp: HTTP (non-SSL) Port

--- a/rpc_shutdown/translations/en.yaml
+++ b/rpc_shutdown/translations/en.yaml
@@ -2,4 +2,5 @@
 configuration:
   computers:
     name: Computers
-    description: A list of computer objects to be able to shutdown from Home-Assistant.
+    description: >-
+      A list of computer objects to be able to shutdown from Home-Assistant.

--- a/rpc_shutdown/translations/en.yaml
+++ b/rpc_shutdown/translations/en.yaml
@@ -1,0 +1,5 @@
+---
+configuration:
+  computers:
+    name: Computers
+    description: A list of computer objects to be able to shutdown from Home-Assistant.

--- a/samba/config.yaml
+++ b/samba/config.yaml
@@ -22,21 +22,21 @@ map:
   - backup:rw
   - media:rw
 options:
-  allow_hosts:
-    - 10.0.0.0/8
-    - 172.16.0.0/12
-    - 192.168.0.0/16
-    - fe80::/10
-  compatibility_mode: false
-  password: null
   username: homeassistant
+  password: null
+  workgroup: WORKGROUP
+  compatibility_mode: false
   veto_files:
     - ._*
     - .DS_Store
     - Thumbs.db
     - icon?
     - .Trashes
-  workgroup: WORKGROUP
+  allow_hosts:
+    - 10.0.0.0/8
+    - 172.16.0.0/12
+    - 192.168.0.0/16
+    - fe80::/10
 schema:
   username: str
   password: password

--- a/samba/config.yaml
+++ b/samba/config.yaml
@@ -38,12 +38,12 @@ options:
     - .Trashes
   workgroup: WORKGROUP
 schema:
-  allow_hosts:
-    - str
-  compatibility_mode: bool
-  password: password
   username: str
+  password: password
+  workgroup: str
+  compatibility_mode: bool
   veto_files:
     - str
-  workgroup: str
+  allow_hosts:
+    - str
 startup: services

--- a/samba/translations/en.yaml
+++ b/samba/translations/en.yaml
@@ -2,16 +2,19 @@
 configuration:
   username:
     name: Username
-    description: The username you would like to use to authenticate with the Samba server.
+    description: >-
+      The username you would like to use to authenticate with the Samba server.
   password:
     name: Password
-    description: The password that goes with the username configured for authentication.
+    description: >-
+      The password that goes with the username configured for authentication.
   workgroup:
     name: Workgroup
     description: Change WORKGROUP to reflect your network needs.
   compatibility_mode:
     name: Enable Compatibility Mode
-    description: Enable this to use old legacy Samba protocols on the Samba add-on.
+    description: >-
+      Enable this to use old legacy Samba protocols on the Samba add-on.
   veto_files:
     name: Veto Files
     description: List of files that are neither visible nor accessible.

--- a/samba/translations/en.yaml
+++ b/samba/translations/en.yaml
@@ -1,0 +1,20 @@
+---
+configuration:
+  username:
+    name: Username
+    description: The username you would like to use to authenticate with the Samba server.
+  password:
+    name: Password
+    description: The password that goes with the username configured for authentication.
+  workgroup:
+    name: Workgroup
+    description: Change WORKGROUP to reflect your network needs.
+  compatibility_mode:
+    name: Enable Compatibility Mode
+    description: Enable this to use old legacy Samba protocols on the Samba add-on.
+  veto_files:
+    name: Veto Files
+    description: List of files that are neither visible nor accessible.
+  allow_hosts:
+    name: Allowed Hosts
+    description: List of hosts/networks allowed to access the shared folders.

--- a/ssh/config.yaml
+++ b/ssh/config.yaml
@@ -36,11 +36,11 @@ panel_title: Terminal
 ports:
   22/tcp: null
 schema:
-  apks:
-    - str
   authorized_keys:
     - str
   password: password
+  apks:
+    - str
   server:
     tcp_forwarding: bool
 startup: services

--- a/ssh/config.yaml
+++ b/ssh/config.yaml
@@ -26,9 +26,9 @@ map:
   - backup:rw
   - media:rw
 options:
-  apks: []
   authorized_keys: []
   password: ""
+  apks: []
   server:
     tcp_forwarding: false
 panel_icon: mdi:console

--- a/ssh/translations/en.yaml
+++ b/ssh/translations/en.yaml
@@ -1,0 +1,16 @@
+---
+configuration:
+  password:
+    name: Password
+    description: Set a password for login. We do NOT recommend this variant.
+  authorized_keys:
+    name: Authorized Keys
+    description: Your public keys that you wish to accept for login.
+  apks:
+    name: Packages
+    description: Additional software packages to install in the add-on container.
+  server:
+    name: Server
+    description: SSH Server configuration
+network:
+  22/tcp: SSH Port

--- a/ssh/translations/en.yaml
+++ b/ssh/translations/en.yaml
@@ -8,7 +8,8 @@ configuration:
     description: Your public keys that you wish to accept for login.
   apks:
     name: Packages
-    description: Additional software packages to install in the add-on container.
+    description: >-
+      Additional software packages to install in the add-on container.
   server:
     name: Server
     description: SSH Server configuration

--- a/ssh/translations/en.yaml
+++ b/ssh/translations/en.yaml
@@ -1,11 +1,11 @@
 ---
 configuration:
-  password:
-    name: Password
-    description: Set a password for login. We do NOT recommend this variant.
   authorized_keys:
     name: Authorized Keys
     description: Your public keys that you wish to accept for login.
+  password:
+    name: Password
+    description: Set a password for login. We do NOT recommend this variant.
   apks:
     name: Packages
     description: >-

--- a/tellstick/translations/en.yaml
+++ b/tellstick/translations/en.yaml
@@ -1,0 +1,7 @@
+---
+configuration:
+  devices:
+    name: Devices
+    description: >-
+      Add one or more devices entries to the add-on configuration for each
+      device you'd like to add.

--- a/zwave/DOCS.md
+++ b/zwave/DOCS.md
@@ -48,7 +48,7 @@ instance: 1
 
 ### Option `device`
 
-The device address of your Z-Wave controller.
+The Z-Wave controller device.
 
 If you're using Home Assistant you may find the correct value for this on the
 `Supervisor -> System -> Host system -> Hardware` page. It is recommended

--- a/zwave/config.yaml
+++ b/zwave/config.yaml
@@ -25,9 +25,6 @@ panel_title: OpenZWave
 ports:
   1983/tcp: null
   5900/tcp: null
-ports_description:
-  1983/tcp: ozw-admin port
-  5900/tcp: VNC port
 schema:
   device: device(subsystem=tty)
   instance: int(1,)?

--- a/zwave/translations/en.yaml
+++ b/zwave/translations/en.yaml
@@ -2,7 +2,7 @@
 configuration:
   device:
     name: Device
-    description: The device address of your Z-Wave controller.
+    description: The Z-Wave controller device.
   instance:
     name: Instance
     description: >-

--- a/zwave/translations/en.yaml
+++ b/zwave/translations/en.yaml
@@ -1,0 +1,18 @@
+---
+configuration:
+  device:
+    name: Device
+    description: The device address of your Z-Wave controller.
+  instance:
+    name: Instance
+    description: >-
+      Z-Wave instance number as reported to MQTT. This corresponds with the
+      `instance_id` attribute of `ozw` services in Home Assistant.
+  network_key:
+    name: Network Key
+    description: >-
+      Security Z-Wave devices require a network key before being added to the
+      network.
+network:
+  1983/tcp: ozw-admin port
+  5900/tcp: VNC port

--- a/zwave_js/DOCS.md
+++ b/zwave_js/DOCS.md
@@ -26,13 +26,12 @@ change if other devices are added to the system.
    in order to connect securely to compatible devices. It is recommended
    that all four network keys are configured as some security enabled devices (locks, etc)
    may not function correctly if they are not added securely.
-     * As a note, it is not recommended to securely connect *all* devices unless they support S2 security
-       as the S0 security triples the amount of messages sent on the mesh.
+   - As a note, it is not recommended to securely connect _all_ devices unless they support S2 security
+     as the S0 security triples the amount of messages sent on the mesh.
 3. Click on "SAVE" to save the add-on configuration.
 4. Start the add-on.
 5. Add the Z-Wave JS integration to Home Assistant, see documentation:
    <https://www.home-assistant.io/integrations/zwave_js>
-
 
 ## Configuration
 
@@ -48,7 +47,7 @@ s2_unauthenticated_key: CF338FE0CB99549F7C0EA96308E5A403
 
 ### Option `device`
 
-The device address of your Z-Wave controller.
+The Z-Wave controller device.
 
 If you're using Home Assistant you may find the correct value for this on the
 `Supervisor -> System -> Host system -> Hardware` page. It is recommended
@@ -126,6 +125,7 @@ automatically on startup.
 ### Option `log_level` (optional)
 
 This option sets the log level of Z-Wave JS. Valid options are:
+
 - silly
 - debug
 - verbose

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -25,8 +25,6 @@ options:
   s2_unauthenticated_key: ""
 ports:
   3000/tcp: null
-ports_description:
-  3000/tcp: Z-Wave JS communication
 schema:
   device: device(subsystem=tty)
   emulate_hardware: bool?

--- a/zwave_js/translations/en.yaml
+++ b/zwave_js/translations/en.yaml
@@ -2,7 +2,7 @@
 configuration:
   device:
     name: Device
-    description: The device address of your Z-Wave controller.
+    description: The Z-Wave controller device.
   emulate_hardware:
     name: Enable Emulated Hardware
     description: >-

--- a/zwave_js/translations/en.yaml
+++ b/zwave_js/translations/en.yaml
@@ -1,0 +1,41 @@
+---
+configuration:
+  device:
+    name: Device
+    description: The device address of your Z-Wave controller.
+  emulate_hardware:
+    name: Enable Emulated Hardware
+    description: >-
+      If you don't have a USB stick, you can use a fake stick for testing
+      purposes.
+  log_level:
+    name: Log Level
+    description: This option sets the log level of Z-Wave JS.
+  network_key:
+    name: Network Key
+    description: >-
+      In previous versions of the addon, this was the only key that was needed.
+      With the introduction of S2 security inclusion in zwave-js, this option
+      has been deprecated.
+  s0_legacy_key:
+    name: S0 Legacy Key
+    description: >-
+      S0 Security Z-Wave devices require a network key before being added to the
+      network.
+  s2_access_control_key:
+    name: S2 Access Control Key
+    description: >-
+      This must be provided in order to include devices with the S2 Access
+      Control security class.
+  s2_authenticated_key:
+    name: S2 Authenticated Key
+    description: >-
+      This must be provided in order to include devices with the S2
+      Authenticated security class.
+  s2_unauthenticated_key:
+    name: S2 Unauthenticated Key
+    description: >-
+      This must be provided in order to include devices with the S2
+      Unauthenticated security class.
+network:
+  3000/tcp: Z-Wave JS communication


### PR DESCRIPTION
Add translation files were missing for all add-ons that have configuration or network options.
Some schema options were reordered to make the "flow" of the configuration better.

Example of the difference:
![image](https://user-images.githubusercontent.com/15093472/162692010-947ca2de-ec7a-4e3a-b868-1280ce36fbc4.png)
![image](https://user-images.githubusercontent.com/15093472/162691736-18197406-a92b-4ced-8e48-be3a058c48ae.png)
