### PR TITLE
Exclude Whisper model files from backups

### DIFF
--- a/whisper/CHANGELOG.md
+++ b/whisper/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.1
+
+- Exclude `*.bin` model files from backup
+
 ## 0.2.0
 
 - Hash model files at startup to detect bad downloads

--- a/whisper/DOCS.md
+++ b/whisper/DOCS.md
@@ -54,6 +54,10 @@ Number of candidates to consider simultaneously during transcription (see [beam 
 
 Increasing the beam size will increase accuracy at the cost of performance.
 
+## Backups
+
+Whisper model files can be quite large, so they are automatically excluded from backups. The models will be re-downloaded when the backup is restored.
+
 ## Support
 
 Got questions?

--- a/whisper/config.yaml
+++ b/whisper/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.2.0
+version: 0.2.1
 slug: whisper
 name: Whisper
 description: Speech-to-text with Whisper
@@ -10,6 +10,8 @@ arch:
 init: false
 discovery:
   - wyoming
+backup_exclude:
+  - "*.bin"
 options:
   model: tiny-int8
   language: en


### PR DESCRIPTION
Excludes large `.bin` Whisper model files from backups.