### PR TITLE
Bump Matter Server to 3.2.0

### DIFF
--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 4.2.0
+
+- Bump Matter Server to [3.2.0](https://github.com/home-assistant-libs/python-matter-server/releases/tag/3.2.0)
+- Significantly reduced add-on size
+
 ## 4.1.0
 
 - Bump Matter Server to [3.1.0](https://github.com/home-assistant-libs/python-matter-server/releases/tag/3.1.0)

--- a/matter_server/Dockerfile
+++ b/matter_server/Dockerfile
@@ -71,8 +71,10 @@ RUN \
     && rm -rf /usr/src/*
 
 # S6-Overlay
-WORKDIR /
+WORKDIR /root
 ENTRYPOINT ["/init"]
+
+ARG MATTER_SERVER_VERSION
 
 RUN \
     set -x \
@@ -82,30 +84,16 @@ RUN \
        openssl \
        zlib1g \
        libjson-c5 \
-       python3-venv \
-       python3-pip \
-       python3-psutil \
        unzip \
-       libcairo2 \
        gdb \
-       git \
-    && git clone --depth 1 -b master \
-       https://github.com/project-chip/connectedhomeip \
-    && cp -r connectedhomeip/credentials /root/credentials \
-    && mv /root/credentials/production/paa-root-certs/* \
-          /root/credentials/development/paa-root-certs/ \
-    && rm -rf connectedhomeip \
+       gcc \
+       linux-libc-dev \
+       libc6-dev \
+    && pip3 install --no-cache-dir "python-matter-server[server]==${MATTER_SERVER_VERSION}" \
     && apt-get purge -y --auto-remove \
-       git \
+       gcc \
+       linux-libc-dev \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /usr/src/*
-
-WORKDIR /root
-
-ARG MATTER_SERVER_VERSION
-
-# hadolint ignore=DL3013
-RUN \
-    pip3 install --no-cache-dir "python-matter-server[server]==${MATTER_SERVER_VERSION}"
 
 COPY rootfs /

--- a/matter_server/build.yaml
+++ b/matter_server/build.yaml
@@ -1,9 +1,9 @@
 ---
 build_from:
-  aarch64: python:3.10-bullseye
-  amd64: python:3.10-bullseye
+  aarch64: python:3.10-slim-bullseye
+  amd64: python:3.10-slim-bullseye
 args:
   BASHIO_VERSION: 0.14.3
   TEMPIO_VERSION: 2021.09.0
   S6_OVERLAY_VERSION: 3.1.3.0
-  MATTER_SERVER_VERSION: 3.1.0
+  MATTER_SERVER_VERSION: 3.2.0

--- a/matter_server/config.yaml
+++ b/matter_server/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 4.1.0
+version: 4.2.0
 slug: matter_server
 name: Matter Server
 description: Matter WebSocket Server for Home Assistant Matter support.


### PR DESCRIPTION
Use the slim version of the official Python bullseye image. This requires us manually install and remove some build dependencies, but significantly reduced the image size.

Also don't install any certificates anymore as these get downloaded at runtime today.

closes #2949