### PR TITLE
matter_server: Bump Python Matter server to 3.4.1 and Python 3.11

### DIFF
--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 4.5.0
+
+- Bump Python Matter Server to [3.4.1](https://github.com/home-assistant-libs/python-matter-server/releases/tag/3.4.0)
+- Bump to Python 3.11
+
 ## 4.4.0
 
 - Bump Python Matter Server to [3.4.0](https://github.com/home-assistant-libs/python-matter-server/releases/tag/3.4.0)

--- a/matter_server/Dockerfile
+++ b/matter_server/Dockerfile
@@ -86,13 +86,7 @@ RUN \
        libjson-c5 \
        unzip \
        gdb \
-       gcc \
-       linux-libc-dev \
-       libc6-dev \
     && pip3 install --no-cache-dir "python-matter-server[server]==${MATTER_SERVER_VERSION}" \
-    && apt-get purge -y --auto-remove \
-       gcc \
-       linux-libc-dev \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /usr/src/*
 

--- a/matter_server/build.yaml
+++ b/matter_server/build.yaml
@@ -1,9 +1,9 @@
 ---
 build_from:
-  aarch64: python:3.10-slim-bullseye
-  amd64: python:3.10-slim-bullseye
+  aarch64: python:3.11-slim-bullseye
+  amd64: python:3.11-slim-bullseye
 args:
   BASHIO_VERSION: 0.14.3
   TEMPIO_VERSION: 2021.09.0
   S6_OVERLAY_VERSION: 3.1.5.0
-  MATTER_SERVER_VERSION: 3.4.0
+  MATTER_SERVER_VERSION: 3.4.1


### PR DESCRIPTION
Thanks to dropped dependencies in the Python wheels (specifically by this patch https://github.com/home-assistant-libs/chip-wheels/pull/13/files#diff-e8aa12132d0c8c31085c56ab7267ddf83b7d266019134ebb73ee7ad1e2819feb), the build utilities are no longer required.