### PR TITLE
Fix Piper multi-line, voice checksum

### DIFF
--- a/piper/CHANGELOG.md
+++ b/piper/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.1.3
+
+- Fix multi-line input
+- Verify voice hashes on download
+- Add 4 Icelandic voices
+    - `is-bui-medium`
+    - `is-salka-medium`
+    - `is-steinn-medium`
+    - `is-ugla-medium`
+- Add 1 Russian voice
+    - `ru-irinia-medium`
+
 ## 0.1.2
 
 - Update list of available voices

--- a/piper/DOCS.md
+++ b/piper/DOCS.md
@@ -63,6 +63,11 @@ The following voices are available:
     - `fr-siwis-medium`
     - `fr-gilles-low`
     - `fr-mls_1840-low`
+- Icelandic
+    - `is-bui-medium`
+    - `is-salka-medium`
+    - `is-steinn-medium`
+    - `is-ugla-medium`
 - Italian
     - `it-riccardo_fasol-x-low`
 - Kazakh
@@ -84,6 +89,8 @@ The following voices are available:
     - `pl-mls_6892-low`
 - Brazilian Portuguese
     - `pt-br-edresson-low`
+- Russian
+    - `ru-irinia-medium`
 - Ukrainian
     - `uk-lada-x-low`
 - Vietnamese

--- a/piper/build.yaml
+++ b/piper/build.yaml
@@ -6,5 +6,5 @@ codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
 args:
-  PIPER_LIB_VERSION: 0.0.2
+  PIPER_LIB_VERSION: 0.0.3
   PIPER_RELEASE: v0.0.2

--- a/piper/config.yaml
+++ b/piper/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.1.2
+version: 0.1.3
 slug: piper
 name: Piper
 description: Text-to-speech with Piper
@@ -18,7 +18,7 @@ options:
   noise_w: 0.333
 schema:
   voice: |
-    list(ca-upc_ona-x-low|ca-upc_pau-x-low|da-nst_talesyntese-medium|de-eva_k-x-low|de-karlsson-low|de-kerstin-low|de-pavoque-low|de-ramona-low|de-thorsten-low|el-gr-rapunzelina-low|en-gb-alan-low|en-gb-southern_english_female-low|en-us-amy-low|en-us-danny-low|en-us-kathleen-low|en-us-lessac-low|en-us-lessac-medium|en-us-libritts-high|en-us-ryan-high|en-us-ryan-low|en-us-ryan-medium|es-carlfm-x-low|es-mls_10246-low|es-mls_9972-low|fi-harri-low|fr-gilles-low|fr-mls_1840-low|fr-siwis-low|fr-siwis-medium|it-riccardo_fasol-x-low|kk-iseke-x-low|kk-issai-high|kk-raya-x-low|ne-google-medium|ne-google-x-low|nl-mls_5809-low|nl-mls_7432-low|nl-nathalie-x-low|nl-rdh-medium|nl-rdh-x-low|no-talesyntese-medium|pl-mls_6892-low|pt-br-edresson-low|uk-lada-x-low|vi-25hours-single-low|vi-vivos-x-low|zh-cn-huayan-x-low)
+    list(ca-upc_ona-x-low|ca-upc_pau-x-low|da-nst_talesyntese-medium|de-eva_k-x-low|de-karlsson-low|de-kerstin-low|de-pavoque-low|de-ramona-low|de-thorsten-low|el-gr-rapunzelina-low|en-gb-alan-low|en-gb-southern_english_female-low|en-us-amy-low|en-us-danny-low|en-us-kathleen-low|en-us-lessac-low|en-us-lessac-medium|en-us-libritts-high|en-us-ryan-high|en-us-ryan-low|en-us-ryan-medium|es-carlfm-x-low|es-mls_10246-low|es-mls_9972-low|fi-harri-low|fr-gilles-low|fr-mls_1840-low|fr-siwis-low|fr-siwis-medium|is-bui-medium|is-salka-medium|is-steinn-medium|is-ugla-medium|it-riccardo_fasol-x-low|kk-iseke-x-low|kk-issai-high|kk-raya-x-low|ne-google-medium|ne-google-x-low|nl-mls_5809-low|nl-mls_7432-low|nl-nathalie-x-low|nl-rdh-medium|nl-rdh-x-low|no-talesyntese-medium|pl-mls_6892-low|pt-br-edresson-low|ru-irinia-medium|uk-lada-x-low|vi-25hours-single-low|vi-vivos-x-low|zh-cn-huayan-x-low)
   speaker: int
   length_scale: float
   noise_scale: float


### PR DESCRIPTION
Fixes for Piper add-on:

- Fix multi-line input
- Verify voice hashes on download
- Add 4 Icelandic voices
    - `is-bui-medium`
    - `is-salka-medium`
    - `is-steinn-medium`
    - `is-ugla-medium`
- Add 1 Russian voice
    - `ru-irinia-medium`

Fixes issue: https://github.com/home-assistant/addons/issues/3028