### PR TITLE
Bump python-matter-server to 2.1.0

### DIFF
--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## 3.0.3
 
 - Bump Matter Server to [2.1.0](https://github.com/home-assistant-libs/python-matter-server/releases/tag/2.1.0)
-- Drop unnecessary Python dependencies from image
 
 ## 3.0.2
 

--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.0.3
+
+- Bump Matter Server to [2.1.0](https://github.com/home-assistant-libs/python-matter-server/releases/tag/2.1.0)
+- Drop unnecessary Python dependencies from image
+
 ## 3.0.2
 
 - Bump Matter Server to [2.0.2](https://github.com/home-assistant-libs/python-matter-server/releases/tag/2.0.2)

--- a/matter_server/Dockerfile
+++ b/matter_server/Dockerfile
@@ -14,6 +14,9 @@ RUN \
        libjson-c5 \
        python3-venv \
        python3-pip \
+       python3-gi \
+       python3-gi-cairo \
+       python3-dbus \
        python3-psutil \
        unzip \
        libcairo2 \

--- a/matter_server/Dockerfile
+++ b/matter_server/Dockerfile
@@ -14,9 +14,6 @@ RUN \
        libjson-c5 \
        python3-venv \
        python3-pip \
-       python3-gi \
-       python3-gi-cairo \
-       python3-dbus \
        python3-psutil \
        unzip \
        libcairo2 \

--- a/matter_server/build.yaml
+++ b/matter_server/build.yaml
@@ -3,4 +3,4 @@ build_from:
   aarch64: ghcr.io/home-assistant/aarch64-base-debian:bullseye
   amd64: ghcr.io/home-assistant/amd64-base-debian:bullseye
 args:
-  MATTER_SERVER_VERSION: 2.0.2
+  MATTER_SERVER_VERSION: 2.1.0

--- a/matter_server/config.yaml
+++ b/matter_server/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 3.0.2
+version: 3.0.3
 slug: matter_server
 name: Matter Server
 description: Matter WebSocket Server for Home Assistant Matter support.
@@ -11,7 +11,7 @@ arch:
 discovery:
   - matter
 hassio_api: true
-homeassistant: 2023.2.0b0
+homeassistant: 2023.2.5
 # IPC is only used within the Add-on
 host_ipc: false
 host_network: true


### PR DESCRIPTION
This allwos to drop some unnecessary Python dependencies.