### PR TITLE
Bump zwave-js to 10.0.2

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.67
+
+- [Bump Z-Wave JS to 10.0.2](https://github.com/zwave-js/node-zwave-js/releases/tag/v10.0.2)
+
 ## 0.1.66
 
 - Bump Z-Wave JS Server to 1.22.1

--- a/zwave_js/build.yaml
+++ b/zwave_js/build.yaml
@@ -10,4 +10,4 @@ codenotary:
   base_image: notary@home-assistant.io
 args:
   ZWAVEJS_SERVER_VERSION: 1.22.1
-  ZWAVEJS_VERSION: 10.0.1
+  ZWAVEJS_VERSION: 10.0.2

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.1.66
+version: 0.1.67
 slug: zwave_js
 name: Z-Wave JS
 description: Control a ZWave network with Home Assistant Z-Wave JS


### PR DESCRIPTION
- https://github.com/zwave-js/node-zwave-js/releases/tag/v10.0.2
- May address https://github.com/home-assistant/core/issues/77466 and https://github.com/home-assistant/core/issues/77517