### PR TITLE
silabs-multiprotocol: Use host namespace for hostname

### DIFF
--- a/silabs-multiprotocol/CHANGELOG.md
+++ b/silabs-multiprotocol/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.1
+
+- Use host namespace for hostname (make sure that the BR is announced with the
+  systems real hostname)
+
 ## 1.0.0
 
 - Remove Web UI via ingress (expose ports to use the Web UI, see documentation)

--- a/silabs-multiprotocol/config.yaml
+++ b/silabs-multiprotocol/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 1.0.0
+version: 1.0.1
 slug: silabs_multiprotocol
 name: Silicon Labs Multiprotocol
 description: Zigbee and OpenThread multiprotocol add-on
@@ -16,6 +16,7 @@ discovery:
 # IPC is only used within the Add-on
 host_ipc: false
 host_network: true
+host_uts: true
 privileged:
   - IPC_LOCK
   - NET_ADMIN

--- a/silabs-multiprotocol/rootfs/etc/s6-overlay/scripts/otbr-agent-rest-discovery.sh
+++ b/silabs-multiprotocol/rootfs/etc/s6-overlay/scripts/otbr-agent-rest-discovery.sh
@@ -5,7 +5,7 @@
 declare config
 
 config=$(bashio::var.json \
-    host "$(hostname)" \
+    host "$(bashio::addon.hostname)" \
     port "^8081" \
 )
 


### PR DESCRIPTION
This makes sure that the BR is announced with the systems real hostname.