### PR TITLE
nginx_proxy: update to Alpine 3.18, nginx 1.24.x

### DIFF
--- a/nginx_proxy/CHANGELOG.md
+++ b/nginx_proxy/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.5.0
+
+- Update Alpine to 3.18 (nginx 1.24.x)
+
 ## 3.4.2
 
 - Decrease crond log level

--- a/nginx_proxy/build.yaml
+++ b/nginx_proxy/build.yaml
@@ -1,10 +1,10 @@
 ---
 build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-base:3.16
-  amd64: ghcr.io/home-assistant/amd64-base:3.16
-  armhf: ghcr.io/home-assistant/armhf-base:3.16
-  armv7: ghcr.io/home-assistant/armv7-base:3.16
-  i386: ghcr.io/home-assistant/i386-base:3.16
+  aarch64: ghcr.io/home-assistant/aarch64-base:3.18
+  amd64: ghcr.io/home-assistant/amd64-base:3.18
+  armhf: ghcr.io/home-assistant/armhf-base:3.18
+  armv7: ghcr.io/home-assistant/armv7-base:3.18
+  i386: ghcr.io/home-assistant/i386-base:3.18
 codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io

--- a/nginx_proxy/config.yaml
+++ b/nginx_proxy/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 3.4.2
+version: 3.5.0
 hassio_api: true
 slug: nginx_proxy
 name: NGINX Home Assistant SSL proxy


### PR DESCRIPTION
Caveat: tested only to the extent that the container builds, and `nginx -t -c /etc/nginx.conf` does not complain about anything (placeholders in conf replaced manually and fake cert & key copied in the container). IoW, not tried to actually run this.