### PR TITLE
Bump zwave-js to 10.17.0

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.80
+
+- [Bump Z-Wave JS to 10.17.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v10.17.0)
+
 ## 0.1.79
 
 - [Bump Z-Wave JS to 10.16.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v10.16.0)

--- a/zwave_js/build.yaml
+++ b/zwave_js/build.yaml
@@ -10,4 +10,4 @@ codenotary:
   base_image: notary@home-assistant.io
 args:
   ZWAVEJS_SERVER_VERSION: 1.28.0
-  ZWAVEJS_VERSION: 10.16.0
+  ZWAVEJS_VERSION: 10.17.0

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.1.79
+version: 0.1.80
 slug: zwave_js
 name: Z-Wave JS
 description: Control a Z-Wave network with Home Assistant Z-Wave JS


### PR DESCRIPTION
https://github.com/zwave-js/node-zwave-js/releases/tag/v10.17.0

According to Al there is a critical bugfix related to the Transport Service CC in this release
