### PR TITLE
Bump deCONZ to 2.20.1 (stable)

### DIFF
--- a/deconz/CHANGELOG.md
+++ b/deconz/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.17.2
+
+- Bump deCONZ to 2.20.1
+
 ## 6.17.1
 
 - Bump deCONZ to 2.19.3

--- a/deconz/build.yaml
+++ b/deconz/build.yaml
@@ -7,4 +7,4 @@ codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
 args:
-  DECONZ_VERSION: 2.19.03
+  DECONZ_VERSION: 2.20.01

--- a/deconz/config.yaml
+++ b/deconz/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 6.17.1
+version: 6.17.2
 slug: deconz
 name: deCONZ
 description: >-


### PR DESCRIPTION
The current stable version of deCONZ have some stability issues. See #2783.

The stable version 2.20.1 don't contain all fix but it's way better than current 2.19.3.