### PR TITLE
Add option to configure the preferred chain

### DIFF
--- a/letsencrypt/config.yaml
+++ b/letsencrypt/config.yaml
@@ -35,6 +35,7 @@ schema:
   challenge: list(dns|http)
   acme_root_ca_cert: str?
   acme_server: url?
+  chain: str?
   dns:
     aws_access_key_id: str?
     aws_secret_access_key: str?

--- a/letsencrypt/rootfs/etc/services.d/lets-encrypt/run
+++ b/letsencrypt/rootfs/etc/services.d/lets-encrypt/run
@@ -15,6 +15,7 @@ CHALLENGE=$(bashio::config 'challenge')
 DNS_PROVIDER=$(bashio::config 'dns.provider')
 ACME_SERVER=$(bashio::config 'acme_server')
 ACME_ROOT_CA=$(bashio::config 'acme_root_ca_cert')
+CHAIN=$(bashio::config 'chain')
 
 if [ "${CHALLENGE}" == "dns" ]; then
     bashio::log.info "Selected DNS Provider: ${DNS_PROVIDER}"
@@ -147,13 +148,13 @@ if [ "$CHALLENGE" == "dns" ]; then
         --email "$EMAIL" --agree-tos \
         --config-dir "$CERT_DIR" --work-dir "$WORK_DIR" \
         --preferred-challenges "$CHALLENGE" "${DOMAIN_ARR[@]}" "${PROVIDER_ARGUMENTS[@]}" \
-        --preferred-chain "ISRG Root X1"
+        --preferred-chain "$CHAIN"
 else
     certbot certonly --non-interactive --keep-until-expiring --expand \
         --email "$EMAIL" --agree-tos \
         --config-dir "$CERT_DIR" --work-dir "$WORK_DIR" \
         --preferred-challenges "$CHALLENGE" "${DOMAIN_ARR[@]}" "${ACME_CUSTOM_SERVER_ARGUMENTS[@]}" --standalone \
-        --preferred-chain "ISRG Root X1"
+        --preferred-chain "$CHAIN"
 fi
 
 # Get the last modified cert directory and copy the cert and private key to store

--- a/letsencrypt/translations/en.yaml
+++ b/letsencrypt/translations/en.yaml
@@ -29,6 +29,12 @@ configuration:
       By default, The addon uses Let's Encrypt's default server at
       https://acme-v02.api.letsencrypt.org/. You can instruct the addon to use a
       different ACME server.
+  chain:
+    name: Preferred Certificate Chain
+    description: >-
+      If the CA offers multiple certificate chains, prefer the chain whose
+      topmost certificate was issued from this Subject Common Name. If no match,
+      the default offered chain will be used.
   dns:
     name: DNS
     description: DNS Provider configuration


### PR DESCRIPTION
This should add an extra option to configure the preferred chain for certbot.

Configuring a different chain can help older Android versions to be able to use the generated certificate.