### PR TITLE
Fix DuckDNS Lets Encrypt certificate creation/renewal failing with "Incorrect TXT record" error

### DIFF
--- a/duckdns/CHANGELOG.md
+++ b/duckdns/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.16.0
+
+- Fix certificate renewals with aliases that would fail with "Incorrect TXT record" - <https://github.com/home-assistant/addons/issues/2505>
+- Improve the output from the hooks that set and remove the challenge tokens
+- Fix the behaviour where an invalid domain was always set when initially configuring the addon
+
 ## 1.15.0
 
 - Use Supervisor API to detect IPv6 host addresses, selectable by interface

--- a/duckdns/config.yaml
+++ b/duckdns/config.yaml
@@ -17,8 +17,7 @@ image: homeassistant/{arch}-addon-duckdns
 map:
   - ssl:rw
 options:
-  domains:
-    - null
+  domains: []
   token: null
   aliases: []
   lets_encrypt:

--- a/duckdns/config.yaml
+++ b/duckdns/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 1.15.0
+version: 1.16.0
 slug: duckdns
 name: Duck DNS
 description: >-

--- a/duckdns/data/hooks.sh
+++ b/duckdns/data/hooks.sh
@@ -30,8 +30,8 @@ deploy_challenge() {
     #   validation, this is what you want to put in the _acme-challenge
     #   TXT record. For HTTP validation it is the value that is expected
     #   be found in the $TOKEN_FILENAME file.
-
-    curl -s "https://www.duckdns.org/update?domains=$ALIAS&token=$SYS_TOKEN&txt=$TOKEN_VALUE"
+    res=$(curl -s "https://www.duckdns.org/update?domains=$ALIAS&token=$SYS_TOKEN&txt=$TOKEN_VALUE")
+    echo "$res - setting challenge token for $DOMAIN"
 }
 
 clean_challenge() {
@@ -44,7 +44,8 @@ clean_challenge() {
     #
     # The parameters are the same as for deploy_challenge.
 
-    curl -s "https://www.duckdns.org/update?domains=$ALIAS&token=$SYS_TOKEN&txt=removed&clear=true"
+    res=$(curl -s "https://www.duckdns.org/update?domains=$ALIAS&token=$SYS_TOKEN&txt=removed&clear=true")
+    echo "$res - removing challenge token for $DOMAIN"
 }
 
 deploy_cert() {

--- a/duckdns/data/run.sh
+++ b/duckdns/data/run.sh
@@ -14,7 +14,7 @@ DOMAINS=$(bashio::config 'domains | join(",")')
 WAIT_TIME=$(bashio::config 'seconds')
 ALGO=$(bashio::config 'lets_encrypt.algo')
 
-# Function that performe a renew
+# Function that performs a renew
 function le_renew() {
     local domain_args=()
     local domains=''

--- a/duckdns/data/run.sh
+++ b/duckdns/data/run.sh
@@ -62,7 +62,7 @@ function le_renew() {
             dehydrated --cron --algo "${ALGO}" --hook ./hooks.sh --challenge dns-01 "${domain_args[@]}" --out "${CERT_DIR}" --config "${WORK_DIR}/config" || true
         done
     else
-        bashio::log.info "Skipping renew!"
+        bashio::log.info "Certificate still valid. Skipping renew!"
     fi
 
     LE_UPDATE="$(date +%s)"


### PR DESCRIPTION
As detailed in https://github.com/home-assistant/addons/issues/2505, the DuckDNS extension will fail to issue or renew a certificate and fail with the error "Incorrect TXT record"

```
Processing my-ha.duckdns.org with alternative names: my-ha.cooldomain.cz
 + Signing domains...
 + Generating private key...
 + Generating signing request...
 + Requesting new certificate order from CA...
 + Received 2 authorizations URLs from the CA
 + Handling authorization for my-ha.duckdns.org
 + Handling authorization for my-ha.cooldomain.cz
 + 2 pending challenge(s)
 + Deploying challenge tokens...
OKOK + Responding to challenge for my-ha.duckdns.org authorization...
 + Cleaning challenge tokens...
OKOK + Challenge validation has failed :(
ERROR: Challenge is invalid! (returned: invalid) (result: ["type"]	"dns-01"
["status"]	"invalid"
["error","type"]	"urn:ietf:params:acme:error:unauthorized"
["error","detail"]	"Incorrect TXT record \"1g4FgZoGt2y9WaBs_7TQL7v7jb7lUJz8xNrlixCEuLQ\" found at _acme-challenge.my-ha.duckdns.org"
["error","status"]	403
["error"]	{"type":"urn:ietf:params:acme:error:unauthorized","detail":"Incorrect TXT record \"1g4FgZoGt2y9WaBs_7TQL7v7jb7lUJz8xNrlixCEuLQ\" found at _acme-challenge.my-ha.duckdns.org","status":403}
["url"]	"https://acme-v02.api.letsencrypt.org/acme/chall-v3/114079207846/9uci7g"
["token"]	"mtVWXobHYyfKU8XgjdLUYj6ebiZNqZ89Dh2kYpfLS7g"
["validated"]	"2022-05-30T05:50:26Z")
[07:55:30] INFO: OK
```

As I've detailed in the issue https://github.com/home-assistant/addons/issues/2505#issuecomment-1242714582:

> The issue here is dehydrated that is used for getting/renewing the certificates deploys the challenge tokens for all the domains and then performs the validation for each domain.
>
> This causes a problem with DuckDNS as it only has a single TXT record which will always be overwritten by the challenge for the last domain in the list.

This PR fixes that by requesting the certificates sequentially for each of the aliases. This isn't ideal, but it does the trick and should be fine for most users. Users with a lot of domains or aliases might need to try a few times because of Lets Encrypt's rate limits, but I suspect there won't be many people hitting these.

Whilst I'm at it, I've also made the `OK` lines in the output clearer by adding more context to what the hooks are actually doing so the output now looks like this:

```
[13:10:21] INFO: Renew certificate for domains: example.duckdns.org and aliases: example.com 
[13:10:21] INFO: No certificate found for example.duckdns.org, requesting new certificate.
# INFO: Using main config file /data/workdir/config
 + Creating chain cache directory /data/workdir/chains
Processing example.duckdns.org
 + Creating new directory /data/letsencrypt/example.duckdns.org ...
 + Signing domains...
 + Generating private key...
 + Generating signing request...
 + Requesting new certificate order from CA...
 + Received 1 authorizations URLs from the CA
 + Handling authorization for example.duckdns.org
 + 1 pending challenge(s)
 + Deploying challenge tokens...
OK - setting challenge token for example.duckdns.org
 + Responding to challenge for example.duckdns.org authorization...
 + Challenge is valid!
 + Cleaning challenge tokens...
OK - removing challenge token for example.duckdns.org
 + Requesting certificate...
 + Checking certificate...
 + Done!
 + Creating fullchain.pem...
 + Done!
# INFO: Using main config file /data/workdir/config
Processing example.duckdns.org with alternative names: example.com
 + Checking domain name(s) of existing cert... changed!
 + Domain name(s) are not matching!
 + Names in old certificate: example.duckdns.org
 + Configured names: example.com example.duckdns.org
 + Forcing renew.
 + Checking expire date of existing cert...
 + Valid till Dec  9 11:10:28 2022 GMT (Longer than 30 days). Ignoring because renew was forced!
 + Signing domains...
 + Generating private key...
 + Generating signing request...
 + Requesting new certificate order from CA...
 + Received 2 authorizations URLs from the CA
 + Handling authorization for example.duckdns.org
 + Found valid authorization for example.duckdns.org
 + Handling authorization for example.com
 + 1 pending challenge(s)
 + Deploying challenge tokens...
OK - setting challenge token for example.com
 + Responding to challenge for example.com authorization...
 + Challenge is valid!
 + Cleaning challenge tokens...
OK - removing challenge token for example.com
 + Requesting certificate...
 + Checking certificate...
 + Done!
 + Creating fullchain.pem...
 + Done!
```

And a renew attempt for an already valid certificate will look like this:

```
[13:11:37] INFO: Renew certificate for domains: example.duckdns.org and aliases: example.com 
[13:11:37] INFO: Checking existing cert...
[13:11:37] INFO: Certificate still valid. Skipping renew!
```

I've also fixed an annoyance where first configuring the extension would always have an empty invalid domain name added.

Fixes https://github.com/home-assistant/addons/issues/2505