### PR TITLE
Update Mosquitto to 2.0.17

### DIFF
--- a/mosquitto/CHANGELOG.md
+++ b/mosquitto/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.3.0
+
+- Update mosquitto to 2.0.16
+
 ## 6.2.1
 
 - Add explicit dependencies for dynamic security plugin and asynchronous name resolver 

--- a/mosquitto/CHANGELOG.md
+++ b/mosquitto/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 6.3.0
 
-- Update mosquitto to 2.0.16
+- Update mosquitto to 2.0.17
 
 ## 6.2.1
 

--- a/mosquitto/build.yaml
+++ b/mosquitto/build.yaml
@@ -10,5 +10,5 @@ codenotary:
   base_image: notary@home-assistant.io
 args:
   LIBWEBSOCKET_VERSION: v4.3.2
-  MOSQUITTO_VERSION: v2.0.16
+  MOSQUITTO_VERSION: v2.0.17
   MOSQUITTO_AUTH_VERSION: 1.8.2

--- a/mosquitto/build.yaml
+++ b/mosquitto/build.yaml
@@ -10,5 +10,5 @@ codenotary:
   base_image: notary@home-assistant.io
 args:
   LIBWEBSOCKET_VERSION: v4.3.2
-  MOSQUITTO_VERSION: v2.0.15
+  MOSQUITTO_VERSION: v2.0.16
   MOSQUITTO_AUTH_VERSION: 1.8.2

--- a/mosquitto/config.yaml
+++ b/mosquitto/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 6.2.1
+version: 6.3.0
 slug: mosquitto
 name: Mosquitto broker
 description: An Open Source MQTT broker


### PR DESCRIPTION
Mosquitto bug fix release 

This should fix [#3164](https://github.com/home-assistant/addons/issues/3164)

```
2.0.17 - 2023-08-22
===================

Broker:
- Fix `max_queued_messages 0` stopping clients from receiving messages.
  Closes #2879.
- Fix `max_inflight_messages` not being set correctly. Closes #2876.

Apps:
- Fix `mosquitto_passwd -U` backup file creation. Closes #2873.

2.0.16 - 2023-08-16
===================

Security:
- CVE-2023-28366: Fix memory leak in broker when clients send multiple QoS 2
  messages with the same message ID, but then never respond to the PUBREC
  commands.
- CVE-2023-0809: Fix excessive memory being allocated based on malicious
  initial packets that are not CONNECT packets.
- CVE-2023-3592: Fix memory leak when clients send v5 CONNECT packets with a
  will message that contains invalid property types.
- Broker will now reject Will messages that attempt to publish to $CONTROL/.
- Broker now validates usernames provided in a TLS certificate or TLS-PSK
  identity are valid UTF-8.
- Fix potential crash when loading invalid persistence file.
- Library will no longer allow single level wildcard certificates, e.g. *.com

Broker:
- Fix $SYS messages being expired after 60 seconds and hence unchanged values
  disappearing.
- Fix some retained topic memory not being cleared immediately after used.
- Fix error handling related to the `bind_interface` option.
- Fix std* files not being redirected when daemonising, when built with
  assertions removed. Closes #2708.
- Fix default settings incorrectly allowing TLS v1.1. Closes #2722.
- Use line buffered mode for stdout. Closes #2354. Closes #2749.
- Fix bridges with non-matching cleansession/local_cleansession being expired
  on start after restoring from persistence. Closes #2634.
- Fix connections being limited to 2048 on Windows. The limit is now 8192,
  where supported. Closes #2732.
- Broker will log warnings if sensitive files are world readable/writable, or
  if the owner/group is not the same as the user/group the broker is running
  as. In future versions the broker will refuse to open these files.
- mosquitto_memcmp_const is now more constant time.
- Only register with DLT if DLT logging is enabled.
- Fix any possible case where a json string might be incorrectly loaded. This
  could have caused a crash if a textname or textdescription field of a role was
  not a string, when loading the dynsec config from file only.
- Dynsec plugin will not allow duplicate clients/groups/roles when loading
  config from file, which matches the behaviour for when creating them.
- Fix heap overflow when reading corrupt config with "log_dest file".

Client library:
- Use CLOCK_BOOTTIME when available, to keep track of time. This solves the
  problem of the client OS sleeping and the client hence not being able to
  calculate the actual time for keepalive purposes. Closes #2760.
- Fix default settings incorrectly allowing TLS v1.1. Closes #2722.
- Fix high CPU use on slow TLS connect. Closes #2794.

Clients:
- Fix incorrect topic-alias property value in mosquitto_sub json output.
- Fix confusing message on TLS certificate verification. Closes #2746.

Apps:
- mosquitto_passwd uses mkstemp() for backup files.
- `mosquitto_ctrl dynsec init` will refuse to overwrite an existing file,
  without a race-condition.
  
```