### PR TITLE
Bump zwave-js to 10.23.2

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -399,7 +399,7 @@
 
 ## 0.1.10
 
-- [Bump Z-Wave JS Server to 1.1.0.](https://github.com/zwave-js/zwave-js-server/releases/tag/1.1.0) This is the same code as 2.0.0. Home Assistant 2021.2 rejects any ZJS Server version that is v2+
+- [Bump Z-Wave JS Server to 1.1.0](https://github.com/zwave-js/zwave-js-server/releases/tag/1.1.0) This is the same code as 2.0.0. Home Assistant 2021.2 rejects any ZJS Server version that is v2+
 
 ## 0.1.9
 

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.1.84
+
+### Bug fixes
+
+- The Celsius temperature scale is no longer set as a preferred scale by default
+- Nodes are no longer assumed to be awake when they send a NonceGet
+- Disable optimistic value update for unsupervised Barrier Operator CC commands
+- Improve handling of unexpected/incorrect commands during S2 bootstrapping
+
+### Config file changes
+
+- Correct config parameters for Duwi ZW ESJ 300
+
+### Detailed changelogs
+
+- [Bump Z-Wave JS to 10.23.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v10.23.0)
+- [Bump Z-Wave JS to 10.23.1](https://github.com/zwave-js/node-zwave-js/releases/tag/v10.23.1)
+- [Bump Z-Wave JS to 10.23.2](https://github.com/zwave-js/node-zwave-js/releases/tag/v10.23.2)
+
 ## 0.1.83
 
 ### Bug fixes

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -7,7 +7,6 @@
 - Fixed an issue which could cause temperature to be shown in Celsius instead of Fahrenheit
 - Fixed an issue which could cause devices to be incorrectly considered to be awake
 - Verify state change for barrier devices without support for Supervision CC instead of assuming commands to succeed
-- Improve handling of unexpected/incorrect commands during S2 bootstrapping
 
 ### Config file changes
 

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Bug fixes
 
 - Fixed an issue which could cause temperature to be shown in Celsius instead of Fahrenheit
-- Nodes are no longer assumed to be awake when they send a NonceGet
+- Fixed an issue which could cause devices to be incorrectly considered to be awake
 - Disable optimistic value update for unsupervised Barrier Operator CC commands
 - Improve handling of unexpected/incorrect commands during S2 bootstrapping
 

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Fixed an issue which could cause temperature to be shown in Celsius instead of Fahrenheit
 - Fixed an issue which could cause devices to be incorrectly considered to be awake
-- Disable optimistic value update for unsupervised Barrier Operator CC commands
+- Verify state change for barrier devices without support for Supervision CC instead of assuming commands to succeed
 - Improve handling of unexpected/incorrect commands during S2 bootstrapping
 
 ### Config file changes

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-- The Celsius temperature scale is no longer set as a preferred scale by default
+- Fixed an issue which could cause temperature to be shown in Celsius instead of Fahrenheit
 - Nodes are no longer assumed to be awake when they send a NonceGet
 - Disable optimistic value update for unsupervised Barrier Operator CC commands
 - Improve handling of unexpected/incorrect commands during S2 bootstrapping

--- a/zwave_js/build.yaml
+++ b/zwave_js/build.yaml
@@ -10,4 +10,4 @@ codenotary:
   base_image: notary@home-assistant.io
 args:
   ZWAVEJS_SERVER_VERSION: 1.28.0
-  ZWAVEJS_VERSION: 10.22.3
+  ZWAVEJS_VERSION: 10.23.2

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.1.83
+version: 0.1.84
 slug: zwave_js
 name: Z-Wave JS
 description: Control a Z-Wave network with Home Assistant Z-Wave JS


### PR DESCRIPTION
Mostly bug fixes

Changelog
- [Bump Z-Wave JS to 10.23.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v10.23.0)
- [Bump Z-Wave JS to 10.23.1](https://github.com/zwave-js/node-zwave-js/releases/tag/v10.23.1)
- [Bump Z-Wave JS to 10.23.2](https://github.com/zwave-js/node-zwave-js/releases/tag/v10.23.2)

CC @AlCalzone feel free to suggest release note changes but I highlighted the ones I thought would be relevant to users