### PR TITLE
Fix matter server fabric id

### DIFF
--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.0.1
+
+- Bump Matter Server fabric ID after changing vendor ID
+
 ## 3.0.0
 
 - Bump Matter Server to 2.0.1

--- a/matter_server/config.yaml
+++ b/matter_server/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 3.0.0
+version: 3.0.1
 slug: matter_server
 name: Matter Server
 description: Matter WebSocket Server for Home Assistant Matter support.

--- a/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
+++ b/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
@@ -26,4 +26,5 @@ fi
 cd /root
 
 exec matter-server --storage-path "/data" --port "${server_port}" \
-                   --log-level "${log_level}" --vendorid 4939
+                   --log-level "${log_level}" \
+                   --fabricid 2 --vendorid 4939


### PR DESCRIPTION
- We changed the vendor ID in version 3.0.0 of the add-on. We didn't update the fabric ID at the same time, which caused a collision for add-ons that updated to 3.0.0 with existing persistent data.
  ```
  ValueError: Provided fabricId of 1 collides with an existing FabricAdmin instance!
  ```
- Fix this by bumping the fabric ID.