### PR TITLE
Remove "auto" language option from Whisper

### DIFF
--- a/whisper/DOCS.md
+++ b/whisper/DOCS.md
@@ -24,7 +24,7 @@ for more information.
 
 ### Option: `language`
 
-Language that you will speak to the add-on. If you select "auto", the model will run **much** slower but will auto-detect the spoken language.
+Language that you will speak to the add-on (default: "en").
 
 [Performance of supported languages](https://github.com/openai/whisper#available-models-and-languages)
 

--- a/whisper/config.yaml
+++ b/whisper/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.1.1
+version: 0.1.2
 slug: whisper
 name: Whisper
 description: Speech-to-text with Whisper
@@ -17,7 +17,7 @@ options:
 schema:
   model: list(tiny-int8|tiny|base|base-int8|small-int8|small|medium-int8)
   language: |
-    list(auto|af|am|ar|as|az|ba|be|bg|bn|bo|br|bs|ca|cs|cy|da|de|el|en|es|et|eu|fa|fi|fo|fr|gl|gu|ha|haw|he|hi|hr|ht|hu|hy|id|is|it|ja|jw|ka|kk|km|kn|ko|la|lb|ln|lo|lt|lv|mg|mi|mk|ml|mn|mr|ms|mt|my|ne|nl|nn|no|oc|pa|pl|ps|pt|ro|ru|sa|sd|si|sk|sl|sn|so|sq|sr|su|sv|sw|ta|te|tg|th|tk|tl|tr|tt|uk|ur|uz|vi|yi|yo|zh)
+    list(af|am|ar|as|az|ba|be|bg|bn|bo|br|bs|ca|cs|cy|da|de|el|en|es|et|eu|fa|fi|fo|fr|gl|gu|ha|haw|he|hi|hr|ht|hu|hy|id|is|it|ja|jw|ka|kk|km|kn|ko|la|lb|ln|lo|lt|lv|mg|mi|mk|ml|mn|mr|ms|mt|my|ne|nl|nn|no|oc|pa|pl|ps|pt|ro|ru|sa|sd|si|sk|sl|sn|so|sq|sr|su|sv|sw|ta|te|tg|th|tk|tl|tr|tt|uk|ur|uz|vi|yi|yo|zh)
   beam_size: int
 ports:
   "10300/tcp": null


### PR DESCRIPTION
The "auto" language option is confusing, slow, and will not work with the current wyoming-whisper library.
Removing from the add-on config.