### PR TITLE
Use node-zwave-js with `xstate` pinned to an older version in Z-Wave JS

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.73
+
+- [Bump Z-Wave JS Server to 1.23.0](https://github.com/zwave-js/zwave-js-server/releases/tag/1.23.0)
+
 ## 0.1.72
 
 - Use same base image as community add-on zwave-js-ui

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 0.1.73
 
 - [Bump Z-Wave JS Server to 1.23.0](https://github.com/zwave-js/zwave-js-server/releases/tag/1.23.0)
+- [Bump Z-Wave JS to 10.2.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v10.2.0)
+- Bump Z-Wave JS to test build to try to address memory leak
 
 ## 0.1.72
 

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [Bump Z-Wave JS Server to 1.23.0](https://github.com/zwave-js/zwave-js-server/releases/tag/1.23.0)
 - [Bump Z-Wave JS to 10.2.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v10.2.0)
 - Bump Z-Wave JS to test build to try to address memory leak
+- Revert to default base image
 
 ## 0.1.72
 

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.1.73
 
-- [Bump Z-Wave JS Server to 1.23.0](https://github.com/zwave-js/zwave-js-server/releases/tag/1.23.0)
+- [Bump Z-Wave JS Server to 1.23.1](https://github.com/zwave-js/zwave-js-server/releases/tag/1.23.1)
 - [Bump Z-Wave JS to 10.2.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v10.2.0)
 - Bump Z-Wave JS to test build to try to address memory leak
 - Revert to default base image

--- a/zwave_js/Dockerfile
+++ b/zwave_js/Dockerfile
@@ -19,7 +19,7 @@ RUN \
         python3 \
     \
     && npm config set unsafe-perm \
-    && npm install \
+    && npm install --force \
         "zwave-js@${ZWAVEJS_VERSION}" \
         "@zwave-js/server@${ZWAVEJS_SERVER_VERSION}" \
     \

--- a/zwave_js/build.yaml
+++ b/zwave_js/build.yaml
@@ -9,5 +9,5 @@ codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
 args:
-  ZWAVEJS_SERVER_VERSION: 1.23.0
+  ZWAVEJS_SERVER_VERSION: 1.23.1
   ZWAVEJS_VERSION: 10.2.1-0-pr-5108-7ec35dd

--- a/zwave_js/build.yaml
+++ b/zwave_js/build.yaml
@@ -1,13 +1,13 @@
 ---
 build_from:
-  aarch64: ghcr.io/hassio-addons/base:12.2.4
-  amd64: ghcr.io/hassio-addons/base:12.2.4
-  armhf: ghcr.io/hassio-addons/base:12.2.4
-  armv7: ghcr.io/hassio-addons/base:12.2.4
-  i386: ghcr.io/hassio-addons/base:12.2.4
+  aarch64: ghcr.io/home-assistant/aarch64-base:3.16
+  amd64: ghcr.io/home-assistant/amd64-base:3.16
+  armhf: ghcr.io/home-assistant/armhf-base:3.16
+  armv7: ghcr.io/home-assistant/armv7-base:3.16
+  i386: ghcr.io/home-assistant/i386-base:3.16
 codenotary:
   signer: notary@home-assistant.io
-  base_image: codenotary@frenck.dev
+  base_image: notary@home-assistant.io
 args:
   ZWAVEJS_SERVER_VERSION: 1.23.0
   ZWAVEJS_VERSION: 10.2.1-0-pr-5108-7ec35dd

--- a/zwave_js/build.yaml
+++ b/zwave_js/build.yaml
@@ -10,4 +10,4 @@ codenotary:
   base_image: codenotary@frenck.dev
 args:
   ZWAVEJS_SERVER_VERSION: 1.22.1
-  ZWAVEJS_VERSION: 10.1.0
+  ZWAVEJS_VERSION: 10.2.1-0-pr-5108-7ec35dd

--- a/zwave_js/build.yaml
+++ b/zwave_js/build.yaml
@@ -9,5 +9,5 @@ codenotary:
   signer: notary@home-assistant.io
   base_image: codenotary@frenck.dev
 args:
-  ZWAVEJS_SERVER_VERSION: 1.22.1
+  ZWAVEJS_SERVER_VERSION: 1.23.0
   ZWAVEJS_VERSION: 10.2.1-0-pr-5108-7ec35dd

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.1.72
+version: 0.1.73
 slug: zwave_js
 name: Z-Wave JS
 description: Control a ZWave network with Home Assistant Z-Wave JS


### PR DESCRIPTION
That version is a [test build](https://github.com/zwave-js/node-zwave-js/pull/5108), which is basically 10.2.0, but with xstate pinned to 4.29.0 - the version node-zwave-js had in its own lockfile. This seems to be the most obvious difference in dependencies between the addons.

With this change, the core addon will use an older version of the dependency than the community addon (4.32.1), but one that was previously in use and did not leak. With 4.32.1, the driver does not compile - they are using some funky types.

@raman325 @MartinHjelmare I'm not sure if anything else needs to be changed (server versions etc.)

Closes https://github.com/home-assistant/addons/issues/2683