### PR TITLE
Bump zwave-js-server to 1.19.0

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.62
+
+- Bump Z-Wave JS Server to 1.19.0
+
 ## 0.1.61
 
 - Bump Z-Wave JS to 9.4.0

--- a/zwave_js/build.yaml
+++ b/zwave_js/build.yaml
@@ -9,5 +9,5 @@ codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
 args:
-  ZWAVEJS_SERVER_VERSION: 1.18.0
+  ZWAVEJS_SERVER_VERSION: 1.19.0
   ZWAVEJS_VERSION: 9.4.0

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.1.61
+version: 0.1.62
 slug: zwave_js
 name: Z-Wave JS
 description: Control a ZWave network with Home Assistant Z-Wave JS


### PR DESCRIPTION
There's a bug with the logic for the `node found` event which would trigger anytime a user tries to add a node.

The fix appears to have worked without issue