### PR TITLE
deCONZ 2.17.1 (stable)

### DIFF
--- a/deconz/CHANGELOG.md
+++ b/deconz/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.15.0
+
+- Bump deCONZ to 2.17.1
+
 ## 6.14.2
 
 - Fix finish script for S6 V3

--- a/deconz/build.yaml
+++ b/deconz/build.yaml
@@ -7,4 +7,4 @@ codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
 args:
-  DECONZ_VERSION: 2.16.01
+  DECONZ_VERSION: 2.17.01

--- a/deconz/config.yaml
+++ b/deconz/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 6.14.2
+version: 6.15.0
 slug: deconz
 name: deCONZ
 description: >-


### PR DESCRIPTION
Bump deCONZ version to [2.17.01](https://github.com/dresden-elektronik/deconz-rest-plugin/releases/tag/v2.17.1)