### PR TITLE
Change the default multi-PAN baudrate option type to be a string

### DIFF
--- a/silabs-multiprotocol/config.yaml
+++ b/silabs-multiprotocol/config.yaml
@@ -23,7 +23,7 @@ image: homeassistant/{arch}-addon-silabs-multiprotocol
 init: false
 options:
   device: null
-  baudrate: 115200
+  baudrate: "115200"
   flow_control: true
   autoflash_firmware: false
   cpcd_trace: false


### PR DESCRIPTION
The data type of the default should match one of the string options for the default to appear. Otherwise, nothing is selected:

<img width="155" alt="image" src="https://user-images.githubusercontent.com/32534428/215027137-74246c2d-09a6-4288-b1ff-ebb9e26d7a7c.png">
