### PR TITLE
Change zwave_js base image

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.72
+
+- Use same base image as community add-on zwave-js-ui
+
 ## 0.1.71
 
 - [Bump Z-Wave JS to 10.1.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v10.1.0)

--- a/zwave_js/build.yaml
+++ b/zwave_js/build.yaml
@@ -1,10 +1,10 @@
 ---
 build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-base:3.16
-  amd64: ghcr.io/home-assistant/amd64-base:3.16
-  armhf: ghcr.io/home-assistant/armhf-base:3.16
-  armv7: ghcr.io/home-assistant/armv7-base:3.16
-  i386: ghcr.io/home-assistant/i386-base:3.16
+  aarch64: ghcr.io/hassio-addons/base:12.2.4
+  amd64: ghcr.io/hassio-addons/base:12.2.4
+  armhf: ghcr.io/hassio-addons/base:12.2.4
+  armv7: ghcr.io/hassio-addons/base:12.2.4
+  i386: ghcr.io/hassio-addons/base:12.2.4
 codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io

--- a/zwave_js/build.yaml
+++ b/zwave_js/build.yaml
@@ -7,7 +7,7 @@ build_from:
   i386: ghcr.io/hassio-addons/base:12.2.4
 codenotary:
   signer: notary@home-assistant.io
-  base_image: notary@home-assistant.io
+  base_image: codenotary@frenck.dev
 args:
   ZWAVEJS_SERVER_VERSION: 1.22.1
   ZWAVEJS_VERSION: 10.1.0

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.1.71
+version: 0.1.72
 slug: zwave_js
 name: Z-Wave JS
 description: Control a ZWave network with Home Assistant Z-Wave JS


### PR DESCRIPTION
- Use the same base image as the community add-on zwave-js-ui.
- https://github.com/hassio-addons/addon-zwave-js-ui/blob/b52ee689e93d2f732563ee6afaaabcaab2eae285/zwave-js-ui/build.yaml
- This is a test to see if it changes anything for the users that are experiencing a memory leak.
- https://github.com/home-assistant/core/issues/77767