### PR TITLE
Fix Git pull DOCS.md - quoted value for option is evaluated true

### DIFF
--- a/git_pull/DOCS.md
+++ b/git_pull/DOCS.md
@@ -42,7 +42,7 @@ Add-on configuration:
 git_branch: master
 git_command: pull
 git_remote: origin
-git_prune: 'false'
+git_prune: false
 repository: https://example.com/my_configs.git
 auto_restart: false
 restart_ignore:


### PR DESCRIPTION
The addon [`git_pull`](https://github.com/home-assistant/addons/blob/master/git_pull/DOCS.md) documents the following default value for option `git_prune`:

```markdown
git_prune: 'false'
```

This value is misleading as it is evaluated to `true`.