### PR TITLE
add support for dns rebind attack prevention

### DIFF
--- a/dnsmasq/CHANGELOG.md
+++ b/dnsmasq/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.6.1
+
+- Adds support for stop-dns-rebind to prevent dns rebind attack 
+- Adds support for rebind-domain-ok
+
 ## 1.6.0
 
 - Update to Alpine 3.17

--- a/dnsmasq/DOCS.md
+++ b/dnsmasq/DOCS.md
@@ -39,6 +39,7 @@ services:
     priority: 0
     weight: 100
 log_queries: false
+rebind_stop: false
 ```
 
 ### Option: `defaults` (required)
@@ -119,9 +120,21 @@ The name to resolve.
 
 The target name. Note that this only works for targets which are names from DHCP or /etc/hosts. Give host "bert" another name, bertrand cname=bertand,bert
 
+### Option: `rebind_domains` (optional)
+
+This option allows you to provide domains to skip dns-rebind checks if you have set `rebind_stop` to true.
+
+#### Option: `rebind_domains.domains`
+
+The domain that dns-rebind will not be prevented on.
+
 ### Option: `log_queries` (required) 
 
 Log all DNS requests. Defaults to `false`.
+
+### Option: `rebind_stop` (required) 
+
+Reject addresses from upstream nameservers. This blocks an attack where a browser behind a firewall is used to probe machines on the local network. Defaults to `false`.
 
 ## Support
 

--- a/dnsmasq/config.yaml
+++ b/dnsmasq/config.yaml
@@ -21,7 +21,9 @@ options:
   hosts: []
   services: []
   cnames: []
+  rebind_domains: []
   log_queries: false
+  rebind_stop: false
 ports:
   53/tcp: 53
   53/udp: 53
@@ -43,5 +45,8 @@ schema:
   cnames:
     - name: str
       target: str
+  rebind_domains:
+    - domain: str
   log_queries: bool
+  rebind_stop: bool
 startup: system

--- a/dnsmasq/rootfs/usr/share/tempio/dnsmasq.config
+++ b/dnsmasq/rootfs/usr/share/tempio/dnsmasq.config
@@ -10,6 +10,17 @@ log-facility=-
 no-poll
 user=root
 
+{{ if .rebind_stop }}
+stop-dns-rebind
+rebind-localhost-ok
+
+# Domain rebinding allowed
+{{ range .rebind_domains }}
+rebind-domain-ok=/{{ .domain }}/
+{{ end }}
+
+{{ end }}
+
 # Default forward servers
 {{ range .defaults }}
 server={{ . }}
@@ -34,3 +45,5 @@ srv-host={{ .srv }},{{ .host }},{{ .port }},{{ .priority }},{{ .weight }}
 {{ range .cnames }}
 cname={{ .name }},{{ .target }}
 {{ end }}
+
+


### PR DESCRIPTION
this is a draft PR to explore the possibility of enabling a valuable dnsmasq security feature

it still needs testing and advice if folks are open to the suggestion

----------------

[dnsmasq](https://thekelleys.org.uk/dnsmasq/docs/dnsmasq-man.html) has support for [dns rebind attack](https://en.wikipedia.org/wiki/DNS_rebinding) prevention

this PR allows users to opt into this feature and add domains to the skip list