### PR TITLE
Fix slow startup of dnsmasq on HAOS 10

### DIFF
--- a/dnsmasq/CHANGELOG.md
+++ b/dnsmasq/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.6.0
+
+- Update to Alpine 3.17
+- Limit open file descriptors to 1024 to minimize
+
 ## 1.5.2
 
 - Disable DNS request logging by default

--- a/dnsmasq/build.yaml
+++ b/dnsmasq/build.yaml
@@ -1,10 +1,10 @@
 ---
 build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-base:3.13
-  amd64: ghcr.io/home-assistant/amd64-base:3.13
-  armhf: ghcr.io/home-assistant/armhf-base:3.13
-  armv7: ghcr.io/home-assistant/armv7-base:3.13
-  i386: ghcr.io/home-assistant/i386-base:3.13
+  aarch64: ghcr.io/home-assistant/aarch64-base:3.17
+  amd64: ghcr.io/home-assistant/amd64-base:3.17
+  armhf: ghcr.io/home-assistant/armhf-base:3.17
+  armv7: ghcr.io/home-assistant/armv7-base:3.17
+  i386: ghcr.io/home-assistant/i386-base:3.17
 codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io

--- a/dnsmasq/config.yaml
+++ b/dnsmasq/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 1.5.2
+version: 1.6.0
 slug: dnsmasq
 name: Dnsmasq
 description: A simple DNS server

--- a/dnsmasq/rootfs/etc/services.d/dnsmasq/run
+++ b/dnsmasq/rootfs/etc/services.d/dnsmasq/run
@@ -3,5 +3,9 @@ CONFIG="/etc/dnsmasq.conf"
 
 # Run dnsmasq
 bashio::log.info "Starting dnsmasq..."
+
+# Set max open file limit to speed up startup
+ulimit -n 1024
+
 exec dnsmasq -C "${CONFIG}" -z < /dev/null
 


### PR DESCRIPTION
By default dnsmasq seems to close all potentially open file descriptors. This has previously brought up on the mailing list [1], but it seems that the fix did not really fix the issue (maybe an Alpine issue).

Previously the limit of open file descriptors was set to 1048576 for all add-ons (see [2]), which depending on the system takes up to 1s for dnsmasq to start. With the new, much higher limit it takes minutes to start dnsmasq.

This changes the limit to 1024, which speeds up dnsmasq startup in both cases to be well below 1s.

[1] https://lists.thekelleys.org.uk/pipermail/dnsmasq-discuss/2020q1/013821.html
[2] https://developers.home-assistant.io/blog/2023/04/13/new_limits_for_add_ons

Fixes: #2982