### PR TITLE
Add option `use_identity_as_username` to Mosquitto

### DIFF
--- a/mosquitto/CHANGELOG.md
+++ b/mosquitto/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.2.0
+
+- Add `use_identity_as_username` option
+
 ## 6.1.3
 
 - Change timestamp format in logs

--- a/mosquitto/DOCS.md
+++ b/mosquitto/DOCS.md
@@ -82,7 +82,7 @@ If set to `true` encryption will be enabled using the cert- and keyfile options.
 
 ### Option: `use_identity_as_username`
 
-If set to `true` and `require_certificate` is `true` then the identity from the client certificate will be used as the username instead of requiring a username and password to authenticate.
+If set to `true` and `require_certificate` is `true` then the CN from the client certificate will be used as the username instead of requiring a username and password.
 
 ### Option: `debug`
 

--- a/mosquitto/DOCS.md
+++ b/mosquitto/DOCS.md
@@ -80,6 +80,10 @@ A file containing the private key. Place this file in the Home Assistant `ssl` f
 
 If set to `true` encryption will be enabled using the cert- and keyfile options.
 
+### Option: `use_identity_as_username`
+
+If set to `true` and `require_certificate` is `true` then the identity from the client certificate will be used as the username instead of requiring a username and password to authenticate.
+
 ### Option: `debug`
 
 If set to `true` turns on debug logging for mosquitto and its auth plugin. This an help when tracking down an issue however running with this long term is not recommended as sensitive information will be logged.

--- a/mosquitto/config.yaml
+++ b/mosquitto/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 6.1.3
+version: 6.2.0
 slug: mosquitto
 name: Mosquitto broker
 description: An Open Source MQTT broker
@@ -39,6 +39,7 @@ schema:
   certfile: str
   cafile: str?
   keyfile: str
+  use_identity_as_username: bool?
   customize:
     active: bool
     folder: str

--- a/mosquitto/config.yaml
+++ b/mosquitto/config.yaml
@@ -21,6 +21,7 @@ map:
 options:
   logins: []
   require_certificate: false
+  use_identity_as_username: false
   certfile: fullchain.pem
   keyfile: privkey.pem
   customize:

--- a/mosquitto/rootfs/etc/cont-init.d/mosquitto.sh
+++ b/mosquitto/rootfs/etc/cont-init.d/mosquitto.sh
@@ -78,6 +78,7 @@ bashio::var.json \
   customize_folder "$(bashio::config 'customize.folder')" \
   keyfile "${keyfile}" \
   require_certificate "^$(bashio::config 'require_certificate')" \
+  use_identity_as_username "^$(bashio::config 'use_identity_as_username')" \
   ssl "^${ssl}" \
   debug "^$(bashio::config 'debug')" \
   | tempio \

--- a/mosquitto/rootfs/usr/share/tempio/mosquitto.gtpl
+++ b/mosquitto/rootfs/usr/share/tempio/mosquitto.gtpl
@@ -58,6 +58,9 @@ cafile {{ .certfile }}
 certfile {{ .certfile }}
 keyfile {{ .keyfile }}
 require_certificate {{ .require_certificate }}
+{{ if .require_certificate }}
+use_identity_as_username {{ .use_identity_as_username }}
+{{ end }}
 
 listener 8884
 protocol websockets
@@ -69,5 +72,8 @@ cafile {{ .certfile }}
 certfile {{ .certfile }}
 keyfile {{ .keyfile }}
 require_certificate {{ .require_certificate }}
+{{ if .require_certificate }}
+use_identity_as_username {{ .use_identity_as_username }}
+{{ end }}
 
 {{ end }}

--- a/mosquitto/translations/en.yaml
+++ b/mosquitto/translations/en.yaml
@@ -33,6 +33,12 @@ configuration:
     name: Debug
     description: >-
       If enabled will turn on debug logging for mosquitto and the auth plugin.
+  use_identity_as_username:
+    name: Use identity as username
+    description: >-
+      If this and `require_certificate` are enabled then the CN from the client
+      certificate will be used as the username instead of requiring a username
+      and password.
 network:
   1883/tcp: Normal MQTT
   1884/tcp: MQTT over WebSocket


### PR DESCRIPTION
Apparently some devices do not allow you to provide a username and password and only allow you to use a client certificate for authentication. Enabling this option to help those users:
https://community.home-assistant.io/t/publishing-data-to-mqtt-broker-using-only-with-certificate/446470