### PR TITLE
Update silabs-multiprotocol config.yaml URL

### DIFF
--- a/silabs-multiprotocol/config.yaml
+++ b/silabs-multiprotocol/config.yaml
@@ -4,7 +4,7 @@ slug: silabs_multiprotocol
 name: Silicon Labs Multiprotocol
 description: Zigbee and OpenThread multiprotocol add-on
 url: >
-  https://github.com/home-assistant/addons-development/tree/master/silabs-multiprotocol
+  https://github.com/home-assistant/addons/tree/master/silabs-multiprotocol
 arch:
   - armv7
   - aarch64


### PR DESCRIPTION
Since https://github.com/home-assistant/addons/pull/2740, the add-on was moved to this main repo. The add-on URL wasn't updated yet.