### PR TITLE
matter_server: Bump Python Matter server to 3.5.2

### DIFF
--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 4.7.0
+
+- Use the Python Matter Server container as base
+- Bump Python Matter Server to [3.5.2](https://github.com/home-assistant-libs/python-matter-server/releases/tag/3.5.2)
+
 ## 4.6.1
 
 - Bump Python Matter Server to [3.5.1](https://github.com/home-assistant-libs/python-matter-server/releases/tag/3.5.1)

--- a/matter_server/Dockerfile
+++ b/matter_server/Dockerfile
@@ -18,8 +18,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG \
     BASHIO_VERSION \
     TEMPIO_VERSION \
-    S6_OVERLAY_VERSION \
-    QEMU_CPU
+    S6_OVERLAY_VERSION
 
 # Base system
 WORKDIR /usr/src
@@ -73,23 +72,5 @@ RUN \
 # S6-Overlay
 WORKDIR /root
 ENTRYPOINT ["/init"]
-
-ARG MATTER_SERVER_VERSION
-
-RUN \
-    set -x \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends \
-       libuv1 \
-       openssl \
-       zlib1g \
-       libjson-c5 \
-       libnl-3-200 \
-       libnl-route-3-200 \
-       unzip \
-       gdb \
-    && pip3 install --no-cache-dir "python-matter-server[server]==${MATTER_SERVER_VERSION}" \
-    && rm -rf /var/lib/apt/lists/* \
-    && rm -rf /usr/src/*
 
 COPY rootfs /

--- a/matter_server/build.yaml
+++ b/matter_server/build.yaml
@@ -1,9 +1,8 @@
 ---
 build_from:
-  aarch64: python:3.11-slim-bullseye
-  amd64: python:3.11-slim-bullseye
+  aarch64: ghcr.io/home-assistant-libs/python-matter-server:3.5.2
+  amd64: ghcr.io/home-assistant-libs/python-matter-server:3.5.2
 args:
   BASHIO_VERSION: 0.14.3
   TEMPIO_VERSION: 2021.09.0
   S6_OVERLAY_VERSION: 3.1.5.0
-  MATTER_SERVER_VERSION: 3.5.1

--- a/matter_server/config.yaml
+++ b/matter_server/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 4.6.1
+version: 4.7.0
 slug: matter_server
 name: Matter Server
 description: Matter WebSocket Server for Home Assistant Matter support.


### PR DESCRIPTION
With this upgrade also use the Python Matter container image as base for this add-on.