### PR TITLE
Bump zwave-js to 9.0.7

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.1.58
+
+- Bump Z-Wave JS to 9.0.7
+- Bump Z-Wave JS to 1.16.1
+
 ## 0.1.57
 
 - Bump Z-Wave JS to 9.0.4

--- a/zwave_js/build.yaml
+++ b/zwave_js/build.yaml
@@ -9,5 +9,5 @@ codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
 args:
-  ZWAVEJS_SERVER_VERSION: 1.16.0
-  ZWAVEJS_VERSION: 9.0.4
+  ZWAVEJS_SERVER_VERSION: 1.16.1
+  ZWAVEJS_VERSION: 9.0.7

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.1.57
+version: 0.1.58
 slug: zwave_js
 name: Z-Wave JS
 description: Control a ZWave network with Home Assistant Z-Wave JS


### PR DESCRIPTION
We also bumped zwave-js-server to 1.16.1 which just fixes the import changes caused between zwave-js releases (https://github.com/zwave-js/zwave-js-server/releases/tag/1.16.1)

zwave-js Changelog:
- https://github.com/zwave-js/node-zwave-js/releases/tag/v9.0.7
- https://github.com/zwave-js/node-zwave-js/releases/tag/v9.0.6
- https://github.com/zwave-js/node-zwave-js/releases/tag/v9.0.5