### PR TITLE
silabs-multiprotocol: Update vendor name/product name 

### DIFF
--- a/silabs-multiprotocol/CHANGELOG.md
+++ b/silabs-multiprotocol/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.0
+
+- Remove Web UI via ingress (expose ports to use the Web UI, see documentation)
+- Change vendor name to "Home Assistant" and product name to Silicon Labs
+  Multiprotocol" (used in OTBR mDNS/DNS-SD announcments)
+
 ## 0.13.1
 
 - Set default baudrate 115200 correctly

--- a/silabs-multiprotocol/Dockerfile
+++ b/silabs-multiprotocol/Dockerfile
@@ -213,8 +213,8 @@ RUN \
         -DOT_MULTIPAN_RCP=ON \
         -DOT_POSIX_CONFIG_RCP_BUS=CPC \
         -DOT_LINK_RAW=1 \
-        -DOTBR_VENDOR_NAME=HomeAssistant \
-        -DOTBR_PRODUCT_NAME=OpenThreadBorderRouter \
+        -DOTBR_VENDOR_NAME="Home Assistant" \
+        -DOTBR_PRODUCT_NAME="Silicon Labs Multiprotocol" \
         -DOTBR_WEB=ON \
         -DOTBR_BORDER_ROUTING=ON \
         -DOTBR_REST=ON \

--- a/silabs-multiprotocol/Dockerfile
+++ b/silabs-multiprotocol/Dockerfile
@@ -141,7 +141,6 @@ COPY --from=cpcd-builder /usr/local/ /usr/local/
 
 ENV BORDER_ROUTING=1
 ENV BACKBONE_ROUTER=1
-ENV OTBR_OPTIONS "-DOTBR_DBUS=OFF -DOT_MULTIPAN_RCP=ON -DOT_POSIX_CONFIG_RCP_BUS=CPC -DOT_LINK_RAW=1 -DOTBR_VENDOR_NAME=HomeAssistant -DOTBR_PRODUCT_NAME=OpenThreadBorderRouter"
 ENV WEB_GUI=1
 ENV DOCKER 1
 
@@ -197,7 +196,32 @@ RUN \
     && ln -s ../../../openthread/ third_party/openthread/repo \
     && chmod +x ./script/* \
     && patch -p1 < /usr/src/0001-Avoid-writing-to-system-console.patch \
-    && ./script/setup \
+    # Mimic rt_tables_install \
+    && echo "88 openthread" >> /etc/iproute2/rt_tables \
+    # Mimic otbr_install \
+    && (./script/cmake-build \
+        -DBUILD_TESTING=OFF \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DOTBR_FEATURE_FLAGS=ON \
+        -DOTBR_DNSSD_DISCOVERY_PROXY=ON \
+        -DOTBR_SRP_ADVERTISING_PROXY=ON \
+        -DOTBR_INFRA_IF_NAME=eth0 \
+        -DOTBR_MDNS=mDNSResponder \
+        -DOTBR_VERSION= \
+        -DOT_PACKAGE_VERSION= \
+        -DOTBR_DBUS=OFF \
+        -DOT_MULTIPAN_RCP=ON \
+        -DOT_POSIX_CONFIG_RCP_BUS=CPC \
+        -DOT_LINK_RAW=1 \
+        -DOTBR_VENDOR_NAME=HomeAssistant \
+        -DOTBR_PRODUCT_NAME=OpenThreadBorderRouter \
+        -DOTBR_WEB=ON \
+        -DOTBR_BORDER_ROUTING=ON \
+        -DOTBR_REST=ON \
+        -DOTBR_BACKBONE_ROUTER=ON \
+        && cd build/otbr/ \
+        && ninja \
+        && ninja install) \
     && pip install universal-silabs-flasher==0.0.7 \
     && apt-get purge -y --auto-remove \
        build-essential \

--- a/silabs-multiprotocol/Dockerfile.amd64
+++ b/silabs-multiprotocol/Dockerfile.amd64
@@ -218,8 +218,8 @@ RUN \
         -DOT_MULTIPAN_RCP=ON \
         -DOT_POSIX_CONFIG_RCP_BUS=CPC \
         -DOT_LINK_RAW=1 \
-        -DOTBR_VENDOR_NAME=HomeAssistant \
-        -DOTBR_PRODUCT_NAME=OpenThreadBorderRouter \
+        -DOTBR_VENDOR_NAME="Home Assistant" \
+        -DOTBR_PRODUCT_NAME="Silicon Labs Multiprotocol" \
         -DOTBR_WEB=ON \
         -DOTBR_BORDER_ROUTING=ON \
         -DOTBR_REST=ON \

--- a/silabs-multiprotocol/Dockerfile.amd64
+++ b/silabs-multiprotocol/Dockerfile.amd64
@@ -146,7 +146,6 @@ COPY --from=cpcd-builder /usr/local/ /usr/local/
 
 ENV BORDER_ROUTING=1
 ENV BACKBONE_ROUTER=1
-ENV OTBR_OPTIONS "-DOTBR_DBUS=OFF -DOT_MULTIPAN_RCP=ON -DOT_POSIX_CONFIG_RCP_BUS=CPC -DOT_LINK_RAW=1 -DOTBR_VENDOR_NAME=HomeAssistant -DOTBR_PRODUCT_NAME=OpenThreadBorderRouter"
 ENV WEB_GUI=1
 ENV DOCKER 1
 
@@ -202,7 +201,32 @@ RUN \
     && ln -s ../../../openthread/ third_party/openthread/repo \
     && chmod +x ./script/* \
     && patch -p1 < /usr/src/0001-Avoid-writing-to-system-console.patch \
-    && ./script/setup \
+    # Mimic rt_tables_install \
+    && echo "88 openthread" >> /etc/iproute2/rt_tables \
+    # Mimic otbr_install \
+    && (./script/cmake-build \
+        -DBUILD_TESTING=OFF \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DOTBR_FEATURE_FLAGS=ON \
+        -DOTBR_DNSSD_DISCOVERY_PROXY=ON \
+        -DOTBR_SRP_ADVERTISING_PROXY=ON \
+        -DOTBR_INFRA_IF_NAME=eth0 \
+        -DOTBR_MDNS=mDNSResponder \
+        -DOTBR_VERSION= \
+        -DOT_PACKAGE_VERSION= \
+        -DOTBR_DBUS=OFF \
+        -DOT_MULTIPAN_RCP=ON \
+        -DOT_POSIX_CONFIG_RCP_BUS=CPC \
+        -DOT_LINK_RAW=1 \
+        -DOTBR_VENDOR_NAME=HomeAssistant \
+        -DOTBR_PRODUCT_NAME=OpenThreadBorderRouter \
+        -DOTBR_WEB=ON \
+        -DOTBR_BORDER_ROUTING=ON \
+        -DOTBR_REST=ON \
+        -DOTBR_BACKBONE_ROUTER=ON \
+        && cd build/otbr/ \
+        && ninja \
+        && ninja install) \
     && pip install universal-silabs-flasher==0.0.7 \
     && apt-get purge -y --auto-remove \
        build-essential \

--- a/silabs-multiprotocol/config.yaml
+++ b/silabs-multiprotocol/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.13.1
+version: 1.0.0
 slug: silabs_multiprotocol
 name: Silicon Labs Multiprotocol
 description: Zigbee and OpenThread multiprotocol add-on

--- a/silabs-multiprotocol/config.yaml
+++ b/silabs-multiprotocol/config.yaml
@@ -28,7 +28,6 @@ options:
   autoflash_firmware: true
   cpcd_trace: false
   otbr_enable: true
-  otbr_web_enable: false
   otbr_log_level: notice
   otbr_firewall: true
 ports:


### PR DESCRIPTION
Use "Home Assistant" with space since other vendors use vendor names
with spaces as well. Choose a product name where we can distinguish
which OTBR add-on is used exactly.

