### PR TITLE
Update DOCS.md - Azure example azure_creds -> azure_config

### DIFF
--- a/letsencrypt/DOCS.md
+++ b/letsencrypt/DOCS.md
@@ -162,7 +162,7 @@ keyfile: privkey.pem
 challenge: dns
 dns:
   provider: dns-azure
-  azure_creds: azure.txt
+  azure_config: azure.txt
 ```
 
 Please copy your credentials file "azure.txt" into the "share" shared folder


### PR DESCRIPTION
Seems at some point, certbot was updated. Option list shows `azure_config`, but the example seems to have been missed.