### PR TITLE
Bump python-matter-server to 2.0.2

### DIFF
--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.0.2
+
+- Bump Matter Server to [2.0.2](https://github.com/home-assistant-libs/python-matter-server/releases/tag/2.0.2)
+
 ## 3.0.1
 
 - Bump Matter Server fabric ID after changing vendor ID

--- a/matter_server/build.yaml
+++ b/matter_server/build.yaml
@@ -3,4 +3,4 @@ build_from:
   aarch64: ghcr.io/home-assistant/aarch64-base-debian:bullseye
   amd64: ghcr.io/home-assistant/amd64-base-debian:bullseye
 args:
-  MATTER_SERVER_VERSION: 2.0.1
+  MATTER_SERVER_VERSION: 2.0.2

--- a/matter_server/config.yaml
+++ b/matter_server/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 3.0.1
+version: 3.0.2
 slug: matter_server
 name: Matter Server
 description: Matter WebSocket Server for Home Assistant Matter support.


### PR DESCRIPTION
- https://github.com/home-assistant-libs/python-matter-server/releases/tag/2.0.2