### PR TITLE
Update mosquitto to 2.0.11

### DIFF
--- a/mosquitto/CHANGELOG.md
+++ b/mosquitto/CHANGELOG.md
@@ -6,6 +6,10 @@
 - Remove `mosquitto-auth-plug` and replace with `mosquitto-go-auth` 1.8.2
 - Change base image from Alpine to Debian (required for `mosquitto-go-auth`)
 
+Note: Mosquitto 2.0.0 did contain some breaking changes. We don't anticipate
+most users to be affected by them but if you have a heavily customized mosquitto
+config we would advise reviewing [their changelog](https://mosquitto.org/ChangeLog.txt). 
+
 ## 6.0.2
 
 - Mention homeassistant and addon users in ACL doc

--- a/mosquitto/CHANGELOG.md
+++ b/mosquitto/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Update base image to Alpine Linux 3.14
 - Update mosquitto to 2.0.11
 - Update nginx to 1.20.2
+- Remove mosquitto-auth-plug and replace with mosquitto-go-auth 1.8.2
 
 ## 6.0.2
 

--- a/mosquitto/CHANGELOG.md
+++ b/mosquitto/CHANGELOG.md
@@ -2,10 +2,9 @@
 
 ## 6.1.0
 
-- Update base image to Alpine Linux 3.14
 - Update mosquitto to 2.0.11
-- Update nginx to 1.20.2
-- Remove mosquitto-auth-plug and replace with mosquitto-go-auth 1.8.2
+- Remove `mosquitto-auth-plug` and replace with `mosquitto-go-auth` 1.8.2
+- Change base image from Alpine to Debian (required for `mosquitto-go-auth`)
 
 ## 6.0.2
 

--- a/mosquitto/CHANGELOG.md
+++ b/mosquitto/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 6.1.0
+
+- Update base image to Alpine Linux 3.14
+- Update mosquitto to 2.0.11
+- Update nginx to 1.20.2
+
 ## 6.0.2
 
 - Mention homeassistant and addon users in ACL doc

--- a/mosquitto/Dockerfile
+++ b/mosquitto/Dockerfile
@@ -20,6 +20,7 @@ RUN apk add --no-cache \
        https://github.com/iegomez/mosquitto-go-auth \
     \
     && cd mosquitto-go-auth \
+    && sed '/LDFLAGS :=/ s/$/ -Wl,-unresolved-symbols=ignore-all/' Makefile \
     && make \
     && mkdir -p /usr/share/mosquitto \
     && cp -f go-auth.so /usr/share/mosquitto \

--- a/mosquitto/Dockerfile
+++ b/mosquitto/Dockerfile
@@ -14,16 +14,16 @@ RUN apk add --no-cache \
         git \
         mosquitto-dev \
         openssl-dev \
+        go \
     \
     && git clone --depth 1 -b "${MOSQUITTO_AUTH_VERSION}" \
-        https://github.com/pvizeli/mosquitto-auth-plug \
+       https://github.com/iegomez/mosquitto-go-auth \
     \
-    && cd mosquitto-auth-plug \
-    && cp config.mk.in config.mk \
+    && cd mosquitto-go-auth \
     && make \
     && mkdir -p /usr/share/mosquitto \
-    && cp -f auth-plug.so /usr/share/mosquitto \
-    && cp -f np /usr/local/bin \
+    && cp -f go-auth.so /usr/share/mosquitto \
+    && cp -f pw /usr/local/bin \
     \
     && apk del --no-cache .build-dependencies \
     && rm -fr \

--- a/mosquitto/Dockerfile
+++ b/mosquitto/Dockerfile
@@ -20,7 +20,7 @@ RUN apk add --no-cache \
        https://github.com/iegomez/mosquitto-go-auth \
     \
     && cd mosquitto-go-auth \
-    && sed '/LDFLAGS :=/ s/$/ -Wl,-unresolved-symbols=ignore-all/' Makefile \
+    && sed -i 's/LDFLAGS := .*$/& -Wl,-unresolved-symbols=ignore-all/' Makefile \
     && make \
     && mkdir -p /usr/share/mosquitto \
     && cp -f go-auth.so /usr/share/mosquitto \

--- a/mosquitto/Dockerfile
+++ b/mosquitto/Dockerfile
@@ -45,7 +45,9 @@ RUN apt-get update \
         /usr/src/mosquitto-go-auth \
         /var/lib/nginx/html \
         /var/www \
-        /var/lib/apt/lists/*
+        /var/lib/apt/lists/* \
+	/root/.cache \
+	/root/go
 
 # Copy rootfs
 COPY rootfs /

--- a/mosquitto/Dockerfile
+++ b/mosquitto/Dockerfile
@@ -4,35 +4,44 @@ FROM $BUILD_FROM
 # Install mosquitto + auth plugin
 WORKDIR /usr/src
 ARG MOSQUITTO_AUTH_VERSION
-RUN apk add --no-cache \
+RUN apt-get update \
+    && apt-get install -qy --no-install-recommends \
         mosquitto \
         nginx \
         pwgen \
-    && apk add --no-cache --virtual .build-dependencies \
-        build-base \
-        curl-dev \
+        build-essential \
         git \
         mosquitto-dev \
-        openssl-dev \
-        go \
+        libmosquitto-dev \
+        openssl \
+        libssl-dev \
+        golang-go \
     \
     && git clone --depth 1 -b "${MOSQUITTO_AUTH_VERSION}" \
        https://github.com/iegomez/mosquitto-go-auth \
     \
     && cd mosquitto-go-auth \
+    && sed -i 's/-I\/usr\/local\/include/-I\/usr\/include/' Makefile \
     && sed -i 's/LDFLAGS := .*$/& -Wl,-unresolved-symbols=ignore-all/' Makefile \
     && make \
     && mkdir -p /usr/share/mosquitto \
     && cp -f go-auth.so /usr/share/mosquitto \
     && cp -f pw /usr/local/bin \
     \
-    && apk del --no-cache .build-dependencies \
+    && apt-get purge -y --auto-remove \
+        build-essential \
+        git \
+        mosquitto-dev \
+        libmosquitto-dev \
+        openssl \
+        libssl-dev \
+        golang-go \
     && rm -fr \
         /etc/logrotate.d \
         /etc/mosquitto/* \
         /etc/nginx/* \
         /usr/share/nginx \
-        /usr/src/mosquitto-auth-plug \
+        /usr/src/mosquitto-go-auth \
         /var/lib/nginx/html \
         /var/www
 

--- a/mosquitto/Dockerfile
+++ b/mosquitto/Dockerfile
@@ -36,6 +36,7 @@ RUN apt-get update \
         openssl \
         libssl-dev \
         golang-go \
+    && apt-get clean \
     && rm -fr \
         /etc/logrotate.d \
         /etc/mosquitto/* \
@@ -43,7 +44,8 @@ RUN apt-get update \
         /usr/share/nginx \
         /usr/src/mosquitto-go-auth \
         /var/lib/nginx/html \
-        /var/www
+        /var/www \
+        /var/lib/apt/lists/*
 
 # Copy rootfs
 COPY rootfs /

--- a/mosquitto/build.yaml
+++ b/mosquitto/build.yaml
@@ -9,4 +9,4 @@ codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
 args:
-  MOSQUITTO_AUTH_VERSION: 0.1.5
+  MOSQUITTO_AUTH_VERSION: 1.8.2

--- a/mosquitto/build.yaml
+++ b/mosquitto/build.yaml
@@ -1,10 +1,10 @@
 ---
 build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-base:3.14
-  amd64: ghcr.io/home-assistant/amd64-base:3.14
-  armhf: ghcr.io/home-assistant/armhf-base:3.14
-  armv7: ghcr.io/home-assistant/armv7-base:3.14
-  i386: ghcr.io/home-assistant/i386-base:3.14
+  aarch64: ghcr.io/home-assistant/aarch64-base-debian:bullseye
+  amd64: ghcr.io/home-assistant/amd64-base-debian:bullseye
+  armhf: ghcr.io/home-assistant/armhf-base-debian:bullseye
+  armv7: ghcr.io/home-assistant/armv7-base-debian:bullseye
+  i386: ghcr.io/home-assistant/i386-base-debian:bullseye
 codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io

--- a/mosquitto/build.yaml
+++ b/mosquitto/build.yaml
@@ -1,10 +1,10 @@
 ---
 build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-base:3.13
-  amd64: ghcr.io/home-assistant/amd64-base:3.13
-  armhf: ghcr.io/home-assistant/armhf-base:3.13
-  armv7: ghcr.io/home-assistant/armv7-base:3.13
-  i386: ghcr.io/home-assistant/i386-base:3.13
+  aarch64: ghcr.io/home-assistant/aarch64-base:3.14
+  amd64: ghcr.io/home-assistant/amd64-base:3.14
+  armhf: ghcr.io/home-assistant/armhf-base:3.14
+  armv7: ghcr.io/home-assistant/armv7-base:3.14
+  i386: ghcr.io/home-assistant/i386-base:3.14
 codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io

--- a/mosquitto/config.yaml
+++ b/mosquitto/config.yaml
@@ -4,6 +4,7 @@ slug: mosquitto
 name: Mosquitto broker
 description: An Open Source MQTT broker
 url: https://github.com/home-assistant/hassio-addons/tree/master/mosquitto
+codenotary: notary@home-assistant.io
 arch:
   - armhf
   - armv7

--- a/mosquitto/config.yaml
+++ b/mosquitto/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 6.0.2
+version: 6.1.0
 slug: mosquitto
 name: Mosquitto broker
 description: An Open Source MQTT broker

--- a/mosquitto/rootfs/etc/cont-init.d/mosquitto.sh
+++ b/mosquitto/rootfs/etc/cont-init.d/mosquitto.sh
@@ -31,12 +31,12 @@ else
 fi
 
 # Set up discovery user
-password=$(np -p "${discovery_password}")
+password=$(pw -p "${discovery_password}")
 echo "homeassistant:${password}" >> "${PW}"
 echo "user homeassistant" >> "${ACL}"
 
 # Set up service user
-password=$(np -p "${service_password}")
+password=$(pw -p "${service_password}")
 echo "addons:${password}" >> "${PW}"
 echo "user addons" >> "${ACL}"
 
@@ -49,7 +49,7 @@ for login in $(bashio::config 'logins|keys'); do
   password=$(bashio::config "logins[${login}].password")
 
   bashio::log.info "Setting up user ${username}"
-  password=$(np -p "${password}")
+  password=$(pw -p "${password}")
   echo "${username}:${password}" >> "${PW}"
   echo "user ${username}" >> "${ACL}"
 done

--- a/mosquitto/rootfs/usr/share/tempio/mosquitto.gtpl
+++ b/mosquitto/rootfs/usr/share/tempio/mosquitto.gtpl
@@ -11,6 +11,7 @@ persistence_location /data/
 # Authentication plugin
 auth_plugin /usr/share/mosquitto/go-auth.so
 auth_opt_backends files,http
+auth_opt_hasher pbkdf2
 auth_opt_cache true
 auth_opt_auth_cache_seconds 300
 auth_opt_auth_jitter_seconds 30

--- a/mosquitto/rootfs/usr/share/tempio/mosquitto.gtpl
+++ b/mosquitto/rootfs/usr/share/tempio/mosquitto.gtpl
@@ -9,21 +9,21 @@ persistence true
 persistence_location /data/
 
 # Authentication plugin
-auth_plugin /usr/share/mosquitto/auth-plug.so
+auth_plugin /usr/share/mosquitto/go-auth.so
 auth_opt_backends files,http
 auth_opt_cache true
-auth_opt_auth_cacheseconds 300
-auth_opt_auth_cachejitter 30
-auth_opt_acl_cacheseconds 300
-auth_opt_acl_cachejitter 30
-auth_opt_log_quiet true
+auth_opt_auth_cache_seconds 300
+auth_opt_auth_jitter_seconds 30
+auth_opt_acl_cache_seconds 300
+auth_opt_acl_jitter_seconds 30
+auth_opt_log_level error
 
 # HTTP backend for the authentication plugin
-auth_opt_password_file /etc/mosquitto/pw
-auth_opt_acl_file /etc/mosquitto/acl
+auth_opt_files_password_path /etc/mosquitto/pw
+auth_opt_files_acl_path /etc/mosquitto/acl
 
 # HTTP backend for the authentication plugin
-auth_opt_http_ip 127.0.0.1
+auth_opt_http_host 127.0.0.1
 auth_opt_http_port 80
 auth_opt_http_getuser_uri /authentication
 auth_opt_http_superuser_uri /superuser


### PR DESCRIPTION
Update mosquitto from `1.6.12` to `2.0.11`. In support of this I also made the following changes:
- Change from [mosquitto-auth-plug](https://github.com/pvizeli/mosquitto-auth-plug) to [mosquitto-go-auth](https://github.com/iegomez/mosquitto-go-auth) as that latter appears to be actively maintained, working with Mosquitto v2.0.0+ and recommended by Eclipse (see [here](https://mosquitto.org/documentation/authentication-methods) under Authentication Plugins)
- Base image changed from alpine3.13 to debian:bullseye as mosquitto-go-auth uses a c-shared build and those do not work on musl

I pulled this branch locally onto my arm64 dev system and confirmed it works. Was able to authenticate with the broker using both local and HA users successfully.