### PR TITLE
silabs-multiprotocol: Give permission to use GPIO port

### DIFF
--- a/silabs-multiprotocol/CHANGELOG.md
+++ b/silabs-multiprotocol/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.1
+
+- Bugfix: give GPIO permissions to container to allow flashing Yellow
+
 ## 0.8.0
 
 - Initial AMD64/x86-64 support (zigbeed via QEMU)

--- a/silabs-multiprotocol/config.yaml
+++ b/silabs-multiprotocol/config.yaml
@@ -9,6 +9,7 @@ arch:
   - armv7
   - aarch64
   - amd64
+gpio: true
 hassio_api: true
 # IPC is only used within the Add-on
 host_ipc: false

--- a/silabs-multiprotocol/config.yaml
+++ b/silabs-multiprotocol/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.8.0
+version: 0.8.1
 slug: silabs_multiprotocol
 name: Silicon Labs Multiprotocol
 description: Zigbee and OpenThread multiprotocol add-on


### PR DESCRIPTION
Currently it does not have permission to access GPIO, causing the Yellow GPIO reset to fail during flashing:

```python
s6-rc: info: service mdns: starting
s6-rc: info: service s6rc-oneshot-runner: starting
s6-rc: info: service mdns successfully started
s6-rc: info: service s6rc-oneshot-runner successfully started
s6-rc: info: service fix-attrs: starting
s6-rc: info: service fix-attrs successfully started
s6-rc: info: service legacy-cont-init: starting
cont-init: info: running /etc/cont-init.d/check-cpcd-shm.sh
[20:29:46] INFO: Starting mDNS Responder...
Default: mDNSResponder (Engineering Build) (Nov 24 2022 16:49:26) starting
Default: mDNS_AddDNSServer: Lock not held! mDNS_busy (0) mDNS_reentrancy (0)
cont-init: info: /etc/cont-init.d/check-cpcd-shm.sh exited 0
cont-init: info: running /etc/cont-init.d/config.sh
[20:29:48] INFO: Generating cpcd configuration.
cont-init: info: /etc/cont-init.d/config.sh exited 0
s6-rc: info: service legacy-cont-init successfully started
s6-rc: info: service banner: starting
-----------------------------------------------------------
 Add-on: Silicon Labs Multiprotocol
 Zigbee and OpenThread multiprotocol add-on
-----------------------------------------------------------
 Add-on version: 0.8.0
 You are running the latest version of this add-on.
 System: Home Assistant OS 9.3  (aarch64 / yellow)
 Home Assistant Core: 2022.11.1
 Home Assistant Supervisor: 2022.11.2
-----------------------------------------------------------
 Please, share the above information when looking for help
 or support in, e.g., GitHub, forums or the Discord chat.
-----------------------------------------------------------
s6-rc: info: service banner successfully started
s6-rc: info: service universal-silabs-flasher: starting
[20:29:50] INFO: Detected Home Assistant Yellow
[20:29:50] INFO: Starting universal-silabs-flasher with /dev/ttyAMA1 (baudrate 115200)
2022-11-28 20:29:51 core-silabs-multiprotocol universal_silabs_flasher.flash[218] INFO Extracted GBL metadata: NabuCasaMetadata(metadata_version=1, sdk_version=<AwesomeVersion SemVer '4.1.3'>, ezsp_version=None, fw_type=<FirmwareImageType.RCP_UART_802154: 'rcp-uart-802154'>)
Traceback (most recent call last):
  File "/usr/local/bin/universal-silabs-flasher", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/universal_silabs_flasher/flash.py", line 31, in inner
    return asyncio.run(f(*args, **kwargs))
  File "/usr/lib/python3.9/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/lib/python3.9/asyncio/base_events.py", line 642, in run_until_complete
    return future.result()
  File "/usr/local/lib/python3.9/dist-packages/universal_silabs_flasher/flash.py", line 174, in flash
    await flasher.probe_app_type(yellow_gpio_reset=yellow_gpio_reset)
  File "/usr/local/lib/python3.9/dist-packages/universal_silabs_flasher/flasher.py", line 152, in probe_app_type
    await self.enter_yellow_bootloader()
  File "/usr/local/lib/python3.9/dist-packages/universal_silabs_flasher/flasher.py", line 105, in enter_yellow_bootloader
    await send_gpio_pattern(
  File "/usr/local/lib/python3.9/dist-packages/universal_silabs_flasher/flasher.py", line 58, in send_gpio_pattern
    await asyncio.get_running_loop().run_in_executor(
  File "/usr/lib/python3.9/concurrent/futures/thread.py", line 52, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/local/lib/python3.9/dist-packages/universal_silabs_flasher/flasher.py", line 28, in _send_gpio_pattern
    chip = gpiod.chip(0, gpiod.chip.OPEN_BY_NUMBER)
  File "/usr/local/lib/python3.9/dist-packages/gpiod/libgpiodcxx/__init__.py", line 107, in __init__
    self.open(device, how)
  File "/usr/local/lib/python3.9/dist-packages/gpiod/libgpiodcxx/__init__.py", line 136, in open
    chip_struct = func(device)
  File "/usr/local/lib/python3.9/dist-packages/gpiod/libgpiod/__init__.py", line 1085, in gpiod_chip_open_by_number
    return gpiod_chip_open("/dev/gpiochip" + str(num))
  File "/usr/local/lib/python3.9/dist-packages/gpiod/libgpiod/__init__.py", line 112, in gpiod_chip_open
    fd = os_open(path, O_RDWR | O_CLOEXEC)
PermissionError: [Errno 1] Operation not permitted: '/dev/gpiochip0'
s6-rc: warning: unable to start service universal-silabs-flasher: command exited 1
/run/s6/basedir/scripts/rc.init: warning: s6-rc failed to properly bring all the services up! Check your logs (in /run/uncaught-logs/current if you have in-container logging) for more information.
prog: fatal: stopping the container.
s6-rc: info: service mdns: stopping
s6-rc: info: service banner: stopping
Default: mDNSResponder (Engineering Build) (Nov 24 2022 16:49:26) stopping
s6-rc: info: service mdns successfully stopped
s6-rc: info: service banner successfully stopped
s6-rc: info: service legacy-cont-init: stopping
s6-rc: info: service legacy-cont-init successfully stopped
s6-rc: info: service fix-attrs: stopping
s6-rc: info: service fix-attrs successfully stopped
s6-rc: info: service s6rc-oneshot-runner: stopping
s6-rc: info: service s6rc-oneshot-runner successfully stopped
```

I have tested the fix locally by installing the addon tree in `/addons/`.