### PR TITLE
Add Trusted CA User Keys as SSH configuration option

### DIFF
--- a/ssh/CHANGELOG.md
+++ b/ssh/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 9.8.0
+
+- Add Trusted CA User Keys to configuration
+
 ## 9.7.1
 
 - Upgrade Home Assistant CLI to 4.26.0

--- a/ssh/DOCS.md
+++ b/ssh/DOCS.md
@@ -53,6 +53,7 @@ password: ''
 apks: []
 server:
   tcp_forwarding: false
+  trusted_user_ca_keys: ""
 ```
 
 ### Option: `apks`
@@ -78,6 +79,10 @@ Some SSH server options.
 Specifies whether TCP forwarding is permitted or not.
 
 **Note**: _Enabling this option lowers the security of your SSH server! Nevertheless, this warning is debatable._
+
+#### Option `trusted_user_ca_keys`
+
+Sets the public key of an SSH certificate authority to trust.
 
 ## Network
 

--- a/ssh/config.yaml
+++ b/ssh/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 9.7.1
+version: 9.8.0
 slug: ssh
 name: Terminal & SSH
 description: Allow logging in remotely to Home Assistant using SSH
@@ -32,6 +32,7 @@ options:
   apks: []
   server:
     tcp_forwarding: false
+    trusted_user_ca_keys: ""
 panel_icon: mdi:console
 panel_title: Terminal
 ports:
@@ -44,5 +45,6 @@ schema:
     - str
   server:
     tcp_forwarding: bool
+    trusted_user_ca_keys: str
 startup: services
 uart: true

--- a/ssh/rootfs/etc/cont-init.d/ssh.sh
+++ b/ssh/rootfs/etc/cont-init.d/ssh.sh
@@ -42,6 +42,10 @@ elif bashio::var.has_value "$(bashio::addon.port 22)"; then
     bashio::exit.nok "You need to setup a login!"
 fi
 
+if bashio::config.has_value 'server.trusted_user_ca_keys'; then
+    echo "$(bashio::config 'server.trusted_user_ca_keys')" > /etc/ssh/ssh_ca.pub
+fi
+
 # Generate config
 mkdir -p /etc/ssh
 tempio \

--- a/ssh/rootfs/usr/share/tempio/sshd_config
+++ b/ssh/rootfs/usr/share/tempio/sshd_config
@@ -25,3 +25,5 @@ PermitEmptyPasswords no
 {{ end }}
 
 PermitUserEnvironment SUPERVISOR_TOKEN
+
+{{ if .server.trusted_user_ca_keys }}TrustedUserCAKeys /etc/ssh/ssh_ca.pub{{ end }}


### PR DESCRIPTION
This PR adds an additional option at `server.trusted_user_ca_keys` which sets the TrustedUserCAKeys value within sshd_config, as well as writes the value to `/etc/ssh/ssh_ca.pub`. This will enable users with public keys signed by that Certificate Authority to connect to OpenSSH without needing to list authorized_keys.