### PR TITLE
Remove all multi-PAN OTBR dependencies when it is disabled

### DIFF
--- a/silabs-multiprotocol/rootfs/etc/s6-overlay/scripts/otbr-enable-check.sh
+++ b/silabs-multiprotocol/rootfs/etc/s6-overlay/scripts/otbr-enable-check.sh
@@ -6,5 +6,6 @@
 if bashio::config.false 'otbr_enable'; then
     rm /etc/s6-overlay/s6-rc.d/user/contents.d/otbr-agent
     rm /etc/s6-overlay/s6-rc.d/user/contents.d/otbr-web
+    rm /etc/s6-overlay/s6-rc.d/user/contents.d/otbr-agent-rest-discovery
     bashio::log.info "The otbr-agent is disabled."
 fi


### PR DESCRIPTION
Otherwise, OTBR will be started even if it is disabled.