### PR TITLE
Add breaking change information for rsa keys

### DIFF
--- a/ssh/CHANGELOG.md
+++ b/ssh/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 9.6.0
 
+**Breaking change**: RSA keys generated using the SHA-1 hash algorithm
+were disabled by OpenSSH due to a security vulnerability. If you find
+your RSA key does not work after update you will need to make a new key
+with a stronger algoritm or switch to an ECDSA or Ed25519 type key. For
+more information see [OpenSSH v8.8 release notes](https://www.openssh.com/releasenotes.html).
+
 - Upgrade Home Assistant CLI to 4.18.0
 - Upgrade to Alpine 3.16
 - Refactor out usage of fix-attrs for s6 v3


### PR DESCRIPTION
In v8.8 OpenSSH disabled RSA type keys made using SHA-1 due to a security vulnerability (see [release notes](https://www.openssh.com/releasenotes.html)). Since #2579 bumped alpine from 3.14 to 3.16 it also bumped openssh from 8.6 to 9.0. Therefore adding a breaking change warning about this to the changelog.

Fixes #2584