### PR TITLE
Fix my.home-assistant.io link for Supervisor logs in Issue form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -105,7 +105,7 @@ body:
     attributes:
       label: Anything in the Supervisor logs that might be useful for us?
       description: >
-        The Supervisor logs can be found in the [System panel -> Logs -> Supervisor](https://my.home-assistant.io/redirect/logs/).
+        The Supervisor logs can be found in the [Settings panel -> System -> Logs -> Supervisor](https://my.home-assistant.io/redirect/logs/).
       render: txt
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -105,7 +105,7 @@ body:
     attributes:
       label: Anything in the Supervisor logs that might be useful for us?
       description: >
-        The Supervisor logs can be found in the [Supervisor panel -> System tab](https://my.home-assistant.io/redirect/supervisor_info/).
+        The Supervisor logs can be found in the [System panel -> Logs -> Supervisor](https://my.home-assistant.io/redirect/logs/).
       render: txt
 
   - type: textarea


### PR DESCRIPTION
The logs for supervisor were moved, but the issue form was not updated.