### PR TITLE
Allow nginx ssl proxy to have an empty "hsts" setting

### DIFF
--- a/nginx_proxy/config.yaml
+++ b/nginx_proxy/config.yaml
@@ -31,7 +31,7 @@ ports:
   80/tcp: null
 schema:
   domain: str
-  hsts: str
+  hsts: str?
   certfile: str
   keyfile: str
   cloudflare: bool


### PR DESCRIPTION
The docs say that "if empty the header is not sent", but the field is required.

![image](https://user-images.githubusercontent.com/1027111/196963816-15002494-128b-456e-b3b5-441eed8df131.png)
