### PR TITLE
Fix small typo in DHCP configuration translation

### DIFF
--- a/dhcp_server/translations/en.yaml
+++ b/dhcp_server/translations/en.yaml
@@ -1,7 +1,7 @@
 ---
 configuration:
   default_lease:
-    name: Default Least Time
+    name: Default Lease Time
     description: >-
       The default time in seconds that the IP is leased to your client.
   dns:


### PR DESCRIPTION
there's a small typo in "Default Lease Time", this fixes it