### PR TITLE
samba: Update to Alpine 3.17

### DIFF
--- a/samba/CHANGELOG.md
+++ b/samba/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 10.0.1
+
+- Update to Alpine 3.17
+
 ## 10.0.0
 
 BREAKING CHANGE: Don't mangle filenames
@@ -81,4 +85,3 @@ systems do not have these restrictions.
 ## 8.0.0
 
 - Fix access to /backup
-

--- a/samba/build.yaml
+++ b/samba/build.yaml
@@ -1,10 +1,10 @@
 ---
 build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-base:3.16
-  amd64: ghcr.io/home-assistant/amd64-base:3.16
-  armhf: ghcr.io/home-assistant/armhf-base:3.16
-  armv7: ghcr.io/home-assistant/armv7-base:3.16
-  i386: ghcr.io/home-assistant/i386-base:3.16
+  aarch64: ghcr.io/home-assistant/aarch64-base:3.17
+  amd64: ghcr.io/home-assistant/amd64-base:3.17
+  armhf: ghcr.io/home-assistant/armhf-base:3.17
+  armv7: ghcr.io/home-assistant/armv7-base:3.17
+  i386: ghcr.io/home-assistant/i386-base:3.17
 codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io

--- a/samba/config.yaml
+++ b/samba/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 10.0.0
+version: 10.0.1
 slug: samba
 name: Samba share
 description: Expose Home Assistant folders with SMB/CIFS


### PR DESCRIPTION
SSIA, updates the Samba add-on to use Alpine Linux 3.17

To prevent more of #3001 happening, follow up PRs after this one that are ready to go:

- Upgrade to S6 Overlay
- Changes in dependencies
- Adding health checks

Adding the above for clarity to prevent other people (including myself) are wasting time on building on top of this.

../Frenck