### PR TITLE
silabs-multiprotocol: Disable mdns service if otbr agent is disabled

### DIFF
--- a/silabs-multiprotocol/rootfs/etc/s6-overlay/scripts/otbr-enable-check.sh
+++ b/silabs-multiprotocol/rootfs/etc/s6-overlay/scripts/otbr-enable-check.sh
@@ -7,6 +7,7 @@ if bashio::config.false 'otbr_enable'; then
     rm /etc/s6-overlay/s6-rc.d/user/contents.d/otbr-agent
     rm /etc/s6-overlay/s6-rc.d/user/contents.d/otbr-web
     rm /etc/s6-overlay/s6-rc.d/user/contents.d/otbr-agent-rest-discovery
+    rm /etc/s6-overlay/s6-rc.d/user/contents.d/mdns
     bashio::log.info "The otbr-agent is disabled."
 fi
 


### PR DESCRIPTION
As suggested in https://github.com/home-assistant/addons/issues/2910#issuecomment-1534230641, this PR disables the misbehaving mdns service if it is not needed due to disabling of the OTBR.