### PR TITLE
Bump zwave-js to 10.21.0

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Optimized the config parameter queries during the interview to take much less time in many cases
 - Some minor changes to better comply with the Z-Wave specification
 
-#### Config file changes
+### Config file changes
 
 - Add configuration for Zooz ZEN53, 54, 55
 - Extend version range for Vesternet VES-ZW-HLD-016

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -2,9 +2,7 @@
 
 ## 0.1.81
 
-### Notable changes
-
-#### Bug fixes
+### Bug fixes
 
 - Fixed several crashes
 - Expose some device functionality that would previously be hidden as redundant

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.1.81
+- [Bump Z-Wave JS to 10.21.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v10.21.0)
+- [Bump Z-Wave JS to 10.20.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v10.20.0)
+- [Bump Z-Wave JS to 10.19.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v10.19.0)
+- [Bump Z-Wave JS to 10.18.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v10.18.0)
+- [Bump Z-Wave JS to 10.17.1](https://github.com/zwave-js/node-zwave-js/releases/tag/v10.17.1)
+
 ## 0.1.80
 
 - [Bump Z-Wave JS to 10.17.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v10.17.0)

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,11 +1,6 @@
 # Changelog
 
 ## 0.1.81
-- [Bump Z-Wave JS to 10.21.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v10.21.0)
-- [Bump Z-Wave JS to 10.20.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v10.20.0)
-- [Bump Z-Wave JS to 10.19.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v10.19.0)
-- [Bump Z-Wave JS to 10.18.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v10.18.0)
-- [Bump Z-Wave JS to 10.17.1](https://github.com/zwave-js/node-zwave-js/releases/tag/v10.17.1)
 
 ### Notable changes
 
@@ -24,6 +19,14 @@
 - Extend version range for Vesternet VES-ZW-HLD-016
 - Add 700 series variant of SimonTech Roller Blind
 - Updated instructions for Leviton VRS15 and ZW15R
+
+### Detailed changelogs
+
+- [Bump Z-Wave JS to 10.21.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v10.21.0)
+- [Bump Z-Wave JS to 10.20.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v10.20.0)
+- [Bump Z-Wave JS to 10.19.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v10.19.0)
+- [Bump Z-Wave JS to 10.18.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v10.18.0)
+- [Bump Z-Wave JS to 10.17.1](https://github.com/zwave-js/node-zwave-js/releases/tag/v10.17.1)
 
 ## 0.1.80
 

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -7,6 +7,24 @@
 - [Bump Z-Wave JS to 10.18.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v10.18.0)
 - [Bump Z-Wave JS to 10.17.1](https://github.com/zwave-js/node-zwave-js/releases/tag/v10.17.1)
 
+### Notable changes
+
+#### Bug fixes
+
+- Fixed several crashes
+- Expose some device functionality that would previously be hidden as redundant
+- Auto-discovered config parameters (for new devices) can now be edited
+- Properly support config parameters above number 255
+- Optimized the config parameter queries during the interview to take much less time in many cases
+- Some minor changes to better comply with the Z-Wave specification
+
+#### Config file changes
+
+- Add configuration for Zooz ZEN53, 54, 55
+- Extend version range for Vesternet VES-ZW-HLD-016
+- Add 700 series variant of SimonTech Roller Blind
+- Updated instructions for Leviton VRS15 and ZW15R
+
 ## 0.1.80
 
 - [Bump Z-Wave JS to 10.17.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v10.17.0)

--- a/zwave_js/build.yaml
+++ b/zwave_js/build.yaml
@@ -10,4 +10,4 @@ codenotary:
   base_image: notary@home-assistant.io
 args:
   ZWAVEJS_SERVER_VERSION: 1.28.0
-  ZWAVEJS_VERSION: 10.17.0
+  ZWAVEJS_VERSION: 10.21.0

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.1.80
+version: 0.1.81
 slug: zwave_js
 name: Z-Wave JS
 description: Control a Z-Wave network with Home Assistant Z-Wave JS


### PR DESCRIPTION
- [Bump Z-Wave JS to 10.21.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v10.21.0)
- [Bump Z-Wave JS to 10.20.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v10.20.0)
- [Bump Z-Wave JS to 10.19.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v10.19.0)
- [Bump Z-Wave JS to 10.18.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v10.18.0)
- [Bump Z-Wave JS to 10.17.1](https://github.com/zwave-js/node-zwave-js/releases/tag/v10.17.1)

Mostly bug fixes...

Features:
- Add `states` for `boolean` property (this is not well supported by the core right now but will be once the next core release comes out)

CC @AlCalzone - I recall a conversation about improving the changelog, open to suggestions here