### PR TITLE
[Samba] Add default interface to supported interface list

### DIFF
--- a/samba/CHANGELOG.md
+++ b/samba/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 9.6.1
+
+- Run on all supported interfaces plus the default interface if it is not part of the supported interfaces list
+
 ## 9.6.0
 
 - Run on all supported interfaces

--- a/samba/config.yaml
+++ b/samba/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 9.6.0
+version: 9.6.1
 slug: samba
 name: Samba share
 description: Expose Home Assistant folders with SMB/CIFS

--- a/samba/rootfs/etc/cont-init.d/samba.sh
+++ b/samba/rootfs/etc/cont-init.d/samba.sh
@@ -24,6 +24,11 @@ bashio::log.info "Hostname: ${HOSTNAME}"
 for interface in $(bashio::network.interfaces); do
     interfaces+=("${interface}")
 done
+# Add default interface if it is not part of the supported interfaces list
+default_interface=$(bashio::network.name)
+if ! printf '%s\n' "${interfaces[@]}" | grep -Fxq -- "${default_interface}"; then
+    interfaces+=("${default_interface}")
+fi
 interfaces+=("lo")
 bashio::log.info "Interfaces: $(printf '%s ' "${interfaces[@]}")"
 


### PR DESCRIPTION
fixes #2447

Run on all supported interfaces _**plus**_ the default interface if it is not part of the supported interfaces list.