### PR TITLE
Dnsmasq: Added switch that disables dnsmasq "log-queries" parameter

### DIFF
--- a/dnsmasq/DOCS.md
+++ b/dnsmasq/DOCS.md
@@ -38,6 +38,7 @@ services:
     port: 389
     priority: 0
     weight: 100
+log_queries: false
 ```
 
 ### Option: `defaults` (required)
@@ -117,6 +118,10 @@ The name to resolve.
 #### Option: `cnames.target`
 
 The target name. Note that this only works for targets which are names from DHCP or /etc/hosts. Give host "bert" another name, bertrand cname=bertand,bert
+
+### Option: `log_queries` (required) 
+
+Log all DNS requests. Defaults to `false`.
 
 ## Support
 

--- a/dnsmasq/config.yaml
+++ b/dnsmasq/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 1.5.1
+version: 1.5.2
 slug: dnsmasq
 name: Dnsmasq
 description: A simple DNS server
@@ -21,6 +21,7 @@ options:
   hosts: []
   services: []
   cnames: []
+  log_queries: false
 ports:
   53/tcp: 53
   53/udp: 53
@@ -42,4 +43,5 @@ schema:
   cnames:
     - name: str
       target: str
+  log_queries: bool
 startup: system

--- a/dnsmasq/rootfs/usr/share/tempio/dnsmasq.config
+++ b/dnsmasq/rootfs/usr/share/tempio/dnsmasq.config
@@ -3,7 +3,9 @@
 no-resolv
 no-hosts
 keep-in-foreground
+{{ if .log_queries }}
 log-queries
+{{ end }}
 log-facility=-
 no-poll
 user=root

--- a/dnsmasq/translations/en.yaml
+++ b/dnsmasq/translations/en.yaml
@@ -18,6 +18,9 @@ configuration:
   cnames:
     name: Cnames
     description: Provide cname records for DNSMasq to resolve.
+  log_queries:
+    name: Log Queries
+    description: Log all DNS requests
 network:
   53/tcp: TCP port for DNS requests.
   53/udp: UDP port for DNS requests.


### PR DESCRIPTION
**Problem:**
Dnsmasq floods log with dns requests. 

**Solution:**
Added switch that disables `log-queries` parameter so log file became much cleaner.