### PR TITLE
Bump deCONZ 2.19.1 (stable)

### DIFF
--- a/deconz/CHANGELOG.md
+++ b/deconz/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.17.0
+
+- Bump deCONZ to 2.19.1
+
 ## 6.16.0
 
 - Bump deCONZ to 2.18.2

--- a/deconz/build.yaml
+++ b/deconz/build.yaml
@@ -7,4 +7,4 @@ codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
 args:
-  DECONZ_VERSION: 2.18.02
+  DECONZ_VERSION: 2.19.01

--- a/deconz/config.yaml
+++ b/deconz/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 6.16.0
+version: 6.17.0
 slug: deconz
 name: deCONZ
 description: >-


### PR DESCRIPTION
Bump deCONZ version to [2.19.01](https://github.com/dresden-elektronik/deconz-rest-plugin/releases/tag/v2.19.1)