### PR TITLE
Workaround for missing log level in matter add-on

### DIFF
--- a/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
+++ b/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
@@ -7,7 +7,11 @@ bashio::log.info "Starting Matter Server..."
 declare server_port
 declare log_level
 
-log_level=$(bashio::string.lower "$(bashio::config log_level)")
+log_level=$(bashio::string.lower "$(bashio::config log_level invalid)")
+if [ "$log_level" = "invalid" ]; then
+  bashio::log.magenta 'Received invalid log_level from config, fallback to info'
+  log_level="info"
+fi
 
 # Bind to internal hassio network only unless user requests to expose
 server_port="$(bashio::addon.port 5580)"


### PR DESCRIPTION
We received some reports that sometimes the log_level is read as 'NULL', probably because the api call failed or something.
Although this must be addressed the proper way, this is a temporary bandaid to prevent a crashing add-on.

As a small reminder this behavior is logged.