### PR TITLE
Camel case addon names

### DIFF
--- a/configurator/config.yaml
+++ b/configurator/config.yaml
@@ -1,7 +1,7 @@
 ---
 version: 5.5.0
 slug: configurator
-name: File editor
+name: File Editor
 description: Simple browser-based file editor for Home Assistant
 url: https://github.com/home-assistant/hassio-addons/tree/master/configurator
 codenotary: notary@home-assistant.io

--- a/dhcp_server/config.yaml
+++ b/dhcp_server/config.yaml
@@ -1,7 +1,7 @@
 ---
 version: 1.3.0
 slug: dhcp_server
-name: DHCP server
+name: DHCP Server
 description: A simple DHCP server
 url: https://home-assistant.io/addons/dhcp_server/
 codenotary: notary@home-assistant.io

--- a/git_pull/config.yaml
+++ b/git_pull/config.yaml
@@ -1,7 +1,7 @@
 ---
 version: 7.13.1
 slug: git_pull
-name: Git pull
+name: Git Pull
 description: Simple git pull to update the local configuration
 url: https://github.com/home-assistant/hassio-addons/tree/master/git_pull
 advanced: true

--- a/mosquitto/config.yaml
+++ b/mosquitto/config.yaml
@@ -1,7 +1,7 @@
 ---
 version: 6.1.3
 slug: mosquitto
-name: Mosquitto broker
+name: Mosquitto Broker
 description: An Open Source MQTT broker
 url: https://github.com/home-assistant/hassio-addons/tree/master/mosquitto
 codenotary: notary@home-assistant.io

--- a/nginx_proxy/config.yaml
+++ b/nginx_proxy/config.yaml
@@ -2,7 +2,7 @@
 version: 3.2.0
 hassio_api: true
 slug: nginx_proxy
-name: NGINX Home Assistant SSL proxy
+name: NGINX Home Assistant SSL Proxy
 description: An SSL/TLS proxy
 url: https://github.com/home-assistant/hassio-addons/tree/master/nginx_proxy
 arch:

--- a/samba/config.yaml
+++ b/samba/config.yaml
@@ -1,7 +1,7 @@
 ---
 version: 10.0.0
 slug: samba
-name: Samba share
+name: Samba Share
 description: Expose Home Assistant folders with SMB/CIFS
 url: https://github.com/home-assistant/hassio-addons/tree/master/samba
 codenotary: notary@home-assistant.io


### PR DESCRIPTION
This adjusts the addon names of
- configurator
- dhcp_server
- git_ull
- mosquitto
- nginx_proxy
- samba

To be written in camel case, just like the other addons.