### PR TITLE
Ensure all addons have init: false

### DIFF
--- a/cec_scan/config.yaml
+++ b/cec_scan/config.yaml
@@ -16,3 +16,4 @@ options: {}
 schema: {}
 startup: once
 video: true
+init: false

--- a/dhcp_server/config.yaml
+++ b/dhcp_server/config.yaml
@@ -52,3 +52,4 @@ schema:
       range_start: str
       subnet: str
 startup: system
+init: false

--- a/dhcp_server/data/run.sh
+++ b/dhcp_server/data/run.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bashio
+#!/usr/bin/with-contenv bashio
 set -e
 
 CONFIG="/etc/dhcpd.conf"

--- a/homematic/config.yaml
+++ b/homematic/config.yaml
@@ -46,3 +46,4 @@ schema:
 stage: deprecated
 startup: system
 timeout: 15
+init: false

--- a/mosquitto/config.yaml
+++ b/mosquitto/config.yaml
@@ -47,3 +47,4 @@ services:
   - mqtt:provide
 startup: system
 watchdog: tcp://[HOST]:1883
+init: false

--- a/rpc_shutdown/config.yaml
+++ b/rpc_shutdown/config.yaml
@@ -30,3 +30,4 @@ schema:
       message: str?
 startup: services
 stdin: true
+init: false

--- a/rpc_shutdown/data/run.sh
+++ b/rpc_shutdown/data/run.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bashio
+#!/usr/bin/with-contenv bashio
 set -e
 
 # Read from STDIN aliases to send shutdown

--- a/tellstick/config.yaml
+++ b/tellstick/config.yaml
@@ -41,3 +41,4 @@ schema:
 startup: system
 stdin: true
 usb: true
+init: false

--- a/tellstick/data/run.sh
+++ b/tellstick/data/run.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bashio
+#!/usr/bin/with-contenv bashio
 set -e
 
 CONFIG="/etc/tellstick.conf"


### PR DESCRIPTION
Not bumping the version and changelog, just want to make sure this doesn't break on next update of these addons.

Also setting `with-contenv` now that s6 is running the scripts for some of these.