### PR TITLE
Bump zwave-js-server to 1.21.0 and zwave-js to 9.6.2

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.1.65
+
+- Bump Z-Wave JS Server to 1.21.0
+- Bump Z-Wave JS to 9.6.2
+
 ## 0.1.64
 
 - Fix finish script for S6 V3

--- a/zwave_js/build.yaml
+++ b/zwave_js/build.yaml
@@ -9,5 +9,5 @@ codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
 args:
-  ZWAVEJS_SERVER_VERSION: 1.20.0
-  ZWAVEJS_VERSION: 9.4.0
+  ZWAVEJS_SERVER_VERSION: 1.21.0
+  ZWAVEJS_VERSION: 9.6.2

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.1.64
+version: 0.1.65
 slug: zwave_js
 name: Z-Wave JS
 description: Control a ZWave network with Home Assistant Z-Wave JS


### PR DESCRIPTION
Server Changelog: https://github.com/zwave-js/zwave-js-server/releases/tag/1.21.0
Driver changelogs:
- https://github.com/zwave-js/node-zwave-js/releases/tag/v9.6.2
- https://github.com/zwave-js/node-zwave-js/releases/tag/v9.6.1
- https://github.com/zwave-js/node-zwave-js/releases/tag/v9.6.0
- https://github.com/zwave-js/node-zwave-js/releases/tag/v9.5.0
- https://github.com/zwave-js/node-zwave-js/releases/tag/v9.4.1

This has not been tested yet