### PR TITLE
deCONZ 2.15.3 (stable)

### DIFF
--- a/deconz/CHANGELOG.md
+++ b/deconz/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.13.0
+
+- Bump deCONZ to 2.15.3
+
 ## 6.12.1
 
 - Fix Phoscon App gateway discovery with FQDN over Ingress

--- a/deconz/build.yaml
+++ b/deconz/build.yaml
@@ -7,4 +7,4 @@ codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
 args:
-  DECONZ_VERSION: 2.14.01
+  DECONZ_VERSION: 2.15.03

--- a/deconz/config.yaml
+++ b/deconz/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 6.12.1
+version: 6.13.0
 slug: deconz
 name: deCONZ
 description: >-


### PR DESCRIPTION
Bump deCONZ version to [2.15.03](https://github.com/dresden-elektronik/deconz-rest-plugin/releases/tag/v2.15.3)