### PR TITLE
Update file editor to 5.4.1

### DIFF
--- a/configurator/CHANGELOG.md
+++ b/configurator/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 5.4.1
+
+- Bugfix: Disable Ace-internal yaml-linting
+- Disable internal check for new releases
+
 ## 5.4.0
 
 - Add Generate UUID menu item

--- a/configurator/build.yaml
+++ b/configurator/build.yaml
@@ -9,4 +9,4 @@ codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
 args:
-  CONFIGURATOR_VERSION: 0.5.0
+  CONFIGURATOR_VERSION: 0.5.1

--- a/configurator/config.yaml
+++ b/configurator/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 5.4.0
+version: 5.4.1
 slug: configurator
 name: File editor
 description: Simple browser-based file editor for Home Assistant


### PR DESCRIPTION
- Bugfix: Disable Ace-internal yaml-linting
- Disable internal check for new releases

Fixes #2656