### PR TITLE
Allow ha commands without an interactive shell

### DIFF
--- a/ssh/CHANGELOG.md
+++ b/ssh/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 9.6.2
+
+- Make SUPERVISOR_TOKEN available as an SSH environment variable,
+  making it possible to invoke the Home Assistant CLI
+  without an interactive bash session.
+
 ## 9.6.1
 
 - Upgrade Home Assistant CLI to 4.21.0

--- a/ssh/config.yaml
+++ b/ssh/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 9.6.1
+version: 9.6.2
 slug: ssh
 name: Terminal & SSH
 description: Allow logging in remotely to Home Assistant using SSH

--- a/ssh/rootfs/etc/cont-init.d/ssh.sh
+++ b/ssh/rootfs/etc/cont-init.d/ssh.sh
@@ -13,6 +13,13 @@ chmod 700 /data/.ssh \
     || bashio::exit.nok \
         'Failed setting permissions on persistent .ssh folder'
 
+# Make Home Assistant TOKEN available for non-interactive SSH commands
+bashio::var.json \
+    supervisor_token "${SUPERVISOR_TOKEN}" \
+    | tempio \
+        -template /usr/share/tempio/ssh.environment \
+        -out /data/.ssh/environment
+
 if bashio::config.has_value 'authorized_keys'; then
     bashio::log.info "Setup authorized_keys"
 

--- a/ssh/rootfs/usr/share/tempio/ssh.environment
+++ b/ssh/rootfs/usr/share/tempio/ssh.environment
@@ -1,0 +1,1 @@
+SUPERVISOR_TOKEN={{ .supervisor_token }}

--- a/ssh/rootfs/usr/share/tempio/sshd_config
+++ b/ssh/rootfs/usr/share/tempio/sshd_config
@@ -24,3 +24,4 @@ PasswordAuthentication yes
 PermitEmptyPasswords no
 {{ end }}
 
+PermitUserEnvironment SUPERVISOR_TOKEN


### PR DESCRIPTION
The `ha` command works if you log in through SSH and then run the command in bash, but it gives an error if invoked directly like this:

	$ ssh root@hostname ha info --raw-json
	Unexpected server response. Status code: 401
	time="2023-02-11T14:42:33+01:00" level=error msg="Unexpected server response. Status code: 401"

This is caused by a missing `SUPERVISOR_TOKEN` environment variable. This variable is set in `/etc/profile.d/homeassistant.sh`, which is only sourced for an interactive bash session.

This PR adds a `/root/.ssh/environment` file containing the `SUPERVISOR_TOKEN` environment variable. This file is read by SSH so the environment variable is also available in a non-interactive shell. A direct invocation of `ha` over SSH now works:

	$ ssh root@hostname ha info --raw-json
	{"result": "ok", "data": {"supervisor": "REDACTED", "homeassistant": "REDACTED", "hassos": "REDACTED", "docker": "REDACTED", "hostname": "REDACTED", "operating_system": "Home Assistant OS REDACTED", "features": ["reboot", "shutdown", "services", "network", "hostname", "timedate", "os_agent", "haos", "resolved", "journal"], "machine": "generic-x86-64", "arch": "amd64", "state": "running", "supported_arch": ["amd64", "i386"], "supported": true, "channel": "stable", "logging": "info", "timezone": "Europe/REDACTED"}}
