### PR TITLE
DNSMasq - default cnames to empty array

### DIFF
--- a/dnsmasq/CHANGELOG.md
+++ b/dnsmasq/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.5.1
+
+- Default cnames to empty array
+
 ## 1.5.0
 
 - Adds support for CNAME records

--- a/dnsmasq/config.yaml
+++ b/dnsmasq/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 1.5.0
+version: 1.5.1
 slug: dnsmasq
 name: Dnsmasq
 description: A simple DNS server
@@ -20,6 +20,7 @@ options:
   forwards: []
   hosts: []
   services: []
+  cnames: []
 ports:
   53/tcp: 53
   53/udp: 53

--- a/dnsmasq/translations/en.yaml
+++ b/dnsmasq/translations/en.yaml
@@ -15,6 +15,9 @@ configuration:
   services:
     name: Services
     description: This option allows you to provide srv-host records.
+  cnames:
+    name: Cnames
+    description: Provide cname records for DNSMasq to resolve.
 network:
   53/tcp: TCP port for DNS requests.
   53/udp: UDP port for DNS requests.


### PR DESCRIPTION
Default cnames setting to empty array to prevent errors with existing configs.

Fixes #2636 