### PR TITLE
Fix broken image in documentation

### DIFF
--- a/silabs-multiprotocol/DOCS.md
+++ b/silabs-multiprotocol/DOCS.md
@@ -88,7 +88,7 @@ Add-on configuration:
 The add-on runs several service internally. This architecture diagram shows what
 the add-on currently implements.
 
-![Silicon Labs Multiprotocol Add-on Architecture](images/architecture.png)
+![Silicon Labs Multiprotocol Add-on Architecture](https://raw.githubusercontent.com/home-assistant/addons/master/silabs-multiprotocol/images/architecture.png)
 
 ## Support
 


### PR DESCRIPTION
Fixes a broken image while viewing the documentation for SiLabs Multiprotocol from Home Assistant
![image](https://user-images.githubusercontent.com/85389871/226001060-7d58f81b-0de1-471f-b4e6-eba16c6c5dd3.png)
