### PR TITLE
Update File Editor to 5.4.2

### DIFF
--- a/configurator/CHANGELOG.md
+++ b/configurator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.4.2
+
+- Bugfix: Fix page load with special characters in states
+
 ## 5.4.1
 
 - Bugfix: Disable Ace-internal yaml-linting

--- a/configurator/build.yaml
+++ b/configurator/build.yaml
@@ -9,4 +9,4 @@ codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
 args:
-  CONFIGURATOR_VERSION: 0.5.1
+  CONFIGURATOR_VERSION: 0.5.2

--- a/configurator/config.yaml
+++ b/configurator/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 5.4.1
+version: 5.4.2
 slug: configurator
 name: File editor
 description: Simple browser-based file editor for Home Assistant


### PR DESCRIPTION
This PR updates the File Editor addon to version 5.4.2. It fixes the issue discussed here: https://github.com/danielperna84/hass-configurator/issues/217

https://github.com/danielperna84/hass-configurator/compare/0.5.1...0.5.2