### PR TITLE
Bump zwave-js to 10.10.0 and zwave-js-server to 1.26.0

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.1.76
+
+- [Bump Z-Wave JS Server to 1.26.0](https://github.com/zwave-js/zwave-js-server/releases/tag/1.26.0)
+- [Bump Z-Wave JS to 10.10.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v10.10.0)
+
 ## 0.1.75
 
 - [Bump Z-Wave JS Server to 1.25.0](https://github.com/zwave-js/zwave-js-server/releases/tag/1.25.0)

--- a/zwave_js/build.yaml
+++ b/zwave_js/build.yaml
@@ -9,5 +9,5 @@ codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
 args:
-  ZWAVEJS_SERVER_VERSION: 1.25.0
-  ZWAVEJS_VERSION: 10.5.4
+  ZWAVEJS_SERVER_VERSION: 1.26.0
+  ZWAVEJS_VERSION: 10.10.0

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.1.75
+version: 0.1.76
 slug: zwave_js
 name: Z-Wave JS
 description: Control a Z-Wave network with Home Assistant Z-Wave JS


### PR DESCRIPTION
server changelog: https://github.com/zwave-js/zwave-js-server/releases/tag/1.26.0

zwave-js changelogs:
- https://github.com/zwave-js/node-zwave-js/releases/tag/v10.5.5
- https://github.com/zwave-js/node-zwave-js/releases/tag/v10.5.6
- https://github.com/zwave-js/node-zwave-js/releases/tag/v10.6.0
- https://github.com/zwave-js/node-zwave-js/releases/tag/v10.7.0
- https://github.com/zwave-js/node-zwave-js/releases/tag/v10.8.0
- https://github.com/zwave-js/node-zwave-js/releases/tag/v10.10.0 (10.9.0 never got released per the release notes)