### PR TITLE
nginx_proxy documentation update: clarified configuration.

### DIFF
--- a/nginx_proxy/DOCS.md
+++ b/nginx_proxy/DOCS.md
@@ -17,7 +17,7 @@ The NGINX Proxy add-on is commonly used in conjunction with the [Duck DNS](https
    - `ssl_certificate`
    - `ssl_key`
    - `server_port`
-3. And you need to add the `trusted_proxies` section (requests from reverse proxies will be blocked if these options are not set).
+3. And you need to add the `trusted_proxies` section (requests from reverse proxies will be blocked if these options are not set). Restart the Home Assistant Core service after this change from `Developer Tools -> Restart`.
 
    ```yaml
    http:


### PR DESCRIPTION
This is a simple documentation update that clarifies that you need to restart the core service after you updated the `configuration.yaml`. This is necessary for the setting to "enable reverse proxies to access the frontend" to apply.

This is a trivial step for veteran Home Assistant users. But as a newbie, I spent days understanding Home Assistant's underlying structure (and the clever use of shared docker volumes) until I realized my trivial mistake. I hope this saves some time for others in the future.