### PR TITLE
silabs-multiprotocol: various small fixes

### DIFF
--- a/silabs-multiprotocol/CHANGELOG.md
+++ b/silabs-multiprotocol/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.13.1
+
+- Set default baudrate 115200 correctly
+- Prevent OTBR discovery service from start when OTBR is disabled
+- Fix REST API to correctly set the Connection HTTP header on amd64
+- Fix network device support (properly start socat if necessary) on amd64
+
 ## 0.13.0
 
 - Use Silicon Labs Gecko SDK 4.2.1

--- a/silabs-multiprotocol/Dockerfile.amd64
+++ b/silabs-multiprotocol/Dockerfile.amd64
@@ -159,6 +159,7 @@ COPY 0006-rest-allow-to-specify-REST-listen-address-1670.patch /usr/src
 COPY 0007-rest-implement-REST-API-to-get-dataset.patch /usr/src
 COPY 0008-rest-support-state-change.patch /usr/src
 COPY 0009-rest-remove-superfluous-space-in-HTTP-status-line.patch /usr/src
+COPY 0010-rest-explicitly-set-Connection-header-to-close.patch /usr/src
 
 # Required and installed during build (script/bootstrap), could be removed
 ENV OTBR_BUILD_DEPS build-essential ninja-build cmake wget ca-certificates \
@@ -195,6 +196,7 @@ RUN \
     && patch -p1 < /usr/src/0007-rest-implement-REST-API-to-get-dataset.patch \
     && patch -p1 < /usr/src/0008-rest-support-state-change.patch \
     && patch -p1 < /usr/src/0009-rest-remove-superfluous-space-in-HTTP-status-line.patch \
+    && patch -p1 < /usr/src/0010-rest-explicitly-set-Connection-header-to-close.patch \
     && chmod +x ./script/bootstrap \
     && ./script/bootstrap \
     && ln -s ../../../openthread/ third_party/openthread/repo \

--- a/silabs-multiprotocol/Dockerfile.amd64
+++ b/silabs-multiprotocol/Dockerfile.amd64
@@ -239,7 +239,7 @@ COPY rootfs /
 COPY rootfs.amd64 /
 
 ENV \
-    S6_STAGE2_HOOK=/etc/s6-overlay/scripts/otbr-enable-check.sh
+    S6_STAGE2_HOOK=/etc/s6-overlay/scripts/enable-check.sh
 
 HEALTHCHECK --interval=10s --start-period=120s CMD [ "$(s6-svstat -u /run/service/zigbeed)" = "true" ]
 

--- a/silabs-multiprotocol/config.yaml
+++ b/silabs-multiprotocol/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.13.0
+version: 0.13.1
 slug: silabs_multiprotocol
 name: Silicon Labs Multiprotocol
 description: Zigbee and OpenThread multiprotocol add-on

--- a/silabs-multiprotocol/rootfs/etc/s6-overlay/scripts/universal-silabs-flasher-up
+++ b/silabs-multiprotocol/rootfs/etc/s6-overlay/scripts/universal-silabs-flasher-up
@@ -12,6 +12,11 @@ declare usb_manufacturer
 declare usb_product
 declare gpio_reset_flag
 
+function exit_no_firmware {
+    bashio::log.warning "No firmware found for the selected device, assuming firmware is installed."
+    exit 0
+}
+
 device=$(bashio::config 'device')
 baudrate=$(bashio::config 'baudrate')
 
@@ -29,18 +34,23 @@ else
     # Check device manufacturer/product information
     usb_device_path=$(realpath /sys/class/tty/$(readlink /sys/class/tty/$(basename ${device}))/../../../../)
     if [ ! -f "${usb_device_path}/idProduct" ]; then
-        bashio::log.warning "The serial port seems not to be a USB device"
-        s6-svc -d /run/service/universal-silabs-flasher
+        bashio::log.info "The selected serial port is not a USB device."
+        exit_no_firmware
     fi
+
+    if [ ! -f "${usb_device_path}/manufacturer" ] || [ ! -f "${usb_device_path}/product" ]; then
+        bashio::log.info "USB device is missing manufacturer or product name."
+        exit_no_firmware
+    fi
+
     usb_manufacturer=$(cat "${usb_device_path}/manufacturer")
     usb_product=$(cat "${usb_device_path}/product")
 
-    bashio::log.info "Checking ${device} identifying ${usb_product} from ${usb_manufacturer}"
+    bashio::log.info "Checking ${device} identifying ${usb_product} from ${usb_manufacturer}."
     if [[ "${usb_manufacturer}" == "Nabu Casa" && "${usb_product}" == "SkyConnect"* ]]; then
         firmware="NabuCasa_SkyConnect_RCP_v4.2.1_rcp-uart-hw-802154_115200.gbl"
     else
-        bashio::log.info "No valid firmware for this device"
-        s6-svc -d /run/service/universal-silabs-flasher
+        exit_no_firmware
     fi
     gpio_reset_flag=""
 fi


### PR DESCRIPTION
This adds the following fixes:

- Fix REST API to correctly set the Connection HTTP header on amd64
- Fix network device support (properly start socat if necessary) on amd64

Fixes: #2874

And creates a new version with the currently pending fixes included in the changelog.

