### PR TITLE
Bump config check base to `2022.05.0`

### DIFF
--- a/check_config/CHANGELOG.md
+++ b/check_config/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.10.1
+
+- Update base image to 2022.05.0
+
 ## 3.10.0
 
 - Update base image to 2022.02.0

--- a/check_config/build.yaml
+++ b/check_config/build.yaml
@@ -1,10 +1,10 @@
 ---
 build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-homeassistant-base:2022.02.0
-  amd64: ghcr.io/home-assistant/amd64-homeassistant-base:2022.02.0
-  armhf: ghcr.io/home-assistant/armhf-homeassistant-base:2022.02.0
-  armv7: ghcr.io/home-assistant/armv7-homeassistant-base:2022.02.0
-  i386: ghcr.io/home-assistant/i386-homeassistant-base:2022.02.0
+  aarch64: ghcr.io/home-assistant/aarch64-homeassistant-base:2022.05.0
+  amd64: ghcr.io/home-assistant/amd64-homeassistant-base:2022.05.0
+  armhf: ghcr.io/home-assistant/armhf-homeassistant-base:2022.05.0
+  armv7: ghcr.io/home-assistant/armv7-homeassistant-base:2022.05.0
+  i386: ghcr.io/home-assistant/i386-homeassistant-base:2022.05.0
 codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io

--- a/check_config/config.yaml
+++ b/check_config/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 3.10.0
+version: 3.10.1
 slug: check_config
 name: Check Home Assistant configuration
 description: Check your Home Assistant configuration against other versions


### PR DESCRIPTION
Bump config check base from `2022.02.0` to `2022.05.0` to match core

Fixes #2512