### PR TITLE
Update configurator to 0.5.0

### DIFF
--- a/configurator/CHANGELOG.md
+++ b/configurator/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 5.4.0
+
+- Add Generate UUID menu item
+- Harmonize Home Assistant term
+- Rename Components to integrations
+- Remove images for libraries
+- Update jQuery to 3.6.0
+- Update js-yaml to 4.1.0
+- Update Ace Editor to 1.9.6
+
 ## 5.3.3
 
 - Fix Home Assistant API endpoint

--- a/configurator/build.yaml
+++ b/configurator/build.yaml
@@ -9,4 +9,4 @@ codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
 args:
-  CONFIGURATOR_VERSION: 0.4.1
+  CONFIGURATOR_VERSION: 0.5.0

--- a/configurator/config.yaml
+++ b/configurator/config.yaml
@@ -4,6 +4,7 @@ slug: configurator
 name: File editor
 description: Simple browser-based file editor for Home Assistant
 url: https://github.com/home-assistant/hassio-addons/tree/master/configurator
+codenotary: notary@home-assistant.io
 arch:
   - armhf
   - armv7

--- a/configurator/config.yaml
+++ b/configurator/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 5.3.3
+version: 5.4.0
 slug: configurator
 name: File editor
 description: Simple browser-based file editor for Home Assistant


### PR DESCRIPTION
Not sure if `5.4.0` as the addon-version meets the requirements. This release includes bugfixes and features. So I think updating the minor version is correct.

Changes / updates / fixes introduced with Configurator version `0.5.0`:

- Add Generate UUID menu item
- Harmonize Home Assistant term
- Rename Components to integrations
- Remove images for libraries
- Update jQuery to 3.6.0
- Update js-yaml to 4.1.0
- Update Ace Editor to 1.9.6