### PR TITLE
Samba: Don't mangle names by default

### DIFF
--- a/samba/CHANGELOG.md
+++ b/samba/CHANGELOG.md
@@ -2,14 +2,15 @@
 
 ## 10.0.0
 
-BREAKING CHANGE: Don't mangle names by default
+BREAKING CHANGE: Don't mangle filenames
 
 By default Samba mangles filenames with special characters to ensure
-compatibility with all possible clients (including really old versions
-of Windows). The default is changed to not do this anymore. If you
-need this behavior add `mangled_names: true` to the config.
+compatibility with really old versions of Windows which have a very limited
+charset for filenames. The addon no longer does this as modern operating
+systems do not have these restrictions.
 
-- Don't mangle names by default (fixes #2541)
+- Don't mangle filenames (fixes #2541)
+- Upgrade Alpine Linux to 3.16
 
 ## 9.7.0
 

--- a/samba/CHANGELOG.md
+++ b/samba/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 BREAKING CHANGE: Don't mangle filenames
 
-By default Samba mangles filenames with special characters to ensure
+By default, Samba mangles filenames with special characters to ensure
 compatibility with really old versions of Windows which have a very limited
-charset for filenames. The addon no longer does this as modern operating
+charset for filenames. The add-on no longer does this as modern operating
 systems do not have these restrictions.
 
 - Don't mangle filenames (fixes #2541)

--- a/samba/CHANGELOG.md
+++ b/samba/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 10.0.0
+
+BREAKING CHANGE: Don't mangle names by default
+
+By default Samba mangles filenames with special characters to ensure
+compatibility with all possible clients (including really old versions
+of Windows). The default is changed to not do this anymore. If you
+need this behavior add `mangled_names: true` to the config.
+
+- Don't mangle names by default (fixes #2541)
+
 ## 9.7.0
 
 - Upgrade Alpine Linux to 3.15

--- a/samba/build.yaml
+++ b/samba/build.yaml
@@ -1,10 +1,10 @@
 ---
 build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-base:3.15
-  amd64: ghcr.io/home-assistant/amd64-base:3.15
-  armhf: ghcr.io/home-assistant/armhf-base:3.15
-  armv7: ghcr.io/home-assistant/armv7-base:3.15
-  i386: ghcr.io/home-assistant/i386-base:3.15
+  aarch64: ghcr.io/home-assistant/aarch64-base:3.16
+  amd64: ghcr.io/home-assistant/amd64-base:3.16
+  armhf: ghcr.io/home-assistant/armhf-base:3.16
+  armv7: ghcr.io/home-assistant/armv7-base:3.16
+  i386: ghcr.io/home-assistant/i386-base:3.16
 codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io

--- a/samba/config.yaml
+++ b/samba/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 9.7.0
+version: 10.0.0 
 slug: samba
 name: Samba share
 description: Expose Home Assistant folders with SMB/CIFS
@@ -43,6 +43,7 @@ schema:
   password: password
   workgroup: str
   compatibility_mode: bool
+  mangled_names: bool?
   veto_files:
     - str
   allow_hosts:

--- a/samba/config.yaml
+++ b/samba/config.yaml
@@ -43,7 +43,6 @@ schema:
   password: password
   workgroup: str
   compatibility_mode: bool
-  mangled_names: bool?
   veto_files:
     - str
   allow_hosts:

--- a/samba/config.yaml
+++ b/samba/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 10.0.0 
+version: 10.0.0
 slug: samba
 name: Samba share
 description: Expose Home Assistant folders with SMB/CIFS

--- a/samba/rootfs/usr/share/tempio/smb.gtpl
+++ b/samba/rootfs/usr/share/tempio/smb.gtpl
@@ -20,6 +20,12 @@
    server min protocol = NT1
    {{ end }}
 
+   {{ if not .mangled_names }}
+   mangled names = no
+   dos charset = CP850
+   unix charset = UTF-8
+   {{ end }}
+
 [config]
    browseable = yes
    writeable = yes

--- a/samba/rootfs/usr/share/tempio/smb.gtpl
+++ b/samba/rootfs/usr/share/tempio/smb.gtpl
@@ -20,11 +20,9 @@
    server min protocol = NT1
    {{ end }}
 
-   {{ if not .mangled_names }}
    mangled names = no
    dos charset = CP850
    unix charset = UTF-8
-   {{ end }}
 
 [config]
    browseable = yes


### PR DESCRIPTION
Samba defaults to mangling names with special characters in order to be compatible with [really old versions of windows](https://www.oreilly.com/openbook/samba/book/ch05_04.html). Applied the fix suggested [here](https://serverfault.com/a/765951) by default with a new compatibility option if people need to revert this behavior.

This is a breaking change since it changes the default with a new revert option rather then the other way around. Although I imagine its one users will be happy with. 

Fixes #2541 

Also bump base image to Alpine 3.16