### PR TITLE
silabs-multiprotocol: Make HTTP REST server HTTP compliant part 2

### DIFF
--- a/silabs-multiprotocol/0001-web-rest-listen-on-IPv6-addresses-as-well-1659.patch
+++ b/silabs-multiprotocol/0001-web-rest-listen-on-IPv6-addresses-as-well-1659.patch
@@ -1,8 +1,8 @@
 From c2dc2a9940d1f9809403d4dfb28e1f942ef90bab Mon Sep 17 00:00:00 2001
-Message-Id: <c2dc2a9940d1f9809403d4dfb28e1f942ef90bab.1673521948.git.stefan@agner.ch>
+Message-Id: <c2dc2a9940d1f9809403d4dfb28e1f942ef90bab.1673530580.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Fri, 16 Dec 2022 06:20:03 +0100
-Subject: [PATCH 1/9] [web/rest] listen on IPv6 addresses as well (#1659)
+Subject: [PATCH 01/10] [web/rest] listen on IPv6 addresses as well (#1659)
 
 Make the Web and REST API listen on IPv4 and IPv6 by default.
 

--- a/silabs-multiprotocol/0002-rest-add-active-dataset-API-1658.patch
+++ b/silabs-multiprotocol/0002-rest-add-active-dataset-API-1658.patch
@@ -1,10 +1,10 @@
 From 9a624b0ce0f5565a94663693f7690367c95c9d9b Mon Sep 17 00:00:00 2001
-Message-Id: <9a624b0ce0f5565a94663693f7690367c95c9d9b.1673521948.git.stefan@agner.ch>
-In-Reply-To: <c2dc2a9940d1f9809403d4dfb28e1f942ef90bab.1673521948.git.stefan@agner.ch>
-References: <c2dc2a9940d1f9809403d4dfb28e1f942ef90bab.1673521948.git.stefan@agner.ch>
+Message-Id: <9a624b0ce0f5565a94663693f7690367c95c9d9b.1673530580.git.stefan@agner.ch>
+In-Reply-To: <c2dc2a9940d1f9809403d4dfb28e1f942ef90bab.1673530580.git.stefan@agner.ch>
+References: <c2dc2a9940d1f9809403d4dfb28e1f942ef90bab.1673530580.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Fri, 16 Dec 2022 07:34:07 +0100
-Subject: [PATCH 2/9] [rest] add active dataset API (#1658)
+Subject: [PATCH 02/10] [rest] add active dataset API (#1658)
 
 Support setting active dataset using HTTP PUT method. The body
 needs to be formatted as a hex string representing the operational

--- a/silabs-multiprotocol/0003-rest-use-map-for-HTTP-headers-1665.patch
+++ b/silabs-multiprotocol/0003-rest-use-map-for-HTTP-headers-1665.patch
@@ -1,10 +1,10 @@
 From 1fd0572e7ceeb0f7dff59f7a9bdbe8519fb332ec Mon Sep 17 00:00:00 2001
-Message-Id: <1fd0572e7ceeb0f7dff59f7a9bdbe8519fb332ec.1673521948.git.stefan@agner.ch>
-In-Reply-To: <c2dc2a9940d1f9809403d4dfb28e1f942ef90bab.1673521948.git.stefan@agner.ch>
-References: <c2dc2a9940d1f9809403d4dfb28e1f942ef90bab.1673521948.git.stefan@agner.ch>
+Message-Id: <1fd0572e7ceeb0f7dff59f7a9bdbe8519fb332ec.1673530580.git.stefan@agner.ch>
+In-Reply-To: <c2dc2a9940d1f9809403d4dfb28e1f942ef90bab.1673530580.git.stefan@agner.ch>
+References: <c2dc2a9940d1f9809403d4dfb28e1f942ef90bab.1673530580.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Tue, 20 Dec 2022 07:22:01 +0100
-Subject: [PATCH 3/9] [rest] use map for HTTP headers (#1665)
+Subject: [PATCH 03/10] [rest] use map for HTTP headers (#1665)
 
 (cherry picked from commit 2ff52570fdb1a2daa7c93e0aae7e6cb551322252)
 ---

--- a/silabs-multiprotocol/0005-web-bump-to-latest-Simple-Web-Server-version-1667.patch
+++ b/silabs-multiprotocol/0005-web-bump-to-latest-Simple-Web-Server-version-1667.patch
@@ -1,10 +1,10 @@
 From 2e2f6018e1ae48432f5b9eec97f7ca737a3cd871 Mon Sep 17 00:00:00 2001
-Message-Id: <2e2f6018e1ae48432f5b9eec97f7ca737a3cd871.1673521948.git.stefan@agner.ch>
-In-Reply-To: <c2dc2a9940d1f9809403d4dfb28e1f942ef90bab.1673521948.git.stefan@agner.ch>
-References: <c2dc2a9940d1f9809403d4dfb28e1f942ef90bab.1673521948.git.stefan@agner.ch>
+Message-Id: <2e2f6018e1ae48432f5b9eec97f7ca737a3cd871.1673530580.git.stefan@agner.ch>
+In-Reply-To: <c2dc2a9940d1f9809403d4dfb28e1f942ef90bab.1673530580.git.stefan@agner.ch>
+References: <c2dc2a9940d1f9809403d4dfb28e1f942ef90bab.1673530580.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Thu, 22 Dec 2022 16:34:59 +0100
-Subject: [PATCH 5/9] [web] bump to latest Simple-Web-Server version (#1667)
+Subject: [PATCH 05/10] [web] bump to latest Simple-Web-Server version (#1667)
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit

--- a/silabs-multiprotocol/0006-rest-allow-to-specify-REST-listen-address-1670.patch
+++ b/silabs-multiprotocol/0006-rest-allow-to-specify-REST-listen-address-1670.patch
@@ -1,10 +1,10 @@
 From 8959300846adcd0d8dc43c553d54cbc753a7c942 Mon Sep 17 00:00:00 2001
-Message-Id: <8959300846adcd0d8dc43c553d54cbc753a7c942.1673521948.git.stefan@agner.ch>
-In-Reply-To: <c2dc2a9940d1f9809403d4dfb28e1f942ef90bab.1673521948.git.stefan@agner.ch>
-References: <c2dc2a9940d1f9809403d4dfb28e1f942ef90bab.1673521948.git.stefan@agner.ch>
+Message-Id: <8959300846adcd0d8dc43c553d54cbc753a7c942.1673530580.git.stefan@agner.ch>
+In-Reply-To: <c2dc2a9940d1f9809403d4dfb28e1f942ef90bab.1673530580.git.stefan@agner.ch>
+References: <c2dc2a9940d1f9809403d4dfb28e1f942ef90bab.1673530580.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Fri, 23 Dec 2022 04:00:41 +0100
-Subject: [PATCH 6/9] [rest] allow to specify REST listen address (#1670)
+Subject: [PATCH 06/10] [rest] allow to specify REST listen address (#1670)
 
 Allow to bind to a specific address to listen to for REST requests. This
 allows to limit access to the REST interface e.g. from localhost only.

--- a/silabs-multiprotocol/0007-rest-implement-REST-API-to-get-dataset.patch
+++ b/silabs-multiprotocol/0007-rest-implement-REST-API-to-get-dataset.patch
@@ -1,10 +1,10 @@
 From daad0f74723bd5dfb63302ad07bd9e0aefcf9c1f Mon Sep 17 00:00:00 2001
-Message-Id: <daad0f74723bd5dfb63302ad07bd9e0aefcf9c1f.1673521948.git.stefan@agner.ch>
-In-Reply-To: <c2dc2a9940d1f9809403d4dfb28e1f942ef90bab.1673521948.git.stefan@agner.ch>
-References: <c2dc2a9940d1f9809403d4dfb28e1f942ef90bab.1673521948.git.stefan@agner.ch>
+Message-Id: <daad0f74723bd5dfb63302ad07bd9e0aefcf9c1f.1673530580.git.stefan@agner.ch>
+In-Reply-To: <c2dc2a9940d1f9809403d4dfb28e1f942ef90bab.1673530580.git.stefan@agner.ch>
+References: <c2dc2a9940d1f9809403d4dfb28e1f942ef90bab.1673530580.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Fri, 23 Dec 2022 10:39:34 +0100
-Subject: [PATCH 7/9] [rest] implement REST API to get dataset
+Subject: [PATCH 07/10] [rest] implement REST API to get dataset
 
 ---
  src/rest/json.cpp     | 355 +++++++++++++++++++++++++++++++

--- a/silabs-multiprotocol/0008-rest-support-state-change.patch
+++ b/silabs-multiprotocol/0008-rest-support-state-change.patch
@@ -1,10 +1,10 @@
 From 5f38366d5e4c904d2ff2becbfae5a9fbe0ecaaf9 Mon Sep 17 00:00:00 2001
-Message-Id: <5f38366d5e4c904d2ff2becbfae5a9fbe0ecaaf9.1673521948.git.stefan@agner.ch>
-In-Reply-To: <c2dc2a9940d1f9809403d4dfb28e1f942ef90bab.1673521948.git.stefan@agner.ch>
-References: <c2dc2a9940d1f9809403d4dfb28e1f942ef90bab.1673521948.git.stefan@agner.ch>
+Message-Id: <5f38366d5e4c904d2ff2becbfae5a9fbe0ecaaf9.1673530580.git.stefan@agner.ch>
+In-Reply-To: <c2dc2a9940d1f9809403d4dfb28e1f942ef90bab.1673530580.git.stefan@agner.ch>
+References: <c2dc2a9940d1f9809403d4dfb28e1f942ef90bab.1673530580.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Wed, 28 Dec 2022 11:46:25 +0100
-Subject: [PATCH 8/9] [rest] support state change
+Subject: [PATCH 08/10] [rest] support state change
 
 ---
  src/rest/openapi.yaml | 16 +++++++++++++

--- a/silabs-multiprotocol/0009-rest-remove-superfluous-space-in-HTTP-status-line.patch
+++ b/silabs-multiprotocol/0009-rest-remove-superfluous-space-in-HTTP-status-line.patch
@@ -1,10 +1,10 @@
 From 40440fd30df9dcfc8090c11b2e0a6c7cbd49d1c8 Mon Sep 17 00:00:00 2001
-Message-Id: <40440fd30df9dcfc8090c11b2e0a6c7cbd49d1c8.1673521948.git.stefan@agner.ch>
-In-Reply-To: <c2dc2a9940d1f9809403d4dfb28e1f942ef90bab.1673521948.git.stefan@agner.ch>
-References: <c2dc2a9940d1f9809403d4dfb28e1f942ef90bab.1673521948.git.stefan@agner.ch>
+Message-Id: <40440fd30df9dcfc8090c11b2e0a6c7cbd49d1c8.1673530580.git.stefan@agner.ch>
+In-Reply-To: <c2dc2a9940d1f9809403d4dfb28e1f942ef90bab.1673530580.git.stefan@agner.ch>
+References: <c2dc2a9940d1f9809403d4dfb28e1f942ef90bab.1673530580.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Thu, 12 Jan 2023 12:10:47 +0100
-Subject: [PATCH 9/9] [rest] remove superfluous space in HTTP status line
+Subject: [PATCH 09/10] [rest] remove superfluous space in HTTP status line
 
 ---
  src/rest/response.cpp | 2 +-

--- a/silabs-multiprotocol/0010-rest-explicitly-set-Connection-header-to-close.patch
+++ b/silabs-multiprotocol/0010-rest-explicitly-set-Connection-header-to-close.patch
@@ -1,0 +1,42 @@
+From 65a87b8e2beabccf22fe5fc27cacb98dd9ba05dc Mon Sep 17 00:00:00 2001
+Message-Id: <65a87b8e2beabccf22fe5fc27cacb98dd9ba05dc.1673530580.git.stefan@agner.ch>
+In-Reply-To: <c2dc2a9940d1f9809403d4dfb28e1f942ef90bab.1673530580.git.stefan@agner.ch>
+References: <c2dc2a9940d1f9809403d4dfb28e1f942ef90bab.1673530580.git.stefan@agner.ch>
+From: Stefan Agner <stefan@agner.ch>
+Date: Thu, 12 Jan 2023 14:35:04 +0100
+Subject: [PATCH 10/10] [rest] explicitly set Connection header to close
+
+By default, HTTP 1.1 connections should stay open after a transaction.
+However, that is not how the current REST server implementation behaves:
+After each transaction the HTTP connection is being closed by the
+server.
+
+Set the Connection header to "close" to tell the client about this
+behavior.
+---
+ src/rest/response.cpp | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/rest/response.cpp b/src/rest/response.cpp
+index 540a0840e0..5c08fd77b4 100644
+--- a/src/rest/response.cpp
++++ b/src/rest/response.cpp
+@@ -35,6 +35,7 @@
+     "Access-Control-Allow-Headers, Origin,Accept, X-Requested-With, Content-Type, Access-Control-Request-Method, " \
+     "Access-Control-Request-Headers"
+ #define OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_METHOD "GET, OPTIONS, POST, PUT"
++#define OT_REST_RESPONSE_CONNECTION "close"
+ 
+ namespace otbr {
+ namespace rest {
+@@ -51,6 +52,7 @@ Response::Response(void)
+     mHeaders["Access-Control-Allow-Origin"]  = OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_ORIGIN;
+     mHeaders["Access-Control-Allow-Methods"] = OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_METHOD;
+     mHeaders["Access-Control-Allow-Headers"] = OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_HEADERS;
++    mHeaders["Connection"]                   = OT_REST_RESPONSE_CONNECTION;
+ }
+ 
+ void Response::SetComplete()
+-- 
+2.39.0
+

--- a/silabs-multiprotocol/CHANGELOG.md
+++ b/silabs-multiprotocol/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.11.4
+
+- Fix REST API to correctly set the Connection HTTP header
+
 ## 0.11.3
 
 - Fix REST API to return an HTTP compliant status line

--- a/silabs-multiprotocol/Dockerfile
+++ b/silabs-multiprotocol/Dockerfile
@@ -154,6 +154,7 @@ COPY 0006-rest-allow-to-specify-REST-listen-address-1670.patch /usr/src
 COPY 0007-rest-implement-REST-API-to-get-dataset.patch /usr/src
 COPY 0008-rest-support-state-change.patch /usr/src
 COPY 0009-rest-remove-superfluous-space-in-HTTP-status-line.patch /usr/src
+COPY 0010-rest-explicitly-set-Connection-header-to-close.patch /usr/src
 
 # Required and installed during build (script/bootstrap), could be removed
 ENV OTBR_BUILD_DEPS build-essential ninja-build cmake wget ca-certificates \
@@ -190,6 +191,7 @@ RUN \
     && patch -p1 < /usr/src/0007-rest-implement-REST-API-to-get-dataset.patch \
     && patch -p1 < /usr/src/0008-rest-support-state-change.patch \
     && patch -p1 < /usr/src/0009-rest-remove-superfluous-space-in-HTTP-status-line.patch \
+    && patch -p1 < /usr/src/0010-rest-explicitly-set-Connection-header-to-close.patch \
     && chmod +x ./script/bootstrap \
     && ./script/bootstrap \
     && ln -s ../../../openthread/ third_party/openthread/repo \

--- a/silabs-multiprotocol/config.yaml
+++ b/silabs-multiprotocol/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.11.3
+version: 0.11.4
 slug: silabs_multiprotocol
 name: Silicon Labs Multiprotocol
 description: Zigbee and OpenThread multiprotocol add-on


### PR DESCRIPTION
Explicitly set `Connection` header to `close` to tell the client that the server closes the TCP/IP connection after each request.