### PR TITLE
Bump Matter Server to 2.0.1 and set Vendor ID

### DIFF
--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -3,7 +3,11 @@
 ## 3.0.0
 
 - Bump Matter Server to 2.0.1
-- Use Nabu Casa Vendor ID by default (requires recommissioning of devices)
+- Use Nabu Casa Vendor ID by default
+
+### Breaking
+
+- All commissioned devices need to be recommissioned.
 
 ## 2.1.0
 

--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.0.0
 
-- Bump Matter Server to 2.0.0
+- Bump Matter Server to 2.0.1
 - Use Nabu Casa Vendor ID by default (requires recommissioning of devices)
 
 ## 2.1.0

--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.0.0
+
+- Bump Matter Server to 2.0.0
+- Use Nabu Casa Vendor ID by default (requires recommissioning of devices)
+
 ## 2.1.0
 
 - Bump Matter Server to 1.1.0

--- a/matter_server/build.yaml
+++ b/matter_server/build.yaml
@@ -3,4 +3,4 @@ build_from:
   aarch64: ghcr.io/home-assistant/aarch64-base-debian:bullseye
   amd64: ghcr.io/home-assistant/amd64-base-debian:bullseye
 args:
-  MATTER_SERVER_VERSION: 2.0.0
+  MATTER_SERVER_VERSION: 2.0.1

--- a/matter_server/build.yaml
+++ b/matter_server/build.yaml
@@ -3,4 +3,4 @@ build_from:
   aarch64: ghcr.io/home-assistant/aarch64-base-debian:bullseye
   amd64: ghcr.io/home-assistant/amd64-base-debian:bullseye
 args:
-  MATTER_SERVER_VERSION: 1.1.0
+  MATTER_SERVER_VERSION: 2.0.0

--- a/matter_server/config.yaml
+++ b/matter_server/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 2.1.0
+version: 3.0.0
 slug: matter_server
 name: Matter Server
 description: Matter WebSocket Server for Home Assistant Matter support.
@@ -11,7 +11,7 @@ arch:
 discovery:
   - matter
 hassio_api: true
-homeassistant: 2023.1.0b1
+homeassistant: 2023.2.0b0
 # IPC is only used within the Add-on
 host_ipc: false
 host_network: true

--- a/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
+++ b/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
@@ -26,4 +26,4 @@ fi
 cd /root
 
 exec matter-server --storage-path "/data" --port "${server_port}" \
-                   --log-level "${log_level}"
+                   --log-level "${log_level}" --vendorid 4939


### PR DESCRIPTION
Not to be merged until HA 2023.2 beta 0 builds done