### PR TITLE
Require minimum HA Core version for matter server

### DIFF
--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.0
+
+- Require Home Assistant Core 2023.1.0b1 to install the add-on. The chip SDK was bumped in [Matter Server 1.0.8](https://github.com/home-assistant-libs/python-matter-server/releases/tag/1.0.8).
+
 ## 1.2.0
 
 - Bump Matter Server to 1.0.8

--- a/matter_server/Dockerfile
+++ b/matter_server/Dockerfile
@@ -1,8 +1,6 @@
 ARG BUILD_FROM
 FROM $BUILD_FROM
 
-ARG HOME_ASSISTANT_CHIP_VERSION
-
 # Set shell
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
@@ -41,9 +39,6 @@ ARG MATTER_SERVER_VERSION
 
 # hadolint ignore=DL3013
 RUN \
-    pip3 install \
-       home-assistant-chip-clusters==${HOME_ASSISTANT_CHIP_VERSION} \
-       home-assistant-chip-core==${HOME_ASSISTANT_CHIP_VERSION} \
-    && pip3 install --no-cache-dir python-matter-server=="${MATTER_SERVER_VERSION}"
+    pip3 install --no-cache-dir python-matter-server[server]=="${MATTER_SERVER_VERSION}"
 
 COPY rootfs /

--- a/matter_server/Dockerfile
+++ b/matter_server/Dockerfile
@@ -39,6 +39,6 @@ ARG MATTER_SERVER_VERSION
 
 # hadolint ignore=DL3013
 RUN \
-   pip3 install --no-cache-dir "python-matter-server[server]"=="${MATTER_SERVER_VERSION}"
+   pip3 install --no-cache-dir "python-matter-server[server]==${MATTER_SERVER_VERSION}"
 
 COPY rootfs /

--- a/matter_server/Dockerfile
+++ b/matter_server/Dockerfile
@@ -5,33 +5,33 @@ FROM $BUILD_FROM
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN \
-   set -x \
-   && apt-get update \
-   && apt-get install -y --no-install-recommends \
-   libuv1 \
-   openssl \
-   zlib1g \
-   libjson-c5 \
-   python3-venv \
-   python3-pip \
-   python3-gi \
-   python3-gi-cairo \
-   python3-dbus \
-   python3-psutil \
-   unzip \
-   libcairo2 \
-   gdb \
-   git \
-   && git clone --depth 1 -b master \
-   https://github.com/project-chip/connectedhomeip \
-   && cp -r connectedhomeip/credentials /root/credentials \
-   && mv /root/credentials/production/paa-root-certs/* \
-   /root/credentials/development/paa-root-certs/ \
-   && rm -rf connectedhomeip \
-   && apt-get purge -y --auto-remove \
-   git \
-   && rm -rf /var/lib/apt/lists/* \
-   && rm -rf /usr/src/*
+    set -x \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+       libuv1 \
+       openssl \
+       zlib1g \
+       libjson-c5 \
+       python3-venv \
+       python3-pip \
+       python3-gi \
+       python3-gi-cairo \
+       python3-dbus \
+       python3-psutil \
+       unzip \
+       libcairo2 \
+       gdb \
+       git \
+    && git clone --depth 1 -b master \
+       https://github.com/project-chip/connectedhomeip \
+    && cp -r connectedhomeip/credentials /root/credentials \
+    && mv /root/credentials/production/paa-root-certs/* \
+          /root/credentials/development/paa-root-certs/ \
+    && rm -rf connectedhomeip \
+    && apt-get purge -y --auto-remove \
+       git \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /usr/src/*
 
 WORKDIR /root
 
@@ -39,6 +39,6 @@ ARG MATTER_SERVER_VERSION
 
 # hadolint ignore=DL3013
 RUN \
-   pip3 install --no-cache-dir "python-matter-server[server]==${MATTER_SERVER_VERSION}"
+    pip3 install --no-cache-dir "python-matter-server[server]==${MATTER_SERVER_VERSION}"
 
 COPY rootfs /

--- a/matter_server/Dockerfile
+++ b/matter_server/Dockerfile
@@ -5,33 +5,33 @@ FROM $BUILD_FROM
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN \
-    set -x \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends \
-       libuv1 \
-       openssl \
-       zlib1g \
-       libjson-c5 \
-       python3-venv \
-       python3-pip \
-       python3-gi \
-       python3-gi-cairo \
-       python3-dbus \
-       python3-psutil \
-       unzip \
-       libcairo2 \
-       gdb \
-       git \
-    && git clone --depth 1 -b master \
-       https://github.com/project-chip/connectedhomeip \
-    && cp -r connectedhomeip/credentials /root/credentials \
-    && mv /root/credentials/production/paa-root-certs/* \
-          /root/credentials/development/paa-root-certs/ \
-    && rm -rf connectedhomeip \
-    && apt-get purge -y --auto-remove \
-       git \
-    && rm -rf /var/lib/apt/lists/* \
-    && rm -rf /usr/src/*
+   set -x \
+   && apt-get update \
+   && apt-get install -y --no-install-recommends \
+   libuv1 \
+   openssl \
+   zlib1g \
+   libjson-c5 \
+   python3-venv \
+   python3-pip \
+   python3-gi \
+   python3-gi-cairo \
+   python3-dbus \
+   python3-psutil \
+   unzip \
+   libcairo2 \
+   gdb \
+   git \
+   && git clone --depth 1 -b master \
+   https://github.com/project-chip/connectedhomeip \
+   && cp -r connectedhomeip/credentials /root/credentials \
+   && mv /root/credentials/production/paa-root-certs/* \
+   /root/credentials/development/paa-root-certs/ \
+   && rm -rf connectedhomeip \
+   && apt-get purge -y --auto-remove \
+   git \
+   && rm -rf /var/lib/apt/lists/* \
+   && rm -rf /usr/src/*
 
 WORKDIR /root
 
@@ -39,6 +39,6 @@ ARG MATTER_SERVER_VERSION
 
 # hadolint ignore=DL3013
 RUN \
-    pip3 install --no-cache-dir python-matter-server[server]=="${MATTER_SERVER_VERSION}"
+   pip3 install --no-cache-dir "python-matter-server[server]"=="${MATTER_SERVER_VERSION}"
 
 COPY rootfs /

--- a/matter_server/README.md
+++ b/matter_server/README.md
@@ -13,3 +13,13 @@ integration communicates via WebSocket with this server.
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
+
+## Matter Server Update Procedure
+
+When updating the server library in the add-on follow these steps:
+
+1. Update the `MATTER_SERVER_VERSION` argument in `build.yaml`.
+2. Check if the chip SDK version has changed in the server library.
+3. If the chip SDK version has changed, set the `homeassistant` key in `config.yaml` to the minimum version of Home Assistant Core required to install or update the add-on. Home Assistant Core needs to have the exact same version of the chip SDK as the server.
+4. Update the add-on version in `config.yaml`.
+5. Update the changelog in `CHANGELOG.md`. Include a markdown link to the GitHub release of the server in the changelog.

--- a/matter_server/README.md
+++ b/matter_server/README.md
@@ -13,13 +13,3 @@ integration communicates via WebSocket with this server.
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
-
-## Matter Server Update Procedure
-
-When updating the server library in the add-on follow these steps:
-
-1. Update the `MATTER_SERVER_VERSION` argument in `build.yaml`.
-2. Check if the chip SDK version has changed in the server library.
-3. If the chip SDK version has changed, set the `homeassistant` key in `config.yaml` to the minimum version of Home Assistant Core required to install or update the add-on. Home Assistant Core needs to have the exact same version of the chip SDK as the server.
-4. Update the add-on version in `config.yaml`.
-5. Update the changelog in `CHANGELOG.md`. Include a markdown link to the GitHub release of the server in the changelog.

--- a/matter_server/RELEASE.md
+++ b/matter_server/RELEASE.md
@@ -1,0 +1,11 @@
+# Release documentation for developers
+
+## Matter Server Update Procedure
+
+When updating the server library in the add-on follow these steps:
+
+1. Update the `MATTER_SERVER_VERSION` argument in `build.yaml`.
+2. Check if the chip SDK version has changed in the server library.
+3. If the chip SDK version has changed, set the `homeassistant` key in `config.yaml` to the minimum version of Home Assistant Core required to install or update the add-on. Home Assistant Core needs to have the exact same version of the chip SDK as the server.
+4. Update the add-on version in `config.yaml`. Bump to a new major version if the chip SDK version was changed.
+5. Update the changelog in `CHANGELOG.md`. Include a markdown link to the GitHub release of the server in the changelog.

--- a/matter_server/build.yaml
+++ b/matter_server/build.yaml
@@ -4,4 +4,3 @@ build_from:
   amd64: ghcr.io/home-assistant/amd64-base-debian:bullseye
 args:
   MATTER_SERVER_VERSION: 1.0.8
-  HOME_ASSISTANT_CHIP_VERSION: 2022.12.0

--- a/matter_server/config.yaml
+++ b/matter_server/config.yaml
@@ -11,6 +11,7 @@ arch:
 discovery:
   - matter
 hassio_api: true
+homeassistant: 2023.1.0b1
 # IPC is only used within the Add-on
 host_ipc: false
 host_network: true

--- a/matter_server/config.yaml
+++ b/matter_server/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 1.2.0
+version: 2.0.0
 slug: matter_server
 name: Matter Server
 description: Matter WebSocket Server for Home Assistant Matter support.


### PR DESCRIPTION
- Set minimum version of Home Assistant Core needed for the add-on. This version is decided based on the chip SDK version available in Home Assistant Core.
- Add update procedure docs for developers of the add-on.
- Simplify docker file installation of chip SDK. It's included in the matter server extra requirements.