### PR TITLE
Typo fix: `ZWave` -> `Z-Wave`

### DIFF
--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -2,7 +2,7 @@
 version: 0.1.74
 slug: zwave_js
 name: Z-Wave JS
-description: Control a ZWave network with Home Assistant Z-Wave JS
+description: Control a Z-Wave network with Home Assistant Z-Wave JS
 url: https://github.com/home-assistant/hassio-addons/tree/master/zwave_js
 arch:
   - amd64


### PR DESCRIPTION
See title.