### PR TITLE
nginx_proxy: update Alpine to 3.16 (nginx 1.22.x)

### DIFF
--- a/nginx_proxy/CHANGELOG.md
+++ b/nginx_proxy/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.2.0
+
+- Update Alpine to 3.16 (nginx 1.22.x)
+
 ## 3.1.5
 
 - Fixed container environment

--- a/nginx_proxy/build.yaml
+++ b/nginx_proxy/build.yaml
@@ -1,10 +1,10 @@
 ---
 build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-base:3.14
-  amd64: ghcr.io/home-assistant/amd64-base:3.14
-  armhf: ghcr.io/home-assistant/armhf-base:3.14
-  armv7: ghcr.io/home-assistant/armv7-base:3.14
-  i386: ghcr.io/home-assistant/i386-base:3.14
+  aarch64: ghcr.io/home-assistant/aarch64-base:3.16
+  amd64: ghcr.io/home-assistant/amd64-base:3.16
+  armhf: ghcr.io/home-assistant/armhf-base:3.16
+  armv7: ghcr.io/home-assistant/armv7-base:3.16
+  i386: ghcr.io/home-assistant/i386-base:3.16
 codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io

--- a/nginx_proxy/config.yaml
+++ b/nginx_proxy/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 3.1.5
+version: 3.2.0
 hassio_api: true
 slug: nginx_proxy
 name: NGINX Home Assistant SSL proxy


### PR DESCRIPTION
Upgrading to a currently maintained stable nginx branch seems in order.