### PR TITLE
Deprecate config check addon

### DIFF
--- a/check_config/CHANGELOG.md
+++ b/check_config/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 3.11.0
+
+This add-on is deprecated because it is no longer needed. Home Assistant now always starts after an update even if your config is invalid. You should do the following after an update to check for issues:
+
+1. Check persistent notifications. If an integration could not be loaded because its config is invalid a notification will tell you.
+2. Check logs. If an integration could be loaded but the config you are using is deprecated a message will tell you what needs to change and by when.
+3. Follow the red banner. In rare cases HA will start in safe mode. In those cases you should follow the instructions in the red banner at the top of the UI.
+
 ## 3.10.2
 
 - Fix check-config finish script

--- a/check_config/README.md
+++ b/check_config/README.md
@@ -1,5 +1,10 @@
 # Home Assistant Add-on: Check Home Assistant configuration
 
+**WARNING: This add-on is deprecated because it is no longer needed. Home Assistant now always starts after an update even if your config is invalid. You should do the following after an update to check for issues:**
+1. Check persistent notifications. If an integration could not be loaded because its config is invalid a notification will tell you.
+2. Check logs. If an integration could be loaded but the config you are using is deprecated a message will tell you what needs to change and by when.
+3. Follow the red banner. In rare cases HA will start in safe mode. In those cases you should follow the instructions in the red banner at the top of the UI.
+
 Check your Home Assistant configuration against other versions.
 
 ![Supports aarch64 Architecture][aarch64-shield] ![Supports amd64 Architecture][amd64-shield] ![Supports armhf Architecture][armhf-shield] ![Supports armv7 Architecture][armv7-shield] ![Supports i386 Architecture][i386-shield]

--- a/check_config/README.md
+++ b/check_config/README.md
@@ -1,6 +1,7 @@
 # Home Assistant Add-on: Check Home Assistant configuration
 
 **WARNING: This add-on is deprecated because it is no longer needed. Home Assistant now always starts after an update even if your config is invalid. You should do the following after an update to check for issues:**
+
 1. Check persistent notifications. If an integration could not be loaded because its config is invalid a notification will tell you.
 2. Check logs. If an integration could be loaded but the config you are using is deprecated a message will tell you what needs to change and by when.
 3. Follow the red banner. In rare cases HA will start in safe mode. In those cases you should follow the instructions in the red banner at the top of the UI.

--- a/check_config/config.yaml
+++ b/check_config/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 3.10.2
+version: 3.11.0
 slug: check_config
 name: Check Home Assistant configuration
 description: Check your Home Assistant configuration against other versions

--- a/check_config/config.yaml
+++ b/check_config/config.yaml
@@ -23,5 +23,6 @@ options:
 schema:
   version: str
 startup: once
+stage: deprecated
 uart: true
 usb: true


### PR DESCRIPTION
This addon does not work. It shows false positive errors every time which makes it not useful for its defined purpose (telling you whether your config will work after the update).

Upon review it is clear recent updates to core have made this addon irrelevant. Core will always start after an update now and if something is wrong with your config it will tell you what broke. It does this for YAML and config entries (which this addon never supported) automatically and with a better UI (persistent notification instead of checking addon logs).

Therefore this addon should be deprecated.