### PR TITLE
Add feature to set MariaDB variables on start

### DIFF
--- a/mariadb/config.yaml
+++ b/mariadb/config.yaml
@@ -23,6 +23,7 @@ options:
   rights:
     - database: homeassistant
       username: homeassistant
+  variables: []
 ports:
   3306/tcp: null
 schema:
@@ -38,6 +39,9 @@ schema:
           CREATE VIEW|DELETE|DELETE HISTORY|DROP|EVENT|GRANT OPTION|INDEX|\
           INSERT|LOCK TABLES|SELECT|SHOW VIEW|TRIGGER|UPDATE)?"
       username: str
+  variables:
+    - name: str?
+      value: str?
 services:
   - mysql:provide
 startup: system

--- a/mariadb/rootfs/etc/services.d/mariadb/run
+++ b/mariadb/rootfs/etc/services.d/mariadb/run
@@ -108,6 +108,18 @@ mysql -e "GRANT ALL PRIVILEGES ON *.* TO 'service'@'172.30.33.%' WITH GRANT OPTI
 # Flush privileges
 mysql -e "FLUSH PRIVILEGES;" 2> /dev/null || true
 
+# Set variables
+bashio::log.info "Setting custom variables"
+for var in $(bashio::config "variables|keys"); do
+    NAME=$(bashio::config "variables[${var}].name")
+    VALUE=$(bashio::config "variables[${var}].value")
+
+    bashio::log.info "Setting variable ${NAME} to ${VALUE}"
+    if ! mysql -e "SET GLOBAL ${NAME} = ${VALUE}" 2> /dev/null; then
+        bashio::log.warning "Could not set custom variable ${NAME}"
+    fi
+done
+
 # Send service information to the Supervisor
 PAYLOAD=$(\
     bashio::var.json \


### PR DESCRIPTION
Adding the possibility to set global variables upon the start of the addon.
Currently there is no possibility to persistently modify variables or the config.