### PR TITLE
Bump zwave-js to 10.22.2

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.1.82
+
+### Bug fixes
+
+- Fixed a crash scenario
+- Fixed an issue that caused device values to stop updating
+
+### Detailed changelogs
+
+- [Bump Z-Wave JS to 10.22.1](https://github.com/zwave-js/node-zwave-js/releases/tag/v10.22.1)
+- [Bump Z-Wave JS to 10.22.2](https://github.com/zwave-js/node-zwave-js/releases/tag/v10.22.2)
+
 ## 0.1.81
 
 ### Bug fixes

--- a/zwave_js/build.yaml
+++ b/zwave_js/build.yaml
@@ -10,4 +10,4 @@ codenotary:
   base_image: notary@home-assistant.io
 args:
   ZWAVEJS_SERVER_VERSION: 1.28.0
-  ZWAVEJS_VERSION: 10.21.0
+  ZWAVEJS_VERSION: 10.22.2

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.1.81
+version: 0.1.82
 slug: zwave_js
 name: Z-Wave JS
 description: Control a Z-Wave network with Home Assistant Z-Wave JS


### PR DESCRIPTION
This is a critical bugfix release. In tests it comes up cleanly with no nodes attached to the controller.


### Detailed changelogs

- [Bump Z-Wave JS to 10.22.1](https://github.com/zwave-js/node-zwave-js/releases/tag/v10.22.1)
- [Bump Z-Wave JS to 10.22.2](https://github.com/zwave-js/node-zwave-js/releases/tag/v10.22.2)

@AlCalzone FYI