### PR TITLE
MariaDB: Remove `innodb_buffer_pool_instances`

### DIFF
--- a/mariadb/CHANGELOG.md
+++ b/mariadb/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.5.1
+
+- Remove deprecated `innodb-buffer-pool-instances`
+
 ## 2.5.0
 
 - Update alpine to 3.16 and s6 to v3

--- a/mariadb/config.yaml
+++ b/mariadb/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 2.5.0
+version: 2.5.1
 slug: mariadb
 name: MariaDB
 description: A SQL database server

--- a/mariadb/rootfs/etc/my.cnf.d/mariadb-server.cnf
+++ b/mariadb/rootfs/etc/my.cnf.d/mariadb-server.cnf
@@ -33,7 +33,6 @@ query_cache_size = 0M
 query_cache_type = 0
 
 # InnoDB Tweaks
-innodb_buffer_pool_instances = 1
 innodb_buffer_pool_size = 128M
 innodb_log_buffer_size = 8M
 innodb_log_file_size = 48M


### PR DESCRIPTION
From #2589 :
> 2022-07-10 23:15:42 0 [Warning] 'innodb-buffer-pool-instances' was removed. It does nothing now and exists only for compatibility with old my.cnf files.

Looks like this field was deprecated and made pointless in [10.5](https://mariadb.com/kb/en/changes-improvements-in-mariadb-105/) so we should remove it.