### PR TITLE
Bump zwave-js to 11.10.1

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 0.1.87
+
+### Bug fixes
+
+- Z-Wave JS: Fixed a bug where firmware links that redirected to another URL were not supported
+- Z-Wave JS: Change order of commands so the startup does not fail when a controller is already set to use 16-bit node IDs and soft-reset is disabled
+- Z-Wave JS: Soft-reset is now always enabled on 700+ series controllers 
+- Z-Wave JS: Queried user codes and their status are now preserved during re-interview when they won't be re-queried automatically
+
+
+### Config file changes
+
+- Add parameters 9-13 to Minoston MP21ZP / MP31ZP
+- Add fingerprint to Yale YRD446-ZW2
+- Add and update Yale Assure ZW3 series locks
+- Remove unnecessary endpoint functionality for CT101
+
+### Detailed changelogs
+
+- [Bump Z-Wave JS to 11.10.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v11.10.0)
+- [Bump Z-Wave JS to 11.10.1](https://github.com/zwave-js/node-zwave-js/releases/tag/v11.10.1)
+
 ## 0.1.86
 
 ### Bug fixes

--- a/zwave_js/build.yaml
+++ b/zwave_js/build.yaml
@@ -10,4 +10,4 @@ codenotary:
   base_image: notary@home-assistant.io
 args:
   ZWAVEJS_SERVER_VERSION: 1.30.0
-  ZWAVEJS_VERSION: 11.9.2
+  ZWAVEJS_VERSION: 11.10.1

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.1.86
+version: 0.1.87
 slug: zwave_js
 name: Z-Wave JS
 description: Control a Z-Wave network with Home Assistant Z-Wave JS


### PR DESCRIPTION
This is primarily a bugfix release - some users were experiencing issues related to the fact that soft resets are disabled by default for the addon which is fixed in 11.10.1

- [Bump Z-Wave JS to 11.10.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v11.10.0)
- [Bump Z-Wave JS to 11.10.1](https://github.com/zwave-js/node-zwave-js/releases/tag/v11.10.1)

CC @AlCalzone 