### PR TITLE
Add URLs to Z-Wave JS changelog

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -49,13 +49,13 @@
 
 ## 0.1.66
 
-- Bump Z-Wave JS Server to 1.22.1
-- Bump Z-Wave JS to 10.0.1
+- [Bump Z-Wave JS Server to 1.22.1](https://github.com/zwave-js/zwave-js-server/releases/tag/1.22.1)
+- [Bump Z-Wave JS to 10.0.1](https://github.com/zwave-js/node-zwave-js/releases/tag/v10.0.1)
 
 ## 0.1.65
 
-- Bump Z-Wave JS Server to 1.21.0
-- Bump Z-Wave JS to 9.6.2
+- [Bump Z-Wave JS Server to 1.21.0](https://github.com/zwave-js/zwave-js-server/releases/tag/1.21.0)
+- [Bump Z-Wave JS to 9.6.2](https://github.com/zwave-js/node-zwave-js/releases/tag/v9.6.2)
 
 ## 0.1.64
 
@@ -63,16 +63,16 @@
 
 ## 0.1.63
 
-- Bump Z-Wave JS Server to 1.20.0
+- [Bump Z-Wave JS Server to 1.20.0](https://github.com/zwave-js/zwave-js-server/releases/tag/1.20.0)
 
 ## 0.1.62
 
-- Bump Z-Wave JS Server to 1.19.0
+- [Bump Z-Wave JS Server to 1.19.0](https://github.com/zwave-js/zwave-js-server/releases/tag/1.19.0)
 
 ## 0.1.61
 
-- Bump Z-Wave JS to 9.4.0
-- Bump Z-Wave JS Server to 1.18.0
+- [Bump Z-Wave JS to 9.4.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v9.4.0)
+- [Bump Z-Wave JS Server to 1.18.0](https://github.com/zwave-js/zwave-js-server/releases/tag/1.18.0)
 
 ## 0.1.60
 
@@ -80,59 +80,59 @@
 
 ## 0.1.59
 
-- Bump Z-Wave JS to 9.3.0
-- Bump Z-Wave JS Server to 1.17.0
+- [Bump Z-Wave JS to 9.3.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v9.3.0)
+- [Bump Z-Wave JS Server to 1.17.0](https://github.com/zwave-js/zwave-js-server/releases/tag/1.17.0)
 
 ## 0.1.58
 
-- Bump Z-Wave JS to 9.0.7
-- Bump Z-Wave JS Server to 1.16.1
+- [Bump Z-Wave JS to 9.0.7](https://github.com/zwave-js/node-zwave-js/releases/tag/v9.0.7)
+- [Bump Z-Wave JS Server to 1.16.1](https://github.com/zwave-js/zwave-js-server/releases/tag/1.16.1)
 
 ## 0.1.57
 
-- Bump Z-Wave JS to 9.0.4
+- [Bump Z-Wave JS to 9.0.4](https://github.com/zwave-js/node-zwave-js/releases/tag/v9.0.4)
 
 ## 0.1.56
 
-- Bump Z-Wave JS to 9.0.2
-- Bump Z-Wave JS Server to 1.16.0
+- [Bump Z-Wave JS to 9.0.2](https://github.com/zwave-js/node-zwave-js/releases/tag/v9.0.2)
+- [Bump Z-Wave JS Server to 1.16.0](https://github.com/zwave-js/zwave-js-server/releases/tag/1.16.0)
 
 ## 0.1.55
 
-- Bump Z-Wave JS to 8.11.9
+- [Bump Z-Wave JS to 8.11.9](https://github.com/zwave-js/node-zwave-js/releases/tag/v8.11.9)
 
 ## 0.1.54
 
-- Bump Z-Wave JS to 8.11.6
-- Bump Z-Wave JS Server to 1.15.0
+- [Bump Z-Wave JS to 8.11.6](https://github.com/zwave-js/node-zwave-js/releases/tag/v8.11.6)
+- [Bump Z-Wave JS Server to 1.15.0](https://github.com/zwave-js/zwave-js-server/releases/tag/1.15.0)
 
 ## 0.1.53
 
-- Bump Z-Wave JS to 8.11.5
+- [Bump Z-Wave JS to 8.11.5](https://github.com/zwave-js/node-zwave-js/releases/tag/v8.11.5)
 
 ## 0.1.52
 
-- Bump Z-Wave JS to 8.10.2
-- Bump Z-Wave JS Server to 1.14.1
+- [Bump Z-Wave JS to 8.10.2](https://github.com/zwave-js/node-zwave-js/releases/tag/v8.10.2)
+- [Bump Z-Wave JS Server to 1.14.1](https://github.com/zwave-js/zwave-js-server/releases/tag/1.14.1)
 
 ## 0.1.51
 
-- Bump Z-Wave JS to 8.9.2
-- Bump Z-Wave JS Server to 1.14.0
+- [Bump Z-Wave JS to 8.9.2](https://github.com/zwave-js/node-zwave-js/releases/tag/v8.9.2)
+- [Bump Z-Wave JS Server to 1.14.0](https://github.com/zwave-js/zwave-js-server/releases/tag/1.14.0)
 
 ## 0.1.50
 
-- Bump Z-Wave JS to 8.8.3
+- [Bump Z-Wave JS to 8.8.3](https://github.com/zwave-js/node-zwave-js/releases/tag/v8.8.3)
 
 ## 0.1.49
 
-- Bump Z-Wave JS to 8.7.7
-- Bump Z-Wave JS Server to 1.12.0
+- [Bump Z-Wave JS to 8.7.7](https://github.com/zwave-js/node-zwave-js/releases/tag/v8.7.7)
+- [Bump Z-Wave JS Server to 1.12.0](https://github.com/zwave-js/zwave-js-server/releases/tag/1.12.0)
 
 ## 0.1.48
 
-- Bump Z-Wave JS to 8.7.6
-- Bump Z-Wave JS Server to 1.11.0
+- [Bump Z-Wave JS to 8.7.6](https://github.com/zwave-js/node-zwave-js/releases/tag/v8.7.6)
+- [Bump Z-Wave JS Server to 1.11.0](https://github.com/zwave-js/zwave-js-server/releases/tag/1.11.0)
 
 ## 0.1.47
 
@@ -140,12 +140,12 @@
 
 ## 0.1.46
 
-- Bump Z-Wave JS to 8.7.5
-- Bump Z-Wave JS Server to 1.10.8
+- [Bump Z-Wave JS to 8.7.5](https://github.com/zwave-js/node-zwave-js/releases/tag/v8.7.5)
+- [Bump Z-Wave JS Server to 1.10.8](https://github.com/zwave-js/zwave-js-server/releases/tag/1.10.8)
 
 ## 0.1.45
 
-- Bump Z-Wave JS Server to 1.10.7
+- [Bump Z-Wave JS Server to 1.10.7](https://github.com/zwave-js/zwave-js-server/releases/tag/1.10.7)
 
 ## 0.1.44
 
@@ -154,7 +154,7 @@
 
 ## 0.1.43
 
-- Bump Z-Wave JS Server to 1.10.6
+- [Bump Z-Wave JS Server to 1.10.6](https://github.com/zwave-js/zwave-js-server/releases/tag/1.10.6)
 
 ## 0.1.42
 
@@ -162,147 +162,147 @@
 
 ## 0.1.41
 
-- Bump Z-Wave JS Server to 1.10.5
-- Bump Z-Wave JS to 8.4.1
+- [Bump Z-Wave JS Server to 1.10.5](https://github.com/zwave-js/zwave-js-server/releases/tag/1.10.5)
+- [Bump Z-Wave JS to 8.4.1](https://github.com/zwave-js/node-zwave-js/releases/tag/v8.4.1)
 - Add support for S2 keys in the addon configuration (check the Security Keys section of the configuration docs for more details)
 
 ## 0.1.40
 
-- Bump Z-Wave JS to 8.3.0
+- [Bump Z-Wave JS to 8.3.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v8.3.0)
 
 ## 0.1.39
 
-- Bump Z-Wave JS to 8.2.3
+- [Bump Z-Wave JS to 8.2.3](https://github.com/zwave-js/node-zwave-js/releases/tag/v8.2.3)
 
 ## 0.1.38
 
-- Bump Z-Wave JS Server to 1.10.3
-- Bump Z-Wave JS to 8.2.1
+- [Bump Z-Wave JS Server to 1.10.3](https://github.com/zwave-js/zwave-js-server/releases/tag/1.10.3)
+- [Bump Z-Wave JS to 8.2.1](https://github.com/zwave-js/node-zwave-js/releases/tag/v8.2.1)
 
 ## 0.1.37
 
-- Bump Z-Wave JS Server to 1.10.0
+- [Bump Z-Wave JS Server to 1.10.0](https://github.com/zwave-js/zwave-js-server/releases/tag/1.10.0)
 
 ## 0.1.36
 
-- Bump Z-Wave JS to 8.1.1
+- [Bump Z-Wave JS to 8.1.1](https://github.com/zwave-js/node-zwave-js/releases/tag/v8.1.1)
 
 ## 0.1.35
 
-- Bump Z-Wave JS Server to 1.9.3
-- Bump Z-Wave JS to 8.0.8
+- [Bump Z-Wave JS Server to 1.9.3](https://github.com/zwave-js/zwave-js-server/releases/tag/1.9.3)
+- [Bump Z-Wave JS to 8.0.8](https://github.com/zwave-js/node-zwave-js/releases/tag/v8.0.8)
 
 ## 0.1.34
 
-- Bump Z-Wave JS Server to 1.9.2
+- [Bump Z-Wave JS Server to 1.9.2](https://github.com/zwave-js/zwave-js-server/releases/tag/1.9.2)
 
 ## 0.1.33
 
-- Bump Z-Wave JS to 8.0.6
+- [Bump Z-Wave JS to 8.0.6](https://github.com/zwave-js/node-zwave-js/releases/tag/v8.0.6)
 
 ## 0.1.32
 
-- Bump Z-Wave JS to 8.0.5
+- [Bump Z-Wave JS to 8.0.5](https://github.com/zwave-js/node-zwave-js/releases/tag/v8.0.5)
 
 ## 0.1.31
 
-- Bump Z-Wave JS Server to 1.9.1
+- [Bump Z-Wave JS Server to 1.9.1](https://github.com/zwave-js/zwave-js-server/releases/tag/1.9.1)
 
 ## 0.1.30
 
-- Bump Z-Wave JS to 8.0.3
-- Bump Z-Wave JS Server to 1.9.0
+- [Bump Z-Wave JS to 8.0.3](https://github.com/zwave-js/node-zwave-js/releases/tag/v8.0.3)
+- [Bump Z-Wave JS Server to 1.9.0](https://github.com/zwave-js/zwave-js-server/releases/tag/1.9.0)
 
 ## 0.1.29
 
-- Bump Z-Wave JS to 7.12.0
+- [Bump Z-Wave JS to 7.12.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v7.12.0)
 
 ## 0.1.28
 
-- Bump Z-Wave JS to 7.10.0
-- Bump Z-Wave JS Server to 1.8.0
+- [Bump Z-Wave JS to 7.10.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v7.10.0)
+- [Bump Z-Wave JS Server to 1.8.0](https://github.com/zwave-js/zwave-js-server/releases/tag/1.8.0)
 
 ## 0.1.27
 
-- Bump Z-Wave JS to 7.9.0
+- [Bump Z-Wave JS to 7.9.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v7.9.0)
 
 ## 0.1.26
 
-- Bump Z-Wave JS to 7.7.4
+- [Bump Z-Wave JS to 7.7.4](https://github.com/zwave-js/node-zwave-js/releases/tag/v7.7.4)
 
 ## 0.1.25
 
-- Bump Z-Wave JS to 7.7.3
+- [Bump Z-Wave JS to 7.7.3](https://github.com/zwave-js/node-zwave-js/releases/tag/v7.7.3)
 
 ## 0.1.24
 
-- Bump Z-Wave JS to 7.7.0
+- [Bump Z-Wave JS to 7.7.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v7.7.0)
 - Create persistent directory for device config files to allow for future config updating functionality through the Home Assistant UI.
 
 ## 0.1.23
 
-- Bump Z-Wave JS Server to 1.7.0
-- Pin Z-Wave JS to 7.6.0
+- [Bump Z-Wave JS Server to 1.7.0](https://github.com/zwave-js/zwave-js-server/releases/tag/1.7.0)
+- [Pin Z-Wave JS to 7.6.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v7.6.0)
 
 ## 0.1.22
 
-- Bump Z-Wave JS Server to 1.6.0
-- Pin Z-Wave JS to 7.5.2
+- [Bump Z-Wave JS Server to 1.6.0](https://github.com/zwave-js/zwave-js-server/releases/tag/1.6.0)
+- [Pin Z-Wave JS to 7.5.2](https://github.com/zwave-js/node-zwave-js/releases/tag/v7.5.2)
 
 ## 0.1.21
 
-- Pin Z-Wave JS to 7.3.0
+- [Pin Z-Wave JS to 7.3.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v7.3.0)
 
 ## 0.1.20
 
-- Bump Z-Wave JS Server to 1.5.0
-- Pin Z-Wave JS to 7.2.4
+- [Bump Z-Wave JS Server to 1.5.0](https://github.com/zwave-js/zwave-js-server/releases/tag/1.5.0)
+- [Pin Z-Wave JS to 7.2.4](https://github.com/zwave-js/node-zwave-js/releases/tag/v7.2.4)
 
 ## 0.1.19
 
-- Pin Z-Wave JS to 7.2.3
+- [Pin Z-Wave JS to 7.2.3](https://github.com/zwave-js/node-zwave-js/releases/tag/v7.2.3)
 - Make log level a configuration option
 
 ## 0.1.18
 
-- Pin Z-Wave JS to 7.2.2
+- [Pin Z-Wave JS to 7.2.2](https://github.com/zwave-js/node-zwave-js/releases/tag/v7.2.2)
 
 ## 0.1.17
 
-- Bump Z-Wave JS Server to 1.4.0
-- Pin Z-Wave JS to 7.1.1
+- [Bump Z-Wave JS Server to 1.4.0](https://github.com/zwave-js/zwave-js-server/releases/tag/1.4.0)
+- [Pin Z-Wave JS to 7.1.1](https://github.com/zwave-js/node-zwave-js/releases/tag/v7.1.1)
 
 ## 0.1.16
 
-- Bump Z-Wave JS Server to 1.3.1
+- [Bump Z-Wave JS Server to 1.3.1](https://github.com/zwave-js/zwave-js-server/releases/tag/1.3.1)
 
 ## 0.1.15
 
-- Pin Z-Wave JS to version 7.0.1
+- [Pin Z-Wave JS to version 7.0.1](https://github.com/zwave-js/node-zwave-js/releases/tag/v7.0.1)
 
 ## 0.1.14
 
-- Bump Z-Wave JS Server to 1.3.0
-- Pin Z-Wave JS to version 7.0.0
+- [Bump Z-Wave JS Server to 1.3.0](https://github.com/zwave-js/zwave-js-server/releases/tag/1.3.0)
+- [Pin Z-Wave JS to version 7.0.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v7.0.0)
 
 ## 0.1.13
 
-- Bump Z-Wave JS Server to 1.2.1
-- Pin Z-Wave JS to version 6.6.3
+- [Bump Z-Wave JS Server to 1.2.1](https://github.com/zwave-js/zwave-js-server/releases/tag/1.2.1)
+- [Pin Z-Wave JS to version 6.6.3](https://github.com/zwave-js/node-zwave-js/releases/tag/v6.6.3)
 - Unpin Z-Wave JS dependencies
 
 ## 0.1.12
 
-- Bump Z-Wave JS to 6.5.1
+- [Bump Z-Wave JS to 6.5.1](https://github.com/zwave-js/node-zwave-js/releases/tag/v6.5.1)
 - Pin Z-Wave JS dependencies
 
 ## 0.1.11
 
-- Bump Z-Wave JS Server to 1.1.1
+- [Bump Z-Wave JS Server to 1.1.1](https://github.com/zwave-js/zwave-js-server/releases/tag/1.1.1)
 
 ## 0.1.10
 
-- Bump Z-Wave JS Server to 1.1.0. This is the same code as 2.0.0. Home Assistant 2021.2 rejects any ZJS Server version that is v2+
+- [Bump Z-Wave JS Server to 1.1.0.](https://github.com/zwave-js/zwave-js-server/releases/tag/1.1.0) This is the same code as 2.0.0. Home Assistant 2021.2 rejects any ZJS Server version that is v2+
 
 ## 0.1.9
 
@@ -310,38 +310,38 @@
 
 ## 0.1.8
 
-- Bump Z-Wave JS Server to 1.0.0
-- Pin Z-Wave JS to version 6.5.0
+- [Bump Z-Wave JS Server to 1.0.0](https://github.com/zwave-js/zwave-js-server/releases/tag/1.0.0)
+- [Pin Z-Wave JS to version 6.5.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v6.5.0)
 
 ## 0.1.7
 
-- Bump Z-Wave JS Server to 1.0.0-beta.6
+- [Bump Z-Wave JS Server to 1.0.0-beta.6](https://github.com/zwave-js/zwave-js-server/releases/tag/1.0.0-beta.6)
 
 ## 0.1.6
 
-- Update zwave-js to version 6.2.0
+- [Update Z-Wave JS to version 6.2.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v6.2.0)
 
 ## 0.1.5
 
 - Update hardware configuration for Supervisor 2021.02.5
-- Upgrade Z-Wave JS Server to 1.0.0-beta 5
-- Pin Z-Wave JS to version 6.1.3
+- [Upgrade Z-Wave JS Server to 1.0.0-beta.5](https://github.com/zwave-js/zwave-js-server/releases/tag/1.0.0-beta.5)
+- [Pin Z-Wave JS to version 6.1.3](https://github.com/zwave-js/node-zwave-js/releases/tag/v6.1.3)
 
 ## 0.1.4
 
-- Bump Z-Wave JS Server to 1.0.0-beta.4
+- [Bump Z-Wave JS Server to 1.0.0-beta.4](https://github.com/zwave-js/zwave-js-server/releases/tag/1.0.0-beta.4)
 
 ## 0.1.3
 
-- Bump Z-Wave JS Server to 1.0.0-beta.3
+- [Bump Z-Wave JS Server to 1.0.0-beta.3](https://github.com/zwave-js/zwave-js-server/releases/tag/1.0.0-beta.3)
 
 ## 0.1.2
 
-- Bump Z-Wave JS Server to 1.0.0-beta.2
+- [Bump Z-Wave JS Server to 1.0.0-beta.2](https://github.com/zwave-js/zwave-js-server/releases/tag/1.0.0-beta.2)
 
 ## 0.1.1
 
-- Bump Z-Wave JS Server to 1.0.0-beta.1
+- [Bump Z-Wave JS Server to 1.0.0-beta.1]https://github.com/zwave-js/zwave-js-server/releases/tag/1.0.0-beta.1()
 
 ## 0.1.0
 

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -341,7 +341,7 @@
 
 ## 0.1.1
 
-- [Bump Z-Wave JS Server to 1.0.0-beta.1]https://github.com/zwave-js/zwave-js-server/releases/tag/1.0.0-beta.1()
+- [Bump Z-Wave JS Server to 1.0.0-beta.1](https://github.com/zwave-js/zwave-js-server/releases/tag/1.0.0-beta.1)
 
 ## 0.1.0
 


### PR DESCRIPTION
Adds URLs for all releases to the Z-Wave JS changelog.
The Z-Wave JS server release 2.0.0 was not available in the z-wave JS server repository, so that one is not added.