### PR TITLE
Fix TLSv1.3

### DIFF
--- a/nginx_proxy/CHANGELOG.md
+++ b/nginx_proxy/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.1.2
+
+- Fix TLSv1.3 support
+
 ## 3.1.1
 
 - Hide server version banner

--- a/nginx_proxy/config.yaml
+++ b/nginx_proxy/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 3.1.1
+version: 3.1.2
 hassio_api: true
 slug: nginx_proxy
 name: NGINX Home Assistant SSL proxy

--- a/nginx_proxy/data/nginx.conf
+++ b/nginx_proxy/data/nginx.conf
@@ -16,6 +16,11 @@ http {
 
     server_names_hash_bucket_size 64;
 	
+    # intermediate configuration
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+    ssl_prefer_server_ciphers off;
+
     #include /data/cloudflare.conf;
 	
     server {
@@ -49,11 +54,6 @@ http {
 
         listen 443 ssl http2;
         %%HSTS%%
-        
-        # intermediate configuration
-        ssl_protocols TLSv1.2 TLSv1.3;
-        ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
-        ssl_prefer_server_ciphers off;
 
         proxy_buffering off;
 


### PR DESCRIPTION
Closes #2527.

According to https://serverfault.com/questions/1097716/tls-1-3-not-working-on-nginx-1-21-with-openssl-1-1-1n and to my own testing (using `curl --tlsv1.3 <URL>`), tlsv1.3 was not working until I moved those lines up (from the server block to the http block)