### PR TITLE
matter_server: Bump Matter Server and Matter SDK wheels

### DIFF
--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.2.0
+
+- Bump Matter Server to 1.0.8
+- Bump pre-built Matter SDK wheels to 2022.12.0
+- Make sure production PAA certificates work too
+
 ## 1.1.2
 
 - Get most recent certificates from master branch

--- a/matter_server/Dockerfile
+++ b/matter_server/Dockerfile
@@ -27,6 +27,8 @@ RUN \
     && git clone --depth 1 -b master \
        https://github.com/project-chip/connectedhomeip \
     && cp -r connectedhomeip/credentials /root/credentials \
+    && mv /root/credentials/production/paa-root-certs/* \
+          /root/credentials/development/paa-root-certs/ \
     && rm -rf connectedhomeip \
     && apt-get purge -y --auto-remove \
        git \

--- a/matter_server/build.yaml
+++ b/matter_server/build.yaml
@@ -3,5 +3,5 @@ build_from:
   aarch64: ghcr.io/home-assistant/aarch64-base-debian:bullseye
   amd64: ghcr.io/home-assistant/amd64-base-debian:bullseye
 args:
-  MATTER_SERVER_VERSION: 1.0.7
-  HOME_ASSISTANT_CHIP_VERSION: 2022.11.1
+  MATTER_SERVER_VERSION: 1.0.8
+  HOME_ASSISTANT_CHIP_VERSION: 2022.12.0

--- a/matter_server/config.yaml
+++ b/matter_server/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 1.1.2
+version: 1.2.0
 slug: matter_server
 name: Matter Server
 description: Matter WebSocket Server for Home Assistant Matter support.


### PR DESCRIPTION
Bump the Matter Server to 1.0.8 and the Matter SDK wheels to 2022.12.0. Also deploy the production certificates into the correct directory.