### PR TITLE
Bump zwave-js to 11.6.0 and zwave-js-server to 1.30.0

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,70 @@
 # Changelog
 
+## 0.1.85
+
+### New features
+
+- Z-Wave JS Server: Add support for inclusions that are started outside of Z-Wave JS Server
+- Z-Wave JS Server: Add support for lastSeen property
+- Z-Wave JS: Improve support for "identify" commands
+- Z-Wave JS: Add API to discover node neighbors
+- Z-Wave JS: Add support for assigning custom return routes and reading previously set priority return routes from cache
+
+### Bug fixes
+
+- Z-Wave JS Server: Fix hard reset support in Z-Wave JS Server
+- Z-Wave JS: Fix an issue that sometimes occurred when attempting to remove a node from the network
+- Z-Wave JS: Fix handling of incoming S2 multicast commands
+
+### Config file changes
+
+- Correct config parameters for Duwi ZW ESJ 300
+- Add new FW3.6 parameters to Aeotec ZW141 Nano Shutter
+- Add metadata to HANK Electronics Ltd. HKZW-SO01
+- Hide Binary Switch CC in favor of Window Covering CC on iBlinds v3
+- Remove unnecessary endpoints for RTC CT32
+- Update Swidget devices to match their June 8th 2023 spec
+- Add endpoint configuration parameters to SES 302
+- Disable Window Covering CC for ZVIDAR Roller Blind
+- Add missing product type to Aeotec Water Sensor 7 Basic ZWA018
+- Override endpoint indizes for heatapp! floor
+- Override schedule slot count for P-KFCON-MOD-YALE
+- Override supported color channels for Zipato RGBW Bulb2
+- Override supported thermostat modes for Z-Wave.me ZME_FT
+- Add Heatit ZM Dimmer
+- Add Heatit Z-HAN2
+- Add Remotec ZXT-800
+- Clarify Hand Button action for ZVIDAR Z-CM-V01 Smart Curtain Motor
+- Add MCOHome MH-S220 FW 3.2
+- Add another device ID for Switch IO On/Off Power Switch
+- Add/fix params for Intermatic PE653
+- Add ShenZhen Sunricher Technology Multisensor SR-ZV9032A-EU
+- Add new fingerprint for Zooz ZST10-700
+- Fix Zooz ZSE40 parameters 7 and 8
+- Correct parameters of Zooz ZEN05
+- Override supported setpoint types for Intermatic PE653
+- Update Inovelli LZW31 parameter 52 for FW 1.54
+
+### Detailed changelogs
+
+- [Bump Z-Wave JS Server to 1.29.0](https://github.com/zwave-js/zwave-js-server/releases/tag/1.29.0)
+- [Bump Z-Wave JS Server to 1.29.1](https://github.com/zwave-js/zwave-js-server/releases/tag/1.29.1)
+- [Bump Z-Wave JS Server to 1.30.0](https://github.com/zwave-js/zwave-js-server/releases/tag/1.30.0)
+- [Bump Z-Wave JS to 10.23.4](https://github.com/zwave-js/node-zwave-js/releases/tag/v10.23.4)
+- [Bump Z-Wave JS to 10.23.5](https://github.com/zwave-js/node-zwave-js/releases/tag/v10.23.5)
+- [Bump Z-Wave JS to 10.23.6](https://github.com/zwave-js/node-zwave-js/releases/tag/v10.23.6)
+- [Bump Z-Wave JS to 11.0.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v11.0.0)
+- [Bump Z-Wave JS to 11.1.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v11.1.0)
+- [Bump Z-Wave JS to 11.2.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v11.2.0)
+- [Bump Z-Wave JS to 11.3.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v11.3.0)
+- [Bump Z-Wave JS to 11.4.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v11.4.0)
+- [Bump Z-Wave JS to 11.4.1](https://github.com/zwave-js/node-zwave-js/releases/tag/v11.4.1)
+- [Bump Z-Wave JS to 11.4.2](https://github.com/zwave-js/node-zwave-js/releases/tag/v11.4.2)
+- [Bump Z-Wave JS to 11.5.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v11.5.0)
+- [Bump Z-Wave JS to 11.5.1](https://github.com/zwave-js/node-zwave-js/releases/tag/v11.5.1)
+- [Bump Z-Wave JS to 11.5.2](https://github.com/zwave-js/node-zwave-js/releases/tag/v11.5.2)
+- [Bump Z-Wave JS to 11.5.3](https://github.com/zwave-js/node-zwave-js/releases/tag/v11.5.3)
+
 ## 0.1.84
 
 ### Bug fixes

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -6,9 +6,8 @@
 
 - Z-Wave JS Server: Add support for inclusions that are started outside of Z-Wave JS Server
 - Z-Wave JS Server: Add support for lastSeen property
-- Z-Wave JS: Improve support for "identify" commands
-- Z-Wave JS: Add API to discover node neighbors
-- Z-Wave JS: Add support for assigning custom return routes and reading previously set priority return routes from cache
+- Z-Wave JS: Add support for identifying on request of other nodes
+- Z-Wave JS: Improved auto-discovery of config parameters
 
 ### Bug fixes
 

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -47,6 +47,11 @@
 - Correct parameters of Zooz ZEN05
 - Override supported setpoint types for Intermatic PE653
 - Update Inovelli LZW31 parameter 52 for FW 1.54
+- Add new product id to Fakro ZWS12
+- Disable Supervision for NICE Spa IBT4ZWAVE
+- Add variant of Inovelli NZW31T with manufacturer ID 0x015d
+- Split and correct Minoston MP21Z/MP31Z/MP21ZP/MP31ZP config files
+- Add EVA LOGIK (NIE Tech) ZKS31 Rotary Dimmer
 
 ### Detailed changelogs
 
@@ -67,6 +72,7 @@
 - [Bump Z-Wave JS to 11.5.1](https://github.com/zwave-js/node-zwave-js/releases/tag/v11.5.1)
 - [Bump Z-Wave JS to 11.5.2](https://github.com/zwave-js/node-zwave-js/releases/tag/v11.5.2)
 - [Bump Z-Wave JS to 11.5.3](https://github.com/zwave-js/node-zwave-js/releases/tag/v11.5.3)
+- [Bump Z-Wave JS to 11.6.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v11.6.0)
 
 ## 0.1.84
 

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -12,8 +12,12 @@
 ### Bug fixes
 
 - Z-Wave JS Server: Fix hard reset support in Z-Wave JS Server
-- Z-Wave JS: Fix an issue that sometimes occurred when attempting to remove a node from the network
-- Z-Wave JS: Fix handling of incoming S2 multicast commands
+- Z-Wave JS: Increased OTA update timeout, which can help with firmware updates in busy/unstable networks
+- Z-Wave JS: Fixed a crash that could happen when including a device with an inclusion controller
+- Z-Wave JS: Improved the automatic removal of factory-reset devices that are slow to leave the network
+- Z-Wave JS: Devices that failed to join using SmartStart are now automatically removed
+- Z-Wave JS: Fix an issue where Z-Wave JS could get stuck when removing a node from the network failed
+
 
 ### Config file changes
 

--- a/zwave_js/Dockerfile
+++ b/zwave_js/Dockerfile
@@ -8,9 +8,8 @@ ARG ZWAVEJS_VERSION
 WORKDIR /usr/src
 RUN \
     set -x \
-    && echo "@edge https://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories \
     && apk add --no-cache \
-        nodejs@edge \
+        nodejs \
         npm \
     && apk add --no-cache --virtual .build-dependencies \
         build-base \

--- a/zwave_js/Dockerfile
+++ b/zwave_js/Dockerfile
@@ -17,7 +17,6 @@ RUN \
         linux-headers \
         python3 \
     \
-    && npm config set unsafe-perm \
     && npm install --force \
         "zwave-js@${ZWAVEJS_VERSION}" \
         "@zwave-js/server@${ZWAVEJS_SERVER_VERSION}" \

--- a/zwave_js/build.yaml
+++ b/zwave_js/build.yaml
@@ -1,10 +1,10 @@
 ---
 build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-base:3.16
-  amd64: ghcr.io/home-assistant/amd64-base:3.16
-  armhf: ghcr.io/home-assistant/armhf-base:3.16
-  armv7: ghcr.io/home-assistant/armv7-base:3.16
-  i386: ghcr.io/home-assistant/i386-base:3.16
+  aarch64: ghcr.io/home-assistant/aarch64-base:3.18
+  amd64: ghcr.io/home-assistant/amd64-base:3.18
+  armhf: ghcr.io/home-assistant/armhf-base:3.18
+  armv7: ghcr.io/home-assistant/armv7-base:3.18
+  i386: ghcr.io/home-assistant/i386-base:3.18
 codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io

--- a/zwave_js/build.yaml
+++ b/zwave_js/build.yaml
@@ -9,5 +9,5 @@ codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
 args:
-  ZWAVEJS_SERVER_VERSION: 1.28.0
-  ZWAVEJS_VERSION: 10.23.2
+  ZWAVEJS_SERVER_VERSION: 1.30.0
+  ZWAVEJS_VERSION: 11.5.3

--- a/zwave_js/build.yaml
+++ b/zwave_js/build.yaml
@@ -10,4 +10,4 @@ codenotary:
   base_image: notary@home-assistant.io
 args:
   ZWAVEJS_SERVER_VERSION: 1.30.0
-  ZWAVEJS_VERSION: 11.5.3
+  ZWAVEJS_VERSION: 11.6.0

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.1.84
+version: 0.1.85
 slug: zwave_js
 name: Z-Wave JS
 description: Control a Z-Wave network with Home Assistant Z-Wave JS


### PR DESCRIPTION
@AlCalzone anything else you want to highlight in the detailed changelog?

- [Bump Z-Wave JS Server to 1.29.0](https://github.com/zwave-js/zwave-js-server/releases/tag/1.29.0)
- [Bump Z-Wave JS Server to 1.29.1](https://github.com/zwave-js/zwave-js-server/releases/tag/1.29.1)
- [Bump Z-Wave JS Server to 1.30.0](https://github.com/zwave-js/zwave-js-server/releases/tag/1.30.0)
- [Bump Z-Wave JS to 10.23.4](https://github.com/zwave-js/node-zwave-js/releases/tag/v10.23.4)
- [Bump Z-Wave JS to 10.23.5](https://github.com/zwave-js/node-zwave-js/releases/tag/v10.23.5)
- [Bump Z-Wave JS to 10.23.6](https://github.com/zwave-js/node-zwave-js/releases/tag/v10.23.6)
- [Bump Z-Wave JS to 11.0.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v11.0.0)
- [Bump Z-Wave JS to 11.1.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v11.1.0)
- [Bump Z-Wave JS to 11.2.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v11.2.0)
- [Bump Z-Wave JS to 11.3.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v11.3.0)
- [Bump Z-Wave JS to 11.4.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v11.4.0)
- [Bump Z-Wave JS to 11.4.1](https://github.com/zwave-js/node-zwave-js/releases/tag/v11.4.1)
- [Bump Z-Wave JS to 11.4.2](https://github.com/zwave-js/node-zwave-js/releases/tag/v11.4.2)
- [Bump Z-Wave JS to 11.5.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v11.5.0)
- [Bump Z-Wave JS to 11.5.1](https://github.com/zwave-js/node-zwave-js/releases/tag/v11.5.1)
- [Bump Z-Wave JS to 11.5.2](https://github.com/zwave-js/node-zwave-js/releases/tag/v11.5.2)
- [Bump Z-Wave JS to 11.5.3](https://github.com/zwave-js/node-zwave-js/releases/tag/v11.5.3)
- [Bump Z-Wave JS to 11.6.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v11.6.0)