### PR TITLE
silabs-multiprotocol: Fix firmware flashing for amd64

### DIFF
--- a/silabs-multiprotocol/CHANGELOG.md
+++ b/silabs-multiprotocol/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.1
+
+- Bugfix: bump universal SiLabs flasher to 0.0.12 for amd64
+
 ## 1.1.0
 
 - Use default baudrate of 460800 (WARNING: You MUST update your configuration!)

--- a/silabs-multiprotocol/Dockerfile.amd64
+++ b/silabs-multiprotocol/Dockerfile.amd64
@@ -128,6 +128,8 @@ RUN \
 
 FROM $BUILD_FROM
 
+ARG UNIVERSAL_SILABS_FLASHER
+
 RUN \
     set -x \
     && apt-get update \
@@ -227,7 +229,7 @@ RUN \
         && cd build/otbr/ \
         && ninja \
         && ninja install) \
-    && pip install universal-silabs-flasher==0.0.7 \
+    && pip install universal-silabs-flasher==${UNIVERSAL_SILABS_FLASHER} \
     && apt-get purge -y --auto-remove \
        build-essential \
        patch \

--- a/silabs-multiprotocol/config.yaml
+++ b/silabs-multiprotocol/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 1.1.0
+version: 1.1.1
 slug: silabs_multiprotocol
 name: Silicon Labs Multiprotocol
 description: Zigbee and OpenThread multiprotocol add-on


### PR DESCRIPTION
The newly-introduced `UNIVERSAL_SILABS_FLASHER` argument wasn't used in `Dockerfile.amd64` so an old version of the flasher was still being installed, breaking startup. No other platform was affected.