### PR TITLE
Add debug option to mosquitto

### DIFF
--- a/mosquitto/CHANGELOG.md
+++ b/mosquitto/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.1.2
+
+- Add debug option to help with issues
+
 ## 6.1.1
 
 - Don't purge openssl in cleanup

--- a/mosquitto/DOCS.md
+++ b/mosquitto/DOCS.md
@@ -80,6 +80,10 @@ A file containing the private key. Place this file in the Home Assistant `ssl` f
 
 If set to `true` encryption will be enabled using the cert- and keyfile options.
 
+### Option: `debug`
+
+If set to `true` turns on debug logging for mosquitto and its auth plugin. This an help when tracking down an issue however running with this long term is not recommended as sensitive information will be logged.
+
 ## Home Assistant user management
 
 This add-on is attached to the Home Assistant user system, so MQTT clients can make use of these credentials. Local users may also still be set independently within the configuration options for the add-on. For the internal Home Assistant ecosystem, we register `homeassistant` and `addons`, so these may not be used as user names.

--- a/mosquitto/config.yaml
+++ b/mosquitto/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 6.1.1
+version: 6.1.2
 slug: mosquitto
 name: Mosquitto broker
 description: An Open Source MQTT broker
@@ -42,6 +42,7 @@ schema:
   customize:
     active: bool
     folder: str
+  debug: bool?
 services:
   - mqtt:provide
 startup: system

--- a/mosquitto/rootfs/etc/cont-init.d/mosquitto.sh
+++ b/mosquitto/rootfs/etc/cont-init.d/mosquitto.sh
@@ -79,6 +79,7 @@ bashio::var.json \
   keyfile "${keyfile}" \
   require_certificate "^$(bashio::config 'require_certificate')" \
   ssl "^${ssl}" \
+  debug "^$(bashio::config 'debug')" \
   | tempio \
     -template /usr/share/tempio/mosquitto.gtpl \
     -out /etc/mosquitto/mosquitto.conf

--- a/mosquitto/rootfs/usr/share/tempio/mosquitto.gtpl
+++ b/mosquitto/rootfs/usr/share/tempio/mosquitto.gtpl
@@ -1,10 +1,14 @@
 protocol mqtt
 user root
 log_dest stdout
+{{ if .debug }}
+log type all
+{{ else }}
 log_type error
 log_type warning
 log_type notice
 log_type information
+{{ end }}
 persistence true
 persistence_location /data/
 
@@ -17,7 +21,7 @@ auth_opt_auth_cache_seconds 300
 auth_opt_auth_jitter_seconds 30
 auth_opt_acl_cache_seconds 300
 auth_opt_acl_jitter_seconds 30
-auth_opt_log_level error
+auth_opt_log_level {{ if .debug }}debug{{ else }}error{{ end }}
 
 # HTTP backend for the authentication plugin
 auth_opt_files_password_path /etc/mosquitto/pw

--- a/mosquitto/rootfs/usr/share/tempio/mosquitto.gtpl
+++ b/mosquitto/rootfs/usr/share/tempio/mosquitto.gtpl
@@ -2,7 +2,7 @@ protocol mqtt
 user root
 log_dest stdout
 {{ if .debug }}
-log type all
+log_type all
 {{ else }}
 log_type error
 log_type warning

--- a/mosquitto/translations/en.yaml
+++ b/mosquitto/translations/en.yaml
@@ -29,6 +29,10 @@ configuration:
     name: Customize
     description: >-
       See the Documentation tab for more information about these options.
+  debug:
+    name: Debug
+    description: >-
+      If enabled will turn on debug logging for mosquitto and the auth plugin.
 network:
   1883/tcp: Normal MQTT
   1884/tcp: MQTT over WebSocket


### PR DESCRIPTION
When true, turns on debug logging for mosquitto and the auth plugin. May help us get to the bottom of issues like #2474