### PR TITLE
Bump zwave-js to 9.0.4

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.57
+
+- Bump Z-Wave JS to 9.0.4
+
 ## 0.1.56
 
 - Bump Z-Wave JS to 9.0.2

--- a/zwave_js/build.yaml
+++ b/zwave_js/build.yaml
@@ -10,4 +10,4 @@ codenotary:
   base_image: notary@home-assistant.io
 args:
   ZWAVEJS_SERVER_VERSION: 1.16.0
-  ZWAVEJS_VERSION: 9.0.2
+  ZWAVEJS_VERSION: 9.0.4

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.1.56
+version: 0.1.57
 slug: zwave_js
 name: Z-Wave JS
 description: Control a ZWave network with Home Assistant Z-Wave JS


### PR DESCRIPTION
Primarily bug fixes in these patch versions

Changelog:
- https://github.com/zwave-js/node-zwave-js/releases/tag/v9.0.4
- https://github.com/zwave-js/node-zwave-js/releases/tag/v9.0.3