### PR TITLE
Bump SiLabs flasher to 0.0.7

### DIFF
--- a/silabs-multiprotocol/Dockerfile
+++ b/silabs-multiprotocol/Dockerfile
@@ -179,7 +179,7 @@ RUN \
     && chmod +x ./script/* \
     && patch -p1 < /usr/src/0001-Avoid-writing-to-system-console.patch \
     && ./script/setup \
-    && pip install universal-silabs-flasher==0.0.4 \
+    && pip install universal-silabs-flasher==0.0.7 \
     && apt-get purge -y --auto-remove \
        build-essential \
        patch \

--- a/silabs-multiprotocol/rootfs/etc/s6-overlay/scripts/universal-silabs-flasher-up
+++ b/silabs-multiprotocol/rootfs/etc/s6-overlay/scripts/universal-silabs-flasher-up
@@ -45,4 +45,4 @@ fi
 bashio::log.info "Starting universal-silabs-flasher with ${device} (baudrate ${baudrate})"
 exec universal-silabs-flasher --device ${device} --baudrate ${baudrate} \
      --bootloader-baudrate 115200 \
-     flash --allow-cross-flashing --firmware "/root/${firmware}"
+     flash --yellow-gpio-reset --allow-cross-flashing --firmware "/root/${firmware}"

--- a/silabs-multiprotocol/rootfs/etc/s6-overlay/scripts/universal-silabs-flasher-up
+++ b/silabs-multiprotocol/rootfs/etc/s6-overlay/scripts/universal-silabs-flasher-up
@@ -13,6 +13,7 @@ declare usb_product
 
 device=$(bashio::config 'device')
 baudrate=$(bashio::config 'baudrate')
+gpio_reset_flag=""
 
 if bashio::config.false 'autoflash_firmware'; then
     bashio::log.info "Flashing firmware is disabled"
@@ -23,7 +24,7 @@ fi
 if [ -d /sys/devices/platform/soc/fe201800.serial/tty/ttyAMA1 ] && [ "${device}" == "/dev/ttyAMA1" ]; then
     bashio::log.info "Detected Home Assistant Yellow"
     firmware="NabuCasa_RCP_v4.1.3_rcp-uart-hw-802154_115200.gbl"
-    gpio_reset="--yellow-gpio-reset"
+    gpio_reset_flag="--yellow-gpio-reset"
 else
     # Check device manufacturer/product information
     usb_device_path=$(realpath /sys/class/tty/$(readlink /sys/class/tty/$(basename ${device}))/../../../../)
@@ -41,11 +42,9 @@ else
         bashio::log.info "No valid firmware for this device"
         s6-svc -d /run/service/universal-silabs-flasher
     fi
-
-    gpio_reset=""
 fi
 
 bashio::log.info "Starting universal-silabs-flasher with ${device} (baudrate ${baudrate})"
 exec universal-silabs-flasher --device ${device} --baudrate ${baudrate} \
      --bootloader-baudrate 115200 \
-     flash ${gpio_reset} --allow-cross-flashing --firmware "/root/${firmware}"
+     flash ${gpio_reset_flag} --allow-cross-flashing --firmware "/root/${firmware}"

--- a/silabs-multiprotocol/rootfs/etc/s6-overlay/scripts/universal-silabs-flasher-up
+++ b/silabs-multiprotocol/rootfs/etc/s6-overlay/scripts/universal-silabs-flasher-up
@@ -23,6 +23,7 @@ fi
 if [ -d /sys/devices/platform/soc/fe201800.serial/tty/ttyAMA1 ] && [ "${device}" == "/dev/ttyAMA1" ]; then
     bashio::log.info "Detected Home Assistant Yellow"
     firmware="NabuCasa_RCP_v4.1.3_rcp-uart-hw-802154_115200.gbl"
+    gpio_reset="--yellow-gpio-reset"
 else
     # Check device manufacturer/product information
     usb_device_path=$(realpath /sys/class/tty/$(readlink /sys/class/tty/$(basename ${device}))/../../../../)
@@ -40,9 +41,11 @@ else
         bashio::log.info "No valid firmware for this device"
         s6-svc -d /run/service/universal-silabs-flasher
     fi
+
+    gpio_reset=""
 fi
 
 bashio::log.info "Starting universal-silabs-flasher with ${device} (baudrate ${baudrate})"
 exec universal-silabs-flasher --device ${device} --baudrate ${baudrate} \
      --bootloader-baudrate 115200 \
-     flash --yellow-gpio-reset --allow-cross-flashing --firmware "/root/${firmware}"
+     flash ${gpio_reset} --allow-cross-flashing --firmware "/root/${firmware}"

--- a/silabs-multiprotocol/rootfs/etc/s6-overlay/scripts/universal-silabs-flasher-up
+++ b/silabs-multiprotocol/rootfs/etc/s6-overlay/scripts/universal-silabs-flasher-up
@@ -10,10 +10,10 @@ declare firmware
 declare usb_device_path
 declare usb_manufacturer
 declare usb_product
+declare gpio_reset_flag
 
 device=$(bashio::config 'device')
 baudrate=$(bashio::config 'baudrate')
-gpio_reset_flag=""
 
 if bashio::config.false 'autoflash_firmware'; then
     bashio::log.info "Flashing firmware is disabled"
@@ -42,6 +42,7 @@ else
         bashio::log.info "No valid firmware for this device"
         s6-svc -d /run/service/universal-silabs-flasher
     fi
+    gpio_reset_flag=""
 fi
 
 bashio::log.info "Starting universal-silabs-flasher with ${device} (baudrate ${baudrate})"


### PR DESCRIPTION
Supersedes #2744.

This change bumps the flasher from [0.0.4 to 0.0.7](https://github.com/puddly/universal-silabs-flasher/compare/v0.0.4...v0.0.7). These releases fix a few bugs with flashing firmware from a bad bootloader state, where the bootloader launches a non-existent application and locks up instead of failing.

I've also enabled the `--yellow-gpio-reset` flag. With the GPIO reset, startup firmware verification speed is limited only by Python's startup time:

```console
$ time /usr/local/bin/universal-silabs-flasher --device /dev/ttyAMA1 flash --yellow-gpio-reset --allow-cross-flashing --firmware /config/fw/RCPMultiPAN/NabuCasa_RCP_v4.1.3_rcp-uart-hw-802154_115200.gbl
2022-11-22 15:28:43 homeassistant universal_silabs_flasher.flash[308] INFO Extracted GBL metadata: NabuCasaMetadata(metadata_version=1, sdk_version=<AwesomeVersion SemVer '4.1.3'>, ezsp_version=None, fw_type=<FirmwareImageType.RCP_UART_802154: 'rcp-uart-802154'>)
2022-11-22 15:28:43 homeassistant universal_silabs_flasher.flasher[308] INFO Probing ApplicationType.GECKO_BOOTLOADER
2022-11-22 15:28:43 homeassistant universal_silabs_flasher.flasher[308] INFO Probing ApplicationType.CPC
2022-11-22 15:28:43 homeassistant universal_silabs_flasher.flasher[308] INFO Detected ApplicationType.CPC, version 4.1.3
2022-11-22 15:28:43 homeassistant universal_silabs_flasher.flash[308] INFO Detected running firmware ApplicationType.CPC, version 4.1.3
2022-11-22 15:28:43 homeassistant universal_silabs_flasher.flash[308] INFO Firmware version 4.1.3 is flashed, not upgrading
real	0m 1.92s
user	0m 1.26s
sys		0m 0.23s
```
