### PR TITLE
Update finish scripts for s6 v3

### DIFF
--- a/ada/rootfs/etc/services.d/ada/finish
+++ b/ada/rootfs/etc/services.d/ada/finish
@@ -6,7 +6,7 @@
 
 if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
   bashio::log.warning "Halt add-on"
-  /run/s6/basedir/bin/halt
+  exec /run/s6/basedir/bin/halt
 fi
 
 bashio::log.info "Service restart after closing"

--- a/ada/rootfs/etc/services.d/ada/finish
+++ b/ada/rootfs/etc/services.d/ada/finish
@@ -1,8 +1,12 @@
-#!/usr/bin/execlineb -S0
+#!/usr/bin/env bashio
 # ==============================================================================
-# Take down the S6 supervision tree when Ada fails
+# Take down the S6 supervision tree when service fails
+# s6-overlay docs: https://github.com/just-containers/s6-overlay
 # ==============================================================================
-if { s6-test ${1} -ne 0 }
-if { s6-test ${1} -ne 256 }
 
-s6-svscanctl -t /var/run/s6/services
+if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
+  bashio::log.warning "Halt add-on"
+  /run/s6/basedir/bin/halt
+fi
+
+bashio::log.info "Service restart after closing"

--- a/almond/rootfs/etc/services.d/almond/finish
+++ b/almond/rootfs/etc/services.d/almond/finish
@@ -6,7 +6,7 @@
 
 if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
   bashio::log.warning "Halt add-on"
-  /run/s6/basedir/bin/halt
+  exec /run/s6/basedir/bin/halt
 fi
 
 bashio::log.info "Service restart after closing"

--- a/almond/rootfs/etc/services.d/almond/finish
+++ b/almond/rootfs/etc/services.d/almond/finish
@@ -1,8 +1,12 @@
-#!/usr/bin/execlineb -S1
+#!/usr/bin/env bashio
 # ==============================================================================
-# Take down the S6 supervision tree based on service exit code
+# Take down the S6 supervision tree when service fails
+# s6-overlay docs: https://github.com/just-containers/s6-overlay
 # ==============================================================================
-if { s6-test ${1} -ne 0 }
-if { s6-test ${1} -ne 256 }
 
-s6-svscanctl -t /var/run/s6/services
+if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
+  bashio::log.warning "Halt add-on"
+  /run/s6/basedir/bin/halt
+fi
+
+bashio::log.info "Service restart after closing"

--- a/almond/rootfs/etc/services.d/nginx/finish
+++ b/almond/rootfs/etc/services.d/nginx/finish
@@ -6,7 +6,7 @@
 
 if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
   bashio::log.warning "Halt add-on"
-  /run/s6/basedir/bin/halt
+  exec /run/s6/basedir/bin/halt
 fi
 
 bashio::log.info "Service restart after closing"

--- a/almond/rootfs/etc/services.d/nginx/finish
+++ b/almond/rootfs/etc/services.d/nginx/finish
@@ -1,8 +1,12 @@
-#!/usr/bin/execlineb -S1	
-# ==============================================================================	
-# Take down the S6 supervision tree based on service exit code	
-# ==============================================================================	
-if { s6-test ${1} -ne 0 }	
-if { s6-test ${1} -ne 256 }	
+#!/usr/bin/env bashio
+# ==============================================================================
+# Take down the S6 supervision tree when service fails
+# s6-overlay docs: https://github.com/just-containers/s6-overlay
+# ==============================================================================
 
-s6-svscanctl -t /var/run/s6/services
+if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
+  bashio::log.warning "Halt add-on"
+  /run/s6/basedir/bin/halt
+fi
+
+bashio::log.info "Service restart after closing"

--- a/cec_scan/rootfs/etc/services.d/cec-scan/finish
+++ b/cec_scan/rootfs/etc/services.d/cec-scan/finish
@@ -1,5 +1,5 @@
-#!/usr/bin/execlineb -S0
+#!/usr/bin/env bashio
 # ==============================================================================
-# Take down the S6 supervision tree when config check is done
+# Take down the S6 supervision tree when service is done
 # ==============================================================================
-s6-svscanctl -t /var/run/s6/services
+/run/s6/basedir/bin/halt

--- a/configurator/rootfs/etc/services.d/configurator/finish
+++ b/configurator/rootfs/etc/services.d/configurator/finish
@@ -6,7 +6,7 @@
 
 if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
   bashio::log.warning "Halt add-on"
-  /run/s6/basedir/bin/halt
+  exec /run/s6/basedir/bin/halt
 fi
 
 bashio::log.info "Service restart after closing"

--- a/configurator/rootfs/etc/services.d/configurator/finish
+++ b/configurator/rootfs/etc/services.d/configurator/finish
@@ -1,8 +1,12 @@
-#!/usr/bin/execlineb -S1
+#!/usr/bin/env bashio
 # ==============================================================================
-# Take down the S6 supervision tree based on service exit code
+# Take down the S6 supervision tree when service fails
+# s6-overlay docs: https://github.com/just-containers/s6-overlay
 # ==============================================================================
-if { s6-test ${1} -ne 0 }
-if { s6-test ${1} -ne 256 }
 
-s6-svscanctl -t /var/run/s6/services
+if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
+  bashio::log.warning "Halt add-on"
+  /run/s6/basedir/bin/halt
+fi
+
+bashio::log.info "Service restart after closing"

--- a/deconz/CHANGELOG.md
+++ b/deconz/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.14.2
+
+- Fix finish script for S6 V3
+
 ## 6.14.1
 
 - Version bump to fix S6 service permissions

--- a/deconz/config.yaml
+++ b/deconz/config.yaml
@@ -12,6 +12,7 @@ arch:
   - aarch64
 backup_exclude:
   - "*/otau"
+codenotary: notary@home-assistant.io
 devices:
   - /dev/mem
 discovery:

--- a/deconz/config.yaml
+++ b/deconz/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 6.14.1
+version: 6.14.2
 slug: deconz
 name: deCONZ
 description: >-

--- a/deconz/rootfs/etc/services.d/deconz/finish
+++ b/deconz/rootfs/etc/services.d/deconz/finish
@@ -6,7 +6,7 @@
 
 if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
   bashio::log.warning "Halt add-on"
-  /run/s6/basedir/bin/halt
+  exec /run/s6/basedir/bin/halt
 fi
 
 bashio::log.info "Service restart after closing"

--- a/deconz/rootfs/etc/services.d/deconz/finish
+++ b/deconz/rootfs/etc/services.d/deconz/finish
@@ -1,8 +1,12 @@
-#!/usr/bin/execlineb -S1
+#!/usr/bin/env bashio
 # ==============================================================================
-# Take down the S6 supervision tree based on service exit code
+# Take down the S6 supervision tree when service fails
+# s6-overlay docs: https://github.com/just-containers/s6-overlay
 # ==============================================================================
-if { s6-test ${1} -ne 0 }
-if { s6-test ${1} -ne 256 }
 
-s6-svscanctl -t /var/run/s6/services
+if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
+  bashio::log.warning "Halt add-on"
+  /run/s6/basedir/bin/halt
+fi
+
+bashio::log.info "Service restart after closing"

--- a/deconz/rootfs/etc/services.d/nginx/finish
+++ b/deconz/rootfs/etc/services.d/nginx/finish
@@ -6,7 +6,7 @@
 
 if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
   bashio::log.warning "Halt add-on"
-  /run/s6/basedir/bin/halt
+  exec /run/s6/basedir/bin/halt
 fi
 
 bashio::log.info "Service restart after closing"

--- a/deconz/rootfs/etc/services.d/nginx/finish
+++ b/deconz/rootfs/etc/services.d/nginx/finish
@@ -1,8 +1,12 @@
-#!/usr/bin/execlineb -S1	
-# ==============================================================================	
-# Take down the S6 supervision tree based on service exit code	
-# ==============================================================================	
-if { s6-test ${1} -ne 0 }	
-if { s6-test ${1} -ne 256 }	
+#!/usr/bin/env bashio
+# ==============================================================================
+# Take down the S6 supervision tree when service fails
+# s6-overlay docs: https://github.com/just-containers/s6-overlay
+# ==============================================================================
 
-s6-svscanctl -t /var/run/s6/services
+if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
+  bashio::log.warning "Halt add-on"
+  /run/s6/basedir/bin/halt
+fi
+
+bashio::log.info "Service restart after closing"

--- a/dnsmasq/rootfs/etc/services.d/dnsmasq/finish
+++ b/dnsmasq/rootfs/etc/services.d/dnsmasq/finish
@@ -6,7 +6,7 @@
 
 if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
   bashio::log.warning "Halt add-on"
-  /run/s6/basedir/bin/halt
+  exec /run/s6/basedir/bin/halt
 fi
 
 bashio::log.info "Service restart after closing"

--- a/dnsmasq/rootfs/etc/services.d/dnsmasq/finish
+++ b/dnsmasq/rootfs/etc/services.d/dnsmasq/finish
@@ -1,8 +1,12 @@
-#!/usr/bin/execlineb -S0
+#!/usr/bin/env bashio
 # ==============================================================================
-# Take down the S6 supervision tree when dnsmasq fails
+# Take down the S6 supervision tree when service fails
+# s6-overlay docs: https://github.com/just-containers/s6-overlay
 # ==============================================================================
-if { s6-test ${1} -ne 0 }
-if { s6-test ${1} -ne 256 }
 
-s6-svscanctl -t /var/run/s6/services
+if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
+  bashio::log.warning "Halt add-on"
+  /run/s6/basedir/bin/halt
+fi
+
+bashio::log.info "Service restart after closing"

--- a/google_assistant/rootfs/etc/services.d/google-assistant/finish
+++ b/google_assistant/rootfs/etc/services.d/google-assistant/finish
@@ -6,7 +6,7 @@
 
 if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
   bashio::log.warning "Halt add-on"
-  /run/s6/basedir/bin/halt
+  exec /run/s6/basedir/bin/halt
 fi
 
 bashio::log.info "Service restart after closing"

--- a/google_assistant/rootfs/etc/services.d/google-assistant/finish
+++ b/google_assistant/rootfs/etc/services.d/google-assistant/finish
@@ -1,8 +1,12 @@
-#!/usr/bin/execlineb -S0
+#!/usr/bin/env bashio
 # ==============================================================================
-# Take down the S6 supervision tree when Google Assistant fails
+# Take down the S6 supervision tree when service fails
+# s6-overlay docs: https://github.com/just-containers/s6-overlay
 # ==============================================================================
-if { s6-test ${1} -ne 0 }
-if { s6-test ${1} -ne 256 }
 
-s6-svscanctl -t /var/run/s6/services
+if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
+  bashio::log.warning "Halt add-on"
+  /run/s6/basedir/bin/halt
+fi
+
+bashio::log.info "Service restart after closing"

--- a/homematic/rootfs/etc/services.d/hmserver/finish
+++ b/homematic/rootfs/etc/services.d/hmserver/finish
@@ -6,7 +6,7 @@
 
 if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
   bashio::log.warning "Halt add-on"
-  /run/s6/basedir/bin/halt
+  exec /run/s6/basedir/bin/halt
 fi
 
 bashio::log.info "Service restart after closing"

--- a/homematic/rootfs/etc/services.d/hmserver/finish
+++ b/homematic/rootfs/etc/services.d/hmserver/finish
@@ -1,8 +1,12 @@
-#!/usr/bin/execlineb -S1
+#!/usr/bin/env bashio
 # ==============================================================================
-# Take down the S6 supervision tree based on service exit code
+# Take down the S6 supervision tree when service fails
+# s6-overlay docs: https://github.com/just-containers/s6-overlay
 # ==============================================================================
-if { s6-test ${1} -ne 0 }
-if { s6-test ${1} -ne 256 }
 
-s6-svscanctl -t /var/run/s6/services
+if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
+  bashio::log.warning "Halt add-on"
+  /run/s6/basedir/bin/halt
+fi
+
+bashio::log.info "Service restart after closing"

--- a/homematic/rootfs/etc/services.d/nginx/finish
+++ b/homematic/rootfs/etc/services.d/nginx/finish
@@ -6,7 +6,7 @@
 
 if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
   bashio::log.warning "Halt add-on"
-  /run/s6/basedir/bin/halt
+  exec /run/s6/basedir/bin/halt
 fi
 
 bashio::log.info "Service restart after closing"

--- a/homematic/rootfs/etc/services.d/nginx/finish
+++ b/homematic/rootfs/etc/services.d/nginx/finish
@@ -1,8 +1,12 @@
-#!/usr/bin/execlineb -S1	
-# ==============================================================================	
-# Take down the S6 supervision tree based on service exit code	
-# ==============================================================================	
-if { s6-test ${1} -ne 0 }	
-if { s6-test ${1} -ne 256 }	
+#!/usr/bin/env bashio
+# ==============================================================================
+# Take down the S6 supervision tree when service fails
+# s6-overlay docs: https://github.com/just-containers/s6-overlay
+# ==============================================================================
 
-s6-svscanctl -t /var/run/s6/services
+if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
+  bashio::log.warning "Halt add-on"
+  /run/s6/basedir/bin/halt
+fi
+
+bashio::log.info "Service restart after closing"

--- a/homematic/rootfs/etc/services.d/regahss/finish
+++ b/homematic/rootfs/etc/services.d/regahss/finish
@@ -6,7 +6,7 @@
 
 if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
   bashio::log.warning "Halt add-on"
-  /run/s6/basedir/bin/halt
+  exec /run/s6/basedir/bin/halt
 fi
 
 bashio::log.info "Service restart after closing"

--- a/homematic/rootfs/etc/services.d/regahss/finish
+++ b/homematic/rootfs/etc/services.d/regahss/finish
@@ -1,8 +1,12 @@
-#!/usr/bin/execlineb -S1
+#!/usr/bin/env bashio
 # ==============================================================================
-# Take down the S6 supervision tree based on service exit code
+# Take down the S6 supervision tree when service fails
+# s6-overlay docs: https://github.com/just-containers/s6-overlay
 # ==============================================================================
-if { s6-test ${1} -ne 0 }
-if { s6-test ${1} -ne 256 }
 
-s6-svscanctl -t /var/run/s6/services
+if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
+  bashio::log.warning "Halt add-on"
+  /run/s6/basedir/bin/halt
+fi
+
+bashio::log.info "Service restart after closing"

--- a/homematic/rootfs/etc/services.d/rfd/finish
+++ b/homematic/rootfs/etc/services.d/rfd/finish
@@ -6,7 +6,7 @@
 
 if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
   bashio::log.warning "Halt add-on"
-  /run/s6/basedir/bin/halt
+  exec /run/s6/basedir/bin/halt
 fi
 
 bashio::log.info "Service restart after closing"

--- a/homematic/rootfs/etc/services.d/rfd/finish
+++ b/homematic/rootfs/etc/services.d/rfd/finish
@@ -1,8 +1,12 @@
-#!/usr/bin/execlineb -S1
+#!/usr/bin/env bashio
 # ==============================================================================
-# Take down the S6 supervision tree based on service exit code
+# Take down the S6 supervision tree when service fails
+# s6-overlay docs: https://github.com/just-containers/s6-overlay
 # ==============================================================================
-if { s6-test ${1} -ne 0 }
-if { s6-test ${1} -ne 256 }
 
-s6-svscanctl -t /var/run/s6/services
+if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
+  bashio::log.warning "Halt add-on"
+  /run/s6/basedir/bin/halt
+fi
+
+bashio::log.info "Service restart after closing"

--- a/homematic/rootfs/etc/services.d/wired/finish
+++ b/homematic/rootfs/etc/services.d/wired/finish
@@ -6,7 +6,7 @@
 
 if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
   bashio::log.warning "Halt add-on"
-  /run/s6/basedir/bin/halt
+  exec /run/s6/basedir/bin/halt
 fi
 
 bashio::log.info "Service restart after closing"

--- a/homematic/rootfs/etc/services.d/wired/finish
+++ b/homematic/rootfs/etc/services.d/wired/finish
@@ -1,8 +1,12 @@
-#!/usr/bin/execlineb -S1
+#!/usr/bin/env bashio
 # ==============================================================================
-# Take down the S6 supervision tree based on service exit code
+# Take down the S6 supervision tree when service fails
+# s6-overlay docs: https://github.com/just-containers/s6-overlay
 # ==============================================================================
-if { s6-test ${1} -ne 0 }
-if { s6-test ${1} -ne 256 }
 
-s6-svscanctl -t /var/run/s6/services
+if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
+  bashio::log.warning "Halt add-on"
+  /run/s6/basedir/bin/halt
+fi
+
+bashio::log.info "Service restart after closing"

--- a/mariadb/rootfs/etc/services.d/mariadb/finish
+++ b/mariadb/rootfs/etc/services.d/mariadb/finish
@@ -6,7 +6,7 @@
 
 if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
   bashio::log.warning "Halt add-on"
-  /run/s6/basedir/bin/halt
+  exec /run/s6/basedir/bin/halt
 fi
 
 bashio::log.info "Service restart after closing"

--- a/mariadb/rootfs/etc/services.d/mariadb/finish
+++ b/mariadb/rootfs/etc/services.d/mariadb/finish
@@ -1,8 +1,12 @@
-#!/usr/bin/execlineb -S0
+#!/usr/bin/env bashio
 # ==============================================================================
-# Take down the S6 supervision tree when mariadb fails
+# Take down the S6 supervision tree when service fails
+# s6-overlay docs: https://github.com/just-containers/s6-overlay
 # ==============================================================================
-if { s6-test ${1} -ne 0 }
-if { s6-test ${1} -ne 256 }
 
-s6-svscanctl -t /var/run/s6/services
+if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
+  bashio::log.warning "Halt add-on"
+  /run/s6/basedir/bin/halt
+fi
+
+bashio::log.info "Service restart after closing"

--- a/mosquitto/rootfs/etc/services.d/mosquitto/finish
+++ b/mosquitto/rootfs/etc/services.d/mosquitto/finish
@@ -6,7 +6,7 @@
 
 if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
   bashio::log.warning "Halt add-on"
-  /run/s6/basedir/bin/halt
+  exec /run/s6/basedir/bin/halt
 fi
 
 bashio::log.info "Service restart after closing"

--- a/mosquitto/rootfs/etc/services.d/mosquitto/finish
+++ b/mosquitto/rootfs/etc/services.d/mosquitto/finish
@@ -1,8 +1,12 @@
-#!/usr/bin/execlineb -S0
+#!/usr/bin/env bashio
 # ==============================================================================
-# Take down the S6 supervision tree when mosquitto crashes
+# Take down the S6 supervision tree when service fails
+# s6-overlay docs: https://github.com/just-containers/s6-overlay
 # ==============================================================================
-if -n { s6-test $# -ne 0 }
-if -n { s6-test ${1} -eq 256 }
 
-s6-svscanctl -t /var/run/s6/services
+if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
+  bashio::log.warning "Halt add-on"
+  /run/s6/basedir/bin/halt
+fi
+
+bashio::log.info "Service restart after closing"

--- a/mosquitto/rootfs/etc/services.d/nginx/finish
+++ b/mosquitto/rootfs/etc/services.d/nginx/finish
@@ -6,7 +6,7 @@
 
 if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
   bashio::log.warning "Halt add-on"
-  /run/s6/basedir/bin/halt
+  exec /run/s6/basedir/bin/halt
 fi
 
 bashio::log.info "Service restart after closing"

--- a/mosquitto/rootfs/etc/services.d/nginx/finish
+++ b/mosquitto/rootfs/etc/services.d/nginx/finish
@@ -1,8 +1,12 @@
-#!/usr/bin/execlineb -S0
+#!/usr/bin/env bashio
 # ==============================================================================
-# Take down the S6 supervision tree when nginx crashes
+# Take down the S6 supervision tree when service fails
+# s6-overlay docs: https://github.com/just-containers/s6-overlay
 # ==============================================================================
-if -n { s6-test $# -ne 0 }
-if -n { s6-test ${1} -eq 256 }
 
-s6-svscanctl -t /var/run/s6/services
+if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
+  bashio::log.warning "Halt add-on"
+  /run/s6/basedir/bin/halt
+fi
+
+bashio::log.info "Service restart after closing"

--- a/ssh/rootfs/etc/services.d/sshd/finish
+++ b/ssh/rootfs/etc/services.d/sshd/finish
@@ -6,7 +6,7 @@
 
 if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
   bashio::log.warning "Halt add-on"
-  /run/s6/basedir/bin/halt
+  exec /run/s6/basedir/bin/halt
 fi
 
 bashio::log.info "Service restart after closing"

--- a/ssh/rootfs/etc/services.d/sshd/finish
+++ b/ssh/rootfs/etc/services.d/sshd/finish
@@ -1,8 +1,12 @@
-#!/usr/bin/execlineb -S1
+#!/usr/bin/env bashio
 # ==============================================================================
-# Take down the S6 supervision tree when sshd fails
+# Take down the S6 supervision tree when service fails
+# s6-overlay docs: https://github.com/just-containers/s6-overlay
 # ==============================================================================
-if { s6-test ${1} -ne 0 }
-if { s6-test ${1} -ne 256 }
 
-s6-svscanctl -t /var/run/s6/services
+if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
+  bashio::log.warning "Halt add-on"
+  /run/s6/basedir/bin/halt
+fi
+
+bashio::log.info "Service restart after closing"

--- a/ssh/rootfs/etc/services.d/ttyd/finish
+++ b/ssh/rootfs/etc/services.d/ttyd/finish
@@ -6,7 +6,7 @@
 
 if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
   bashio::log.warning "Halt add-on"
-  /run/s6/basedir/bin/halt
+  exec /run/s6/basedir/bin/halt
 fi
 
 bashio::log.info "Service restart after closing"

--- a/ssh/rootfs/etc/services.d/ttyd/finish
+++ b/ssh/rootfs/etc/services.d/ttyd/finish
@@ -1,8 +1,12 @@
-#!/usr/bin/execlineb -S1
+#!/usr/bin/env bashio
 # ==============================================================================
-# Take down the S6 supervision tree when ttyd fails
+# Take down the S6 supervision tree when service fails
+# s6-overlay docs: https://github.com/just-containers/s6-overlay
 # ==============================================================================
-if { s6-test ${1} -ne 0 }
-if { s6-test ${1} -ne 256 }
 
-s6-svscanctl -t /var/run/s6/services
+if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
+  bashio::log.warning "Halt add-on"
+  /run/s6/basedir/bin/halt
+fi
+
+bashio::log.info "Service restart after closing"

--- a/vlc/rootfs/etc/services.d/nginx/finish
+++ b/vlc/rootfs/etc/services.d/nginx/finish
@@ -6,7 +6,7 @@
 
 if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
   bashio::log.warning "Halt add-on"
-  /run/s6/basedir/bin/halt
+  exec /run/s6/basedir/bin/halt
 fi
 
 bashio::log.info "Service restart after closing"

--- a/vlc/rootfs/etc/services.d/nginx/finish
+++ b/vlc/rootfs/etc/services.d/nginx/finish
@@ -1,8 +1,12 @@
-#!/usr/bin/execlineb -S1	
-# ==============================================================================	
-# Take down the S6 supervision tree based on service exit code	
-# ==============================================================================	
-if { s6-test ${1} -ne 0 }	
-if { s6-test ${1} -ne 256 }	
+#!/usr/bin/env bashio
+# ==============================================================================
+# Take down the S6 supervision tree when service fails
+# s6-overlay docs: https://github.com/just-containers/s6-overlay
+# ==============================================================================
 
-s6-svscanctl -t /var/run/s6/services
+if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
+  bashio::log.warning "Halt add-on"
+  /run/s6/basedir/bin/halt
+fi
+
+bashio::log.info "Service restart after closing"

--- a/vlc/rootfs/etc/services.d/vlc/finish
+++ b/vlc/rootfs/etc/services.d/vlc/finish
@@ -6,7 +6,7 @@
 
 if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
   bashio::log.warning "Halt add-on"
-  /run/s6/basedir/bin/halt
+  exec /run/s6/basedir/bin/halt
 fi
 
 bashio::log.info "Service restart after closing"

--- a/vlc/rootfs/etc/services.d/vlc/finish
+++ b/vlc/rootfs/etc/services.d/vlc/finish
@@ -1,8 +1,12 @@
-#!/usr/bin/execlineb -S1
+#!/usr/bin/env bashio
 # ==============================================================================
-# Take down the S6 supervision tree when VLC fails
+# Take down the S6 supervision tree when service fails
+# s6-overlay docs: https://github.com/just-containers/s6-overlay
 # ==============================================================================
-if { s6-test ${1} -ne 0 }
-if { s6-test ${1} -ne 256 }
 
-s6-svscanctl -t /var/run/s6/services
+if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
+  bashio::log.warning "Halt add-on"
+  /run/s6/basedir/bin/halt
+fi
+
+bashio::log.info "Service restart after closing"

--- a/zwave/rootfs/etc/services.d/mosquitto/finish
+++ b/zwave/rootfs/etc/services.d/mosquitto/finish
@@ -6,7 +6,7 @@
 
 if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
   bashio::log.warning "Halt add-on"
-  /run/s6/basedir/bin/halt
+  exec /run/s6/basedir/bin/halt
 fi
 
 bashio::log.info "Service restart after closing"

--- a/zwave/rootfs/etc/services.d/mosquitto/finish
+++ b/zwave/rootfs/etc/services.d/mosquitto/finish
@@ -1,8 +1,12 @@
-#!/usr/bin/execlineb -S1
+#!/usr/bin/env bashio
 # ==============================================================================
-# Take down the S6 supervision tree when mosquitto fails
+# Take down the S6 supervision tree when service fails
+# s6-overlay docs: https://github.com/just-containers/s6-overlay
 # ==============================================================================
-if { s6-test ${1} -ne 0 }
-if { s6-test ${1} -ne 256 }
 
-s6-svscanctl -t /var/run/s6/services
+if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
+  bashio::log.warning "Halt add-on"
+  /run/s6/basedir/bin/halt
+fi
+
+bashio::log.info "Service restart after closing"

--- a/zwave/rootfs/etc/services.d/ozwadmin/finish
+++ b/zwave/rootfs/etc/services.d/ozwadmin/finish
@@ -6,7 +6,7 @@
 
 if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
   bashio::log.warning "Halt add-on"
-  /run/s6/basedir/bin/halt
+  exec /run/s6/basedir/bin/halt
 fi
 
 bashio::log.info "Service restart after closing"

--- a/zwave/rootfs/etc/services.d/ozwadmin/finish
+++ b/zwave/rootfs/etc/services.d/ozwadmin/finish
@@ -1,8 +1,12 @@
-#!/usr/bin/execlineb -S1
+#!/usr/bin/env bashio
 # ==============================================================================
-# Take down the S6 supervision tree when ozw-admin fails
+# Take down the S6 supervision tree when service fails
+# s6-overlay docs: https://github.com/just-containers/s6-overlay
 # ==============================================================================
-if { s6-test ${1} -ne 0 }
-if { s6-test ${1} -ne 256 }
 
-s6-svscanctl -t /var/run/s6/services
+if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
+  bashio::log.warning "Halt add-on"
+  /run/s6/basedir/bin/halt
+fi
+
+bashio::log.info "Service restart after closing"

--- a/zwave/rootfs/etc/services.d/websockify/finish
+++ b/zwave/rootfs/etc/services.d/websockify/finish
@@ -6,7 +6,7 @@
 
 if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
   bashio::log.warning "Halt add-on"
-  /run/s6/basedir/bin/halt
+  exec /run/s6/basedir/bin/halt
 fi
 
 bashio::log.info "Service restart after closing"

--- a/zwave/rootfs/etc/services.d/websockify/finish
+++ b/zwave/rootfs/etc/services.d/websockify/finish
@@ -1,8 +1,12 @@
-#!/usr/bin/execlineb -S1
+#!/usr/bin/env bashio
 # ==============================================================================
-# Take down the S6 supervision tree when websockify fails
+# Take down the S6 supervision tree when service fails
+# s6-overlay docs: https://github.com/just-containers/s6-overlay
 # ==============================================================================
-if { s6-test ${1} -ne 0 }
-if { s6-test ${1} -ne 256 }
 
-s6-svscanctl -t /var/run/s6/services
+if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
+  bashio::log.warning "Halt add-on"
+  /run/s6/basedir/bin/halt
+fi
+
+bashio::log.info "Service restart after closing"

--- a/zwave/rootfs/etc/services.d/zwave/finish
+++ b/zwave/rootfs/etc/services.d/zwave/finish
@@ -6,7 +6,7 @@
 
 if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
   bashio::log.warning "Halt add-on"
-  /run/s6/basedir/bin/halt
+  exec /run/s6/basedir/bin/halt
 fi
 
 bashio::log.info "Service restart after closing"

--- a/zwave/rootfs/etc/services.d/zwave/finish
+++ b/zwave/rootfs/etc/services.d/zwave/finish
@@ -1,8 +1,12 @@
-#!/usr/bin/execlineb -S1
+#!/usr/bin/env bashio
 # ==============================================================================
-# Take down the S6 supervision tree when OpenZWave fails
+# Take down the S6 supervision tree when service fails
+# s6-overlay docs: https://github.com/just-containers/s6-overlay
 # ==============================================================================
-if { s6-test ${1} -ne 0 }
-if { s6-test ${1} -ne 256 }
 
-s6-svscanctl -t /var/run/s6/services
+if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
+  bashio::log.warning "Halt add-on"
+  /run/s6/basedir/bin/halt
+fi
+
+bashio::log.info "Service restart after closing"

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.64
+
+- Fix finish script for S6 V3
+
 ## 0.1.63
 
 - Bump Z-Wave JS Server to 1.20.0

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -10,6 +10,7 @@ arch:
   - armhf
   - armv7
   - aarch64
+codenotary: true
 discovery:
   - zwave_js
 hassio_api: true

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.1.63
+version: 0.1.64
 slug: zwave_js
 name: Z-Wave JS
 description: Control a ZWave network with Home Assistant Z-Wave JS

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -10,7 +10,7 @@ arch:
   - armhf
   - armv7
   - aarch64
-codenotary: true
+codenotary: notary@home-assistant.io
 discovery:
   - zwave_js
 hassio_api: true

--- a/zwave_js/rootfs/etc/services.d/zwave_js/finish
+++ b/zwave_js/rootfs/etc/services.d/zwave_js/finish
@@ -6,7 +6,7 @@
 
 if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
   bashio::log.warning "Halt add-on"
-  /run/s6/basedir/bin/halt
+  exec /run/s6/basedir/bin/halt
 fi
 
 bashio::log.info "Service restart after closing"

--- a/zwave_js/rootfs/etc/services.d/zwave_js/finish
+++ b/zwave_js/rootfs/etc/services.d/zwave_js/finish
@@ -1,8 +1,12 @@
-#!/usr/bin/execlineb -S1
+#!/usr/bin/env bashio
 # ==============================================================================
-# Take down the S6 supervision tree when Z-Wave JS fails
+# Take down the S6 supervision tree when service fails
+# s6-overlay docs: https://github.com/just-containers/s6-overlay
 # ==============================================================================
-if { s6-test ${1} -ne 0 }
-if { s6-test ${1} -ne 256 }
 
-s6-svscanctl -t /var/run/s6/services
+if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
+  bashio::log.warning "Halt add-on"
+  /run/s6/basedir/bin/halt
+fi
+
+bashio::log.info "Service restart after closing"


### PR DESCRIPTION
Update finish scripts for https://developers.home-assistant.io/blog/2022/05/12/s6-overlay-base-images

For most addons did not bump the version, just ensuring the next PR to go in doesn't have a surprise issue. Did bump the version for ZwaveJS and Deconz since they have all had recent updates so want to make new images without it.