### PR TITLE
silabs-multiprotocol: Add healthcheck for zigbeed

### DIFF
--- a/silabs-multiprotocol/Dockerfile
+++ b/silabs-multiprotocol/Dockerfile
@@ -200,6 +200,8 @@ RUN ldconfig && touch /accept_silabs_msla
 
 COPY rootfs /
 
+HEALTHCHECK s6-svstat /run/service/zigbeed
+
 # use s6-overlay as init system
 WORKDIR /
 ENTRYPOINT ["/init"]

--- a/silabs-multiprotocol/Dockerfile
+++ b/silabs-multiprotocol/Dockerfile
@@ -200,7 +200,7 @@ RUN ldconfig && touch /accept_silabs_msla
 
 COPY rootfs /
 
-HEALTHCHECK s6-svstat /run/service/zigbeed
+HEALTHCHECK --interval=10s --start-period=120s CMD [ "$(s6-svstat -u /run/service/zigbeed)" = "true" ]
 
 # use s6-overlay as init system
 WORKDIR /


### PR DESCRIPTION
This will allow to wait for the add-on to fully start before starting dependent services (e.g. ZHA).