### PR TITLE
letsencrypt: Backup existing cert/key pair before updating

### DIFF
--- a/letsencrypt/rootfs/etc/services.d/lets-encrypt/run
+++ b/letsencrypt/rootfs/etc/services.d/lets-encrypt/run
@@ -166,5 +166,8 @@ fi
 # Get the last modified cert directory and copy the cert and private key to store
 # shellcheck disable=SC2012
 CERT_DIR_LATEST="$(ls -td $CERT_DIR/live/*/ | head -1)"
+BACKUP_EXTENTION=".bak"
+cp "/ssl/$KEYFILE" "/ssl/$KEYFILE$BACKUP_EXTENTION"
+cp "/ssl/$CERTFILE" "/ssl/$CERTFILE$BACKUP_EXTENTION"
 cp "${CERT_DIR_LATEST}privkey.pem" "/ssl/$KEYFILE"
 cp "${CERT_DIR_LATEST}fullchain.pem" "/ssl/$CERTFILE"


### PR DESCRIPTION
Added backup of existing cert/key pair before updating new cert/key pair