### PR TITLE
SSH - Update CLI 4.21.0

### DIFF
--- a/ssh/CHANGELOG.md
+++ b/ssh/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 9.6.1
+
+- Upgrade Home Assistant CLI to 4.21.0
+
 ## 9.6.0
 
 **Breaking change**: RSA keys generated using the SHA-1 hash algorithm

--- a/ssh/build.yaml
+++ b/ssh/build.yaml
@@ -9,6 +9,6 @@ codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
 args:
-  CLI_VERSION: 4.18.0
+  CLI_VERSION: 4.21.0
   LIBWEBSOCKETS_VERSION: 4.2.1
   TTYD_VERSION: 3e37e33b1cd927ae8f25cfbcf0da268723b6d230

--- a/ssh/config.yaml
+++ b/ssh/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 9.6.0
+version: 9.6.1
 slug: ssh
 name: Terminal & SSH
 description: Allow logging in remotely to Home Assistant using SSH


### PR DESCRIPTION
Update CLI from [4.18.0 to 4.21.0](https://github.com/home-assistant/cli/compare/4.18.0...4.21.0)