### PR TITLE
Allow pre-hashed passwords in mosquitto logins config.

### DIFF
--- a/mosquitto/rootfs/etc/cont-init.d/mosquitto.sh
+++ b/mosquitto/rootfs/etc/cont-init.d/mosquitto.sh
@@ -49,7 +49,13 @@ for login in $(bashio::config 'logins|keys'); do
   password=$(bashio::config "logins[${login}].password")
 
   bashio::log.info "Setting up user ${username}"
-  password=$(pw -p "${password}")
+  if ! { test "$(bashio::string.substring "${password}" 0 14)" == 'PBKDF2$sha512$' \
+      && test "$(bashio::string.length "${password}")" == 134; }
+  then
+      password=$(pw -p "${password}")
+  else
+      bashio::log.info "Using pre-hashed password for ${username}"
+  fi
   echo "${username}:${password}" >> "${PW}"
   echo "user ${username}" >> "${ACL}"
 done


### PR DESCRIPTION
I would like to not hard-code visible passwords in my configuration files. It is possible to pass a pre-hashed password to mosquitto, and this PR adds the ability to use such a value.

This change adds the ability to pass already-hashed passwords in the logins array. If the password begins `PBKDF2$sha512$` and has length 134, it is not hashed again and is incorporated directly into the `pw` file. Otherwise, the existing logic is used.

I have tested these changes locally and found that they worked as expected.

Things I considered but did not implement:

- using a new `password_hash` key in the configuration: I didn't do this because the schema doesn't let you specify mutually-exclusive or "exactly one of these" options, so instead I decided to re-use the existing password key
- doing more in-depth checks against the hash: it seems unlikely that someone would choose a password that matches the format of a PBKDF2 hash and is so long
- checking for other hashing algorithms: it is my understanding from https://github.com/home-assistant/addons/blob/35d99c4f8b484802bebe8c72bb53c12d6f8e0a24/mosquitto/rootfs/usr/share/tempio/mosquitto.gtpl#L19 that only PBKDF2 can be used