### PR TITLE
Bump python-matter-server to 2.1.1

### DIFF
--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.0.4
+
+- Bump Matter Server to [2.1.1](https://github.com/home-assistant-libs/python-matter-server/releases/tag/2.1.1)
+- Drop unnecessary Python dependencies from image
+
 ## 3.0.3
 
 - Bump Matter Server to [2.1.0](https://github.com/home-assistant-libs/python-matter-server/releases/tag/2.1.0)

--- a/matter_server/Dockerfile
+++ b/matter_server/Dockerfile
@@ -14,9 +14,6 @@ RUN \
        libjson-c5 \
        python3-venv \
        python3-pip \
-       python3-gi \
-       python3-gi-cairo \
-       python3-dbus \
        python3-psutil \
        unzip \
        libcairo2 \

--- a/matter_server/build.yaml
+++ b/matter_server/build.yaml
@@ -3,4 +3,4 @@ build_from:
   aarch64: ghcr.io/home-assistant/aarch64-base-debian:bullseye
   amd64: ghcr.io/home-assistant/amd64-base-debian:bullseye
 args:
-  MATTER_SERVER_VERSION: 2.1.0
+  MATTER_SERVER_VERSION: 2.1.1

--- a/matter_server/config.yaml
+++ b/matter_server/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 3.0.3
+version: 3.0.4
 slug: matter_server
 name: Matter Server
 description: Matter WebSocket Server for Home Assistant Matter support.


### PR DESCRIPTION
This allows to drop some unnecessary Python dependencies.