### PR TITLE
Update mosquitto to alpine 3.15 base

### DIFF
--- a/mosquitto/build.yaml
+++ b/mosquitto/build.yaml
@@ -1,10 +1,10 @@
 ---
 build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-base:3.13
-  amd64: ghcr.io/home-assistant/amd64-base:3.13
-  armhf: ghcr.io/home-assistant/armhf-base:3.13
-  armv7: ghcr.io/home-assistant/armv7-base:3.13
-  i386: ghcr.io/home-assistant/i386-base:3.13
+  aarch64: ghcr.io/home-assistant/aarch64-base:3.15
+  amd64: ghcr.io/home-assistant/amd64-base:3.15
+  armhf: ghcr.io/home-assistant/armhf-base:3.15
+  armv7: ghcr.io/home-assistant/armv7-base:3.15
+  i386: ghcr.io/home-assistant/i386-base:3.15
 codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io


### PR DESCRIPTION
Update mosquitto base image from 3.13 to 3.15. This will also update mosquitto and nginx:

- mosquitto: `1.6.12` -> `2.0.14`
- nginx: `1.18.0` -> `1.20.2`