### PR TITLE
MariaDB: Use proper log redirection during backup

### DIFF
--- a/mariadb/CHANGELOG.md
+++ b/mariadb/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.6.1
+
+- Use proper log redirection during backup
+
 ## 2.6.0
 
 - Migrate add-on layout to S6 Overlay

--- a/mariadb/config.yaml
+++ b/mariadb/config.yaml
@@ -10,10 +10,8 @@ arch:
   - aarch64
   - amd64
   - i386
-backup_post: "redirfd -wn 1 /proc/1/fd/1 fdmove -c 2 1 \
-  s6-rc -v 2 -d change mariadb-lock"
-backup_pre: "redirfd -wn 1 /proc/1/fd/1 fdmove -c 2 1 \
-  s6-rc -v 2 -u change mariadb-lock"
+backup_post: unlock-tables-for-backup
+backup_pre: lock-tables-for-backup
 image: homeassistant/{arch}-addon-mariadb
 init: false
 options:

--- a/mariadb/config.yaml
+++ b/mariadb/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 2.6.0
+version: 2.6.1
 slug: mariadb
 name: MariaDB
 description: A SQL database server
@@ -10,8 +10,8 @@ arch:
   - aarch64
   - amd64
   - i386
-backup_post: /command/s6-rc -d change mariadb-lock
-backup_pre: /command/s6-rc -u change mariadb-lock
+backup_post: redirfd -wn 1 /proc/1/fd/1 fdmove -c 2 1 s6-rc -v 2 -d change mariadb-lock
+backup_pre: redirfd -wn 1 /proc/1/fd/1 fdmove -c 2 1 s6-rc -v 2 -u change mariadb-lock
 image: homeassistant/{arch}-addon-mariadb
 init: false
 options:

--- a/mariadb/config.yaml
+++ b/mariadb/config.yaml
@@ -10,8 +10,10 @@ arch:
   - aarch64
   - amd64
   - i386
-backup_post: redirfd -wn 1 /proc/1/fd/1 fdmove -c 2 1 s6-rc -v 2 -d change mariadb-lock
-backup_pre: redirfd -wn 1 /proc/1/fd/1 fdmove -c 2 1 s6-rc -v 2 -u change mariadb-lock
+backup_post: "redirfd -wn 1 /proc/1/fd/1 fdmove -c 2 1 \
+  s6-rc -v 2 -d change mariadb-lock"
+backup_pre: "redirfd -wn 1 /proc/1/fd/1 fdmove -c 2 1 \
+  s6-rc -v 2 -u change mariadb-lock"
 image: homeassistant/{arch}-addon-mariadb
 init: false
 options:

--- a/mariadb/rootfs/etc/s6-overlay/s6-rc.d/mariadb-lock-post/finish
+++ b/mariadb/rootfs/etc/s6-overlay/s6-rc.d/mariadb-lock-post/finish
@@ -4,10 +4,6 @@
 # Unlock tables locked for backups
 # ==============================================================================
 
-# Due to it is started by the supervisor calling the backup_post: `/command/s6-rc -d change mariadb-lock` command,
-# it's stdout won't be redirected automatically to the add-on's log
-exec &> /proc/1/fd/1
-
 declare MARIADB_LOCK_CORE_PID
 MARIADB_LOCK_CORE_PID=$(s6-svstat -o pid "/run/service/mariadb-lock-core")
 if bashio::var.equals ${MARIADB_LOCK_CORE_PID} -1; then

--- a/mariadb/rootfs/etc/s6-overlay/s6-rc.d/mariadb-lock-post/run
+++ b/mariadb/rootfs/etc/s6-overlay/s6-rc.d/mariadb-lock-post/run
@@ -4,10 +4,6 @@
 # Lock tables for backups
 # ==============================================================================
 
-# Due to it is started by the supervisor calling the backup_pre: `/command/s6-rc -u change mariadb-lock` command,
-# it's stdout won't be redirected automatically to the add-on's log
-exec &> /proc/1/fd/1
-
 declare MARIADB_LOCK_CORE_PID
 MARIADB_LOCK_CORE_PID=$(s6-svstat -o pid "/run/service/mariadb-lock-core")
 if bashio::var.equals ${MARIADB_LOCK_CORE_PID} -1; then

--- a/mariadb/rootfs/usr/bin/lock-tables-for-backup
+++ b/mariadb/rootfs/usr/bin/lock-tables-for-backup
@@ -4,5 +4,6 @@
 # Lock tables for backup
 # ==============================================================================
 
+# Redirect stdout to the add-on's log
 exec &> /proc/1/fd/1
 exec s6-rc -v 2 -u change mariadb-lock

--- a/mariadb/rootfs/usr/bin/lock-tables-for-backup
+++ b/mariadb/rootfs/usr/bin/lock-tables-for-backup
@@ -1,0 +1,9 @@
+#!/command/with-contenv bashio
+# shellcheck shell=bash
+# ==============================================================================
+# Lock tables for backup
+# ==============================================================================
+
+redirfd -wn 1 /proc/1/fd/1 \
+    fdmove -c 2 1 \
+    s6-rc -v 2 -u change mariadb-lock

--- a/mariadb/rootfs/usr/bin/lock-tables-for-backup
+++ b/mariadb/rootfs/usr/bin/lock-tables-for-backup
@@ -4,6 +4,5 @@
 # Lock tables for backup
 # ==============================================================================
 
-redirfd -wn 1 /proc/1/fd/1 \
-    fdmove -c 2 1 \
-    s6-rc -v 2 -u change mariadb-lock
+exec &> /proc/1/fd/1
+exec s6-rc -v 2 -u change mariadb-lock

--- a/mariadb/rootfs/usr/bin/unlock-tables-for-backup
+++ b/mariadb/rootfs/usr/bin/unlock-tables-for-backup
@@ -4,5 +4,6 @@
 # Unlock tables for backup
 # ==============================================================================
 
+# Redirect stdout to the add-on's log
 exec &> /proc/1/fd/1
 exec s6-rc -v 2 -d change mariadb-lock

--- a/mariadb/rootfs/usr/bin/unlock-tables-for-backup
+++ b/mariadb/rootfs/usr/bin/unlock-tables-for-backup
@@ -4,6 +4,5 @@
 # Unlock tables for backup
 # ==============================================================================
 
-redirfd -wn 1 /proc/1/fd/1 \
-    fdmove -c 2 1 \
-    s6-rc -v 2 -d change mariadb-lock
+exec &> /proc/1/fd/1
+exec s6-rc -v 2 -d change mariadb-lock

--- a/mariadb/rootfs/usr/bin/unlock-tables-for-backup
+++ b/mariadb/rootfs/usr/bin/unlock-tables-for-backup
@@ -1,0 +1,9 @@
+#!/command/with-contenv bashio
+# shellcheck shell=bash
+# ==============================================================================
+# Unlock tables for backup
+# ==============================================================================
+
+redirfd -wn 1 /proc/1/fd/1 \
+    fdmove -c 2 1 \
+    s6-rc -v 2 -d change mariadb-lock


### PR DESCRIPTION
This is a fix for #2983

cc @agners

In #2983 I used a workaround to write s6 service log messages to the add-on's log (`exec &> /proc/1/fd/1` in each oneshot service script). This is ugly.

After another few hours of googling and experimenting the proper solution seems to be:
- use s6 commands to redirect stdout and stderr before executing the command: `redirfd -wn 1 /proc/1/fd/1 fdmove -c 2 1 <COMMAND>` is roughly equivalent to `/bin/sh -c 'exec &> /proc/1/fd/1; exec <COMMAND>'`
- add `-v 2` to s6-rc to emit messages like `s6-rc: info: service mariadb-lock-core: starting`

Note: I think it is better to put these redirects into the config.yaml than to add it to supervisor, because it is not mandatory for an add-on to use s6 or /proc/1/fd/1 for logging.

With these modifications the add-on's log during backup is:
```
s6-rc: info: service mariadb-lock-core: starting
[16:49:04] INFO: Start MariaDB client (to lock tables for backups)
s6-rc: info: service mariadb-lock-core successfully started
s6-rc: info: service mariadb-lock-post: starting
[16:49:05] INFO: MariaDB tables locked
s6-rc: info: service mariadb-lock-post successfully started
s6-rc: info: service mariadb-lock-post: stopping
[16:49:16] INFO: MariaDB tables unlocked
s6-rc: info: service mariadb-lock-post successfully stopped
s6-rc: info: service mariadb-lock-core: stopping
[16:49:16] INFO: MariaDB client (to lock tables for backups) stopped
s6-rc: info: service mariadb-lock-core successfully stopped
```
