### PR TITLE
openthread_border_router: Bump to latest OTBR POSIX version

### DIFF
--- a/openthread_border_router/0001-Avoid-writing-to-system-console.patch
+++ b/openthread_border_router/0001-Avoid-writing-to-system-console.patch
@@ -1,5 +1,5 @@
-From 53d4be5c893dac04a909563444453fb471852ccc Mon Sep 17 00:00:00 2001
-Message-Id: <53d4be5c893dac04a909563444453fb471852ccc.1677692173.git.stefan@agner.ch>
+From e0792b7605e6d6cb2ebd491025aee7f84d1edbaa Mon Sep 17 00:00:00 2001
+Message-ID: <e0792b7605e6d6cb2ebd491025aee7f84d1edbaa.1692864566.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Thu, 17 Feb 2022 22:57:16 +0100
 Subject: [PATCH] Avoid writing to system console
@@ -13,18 +13,18 @@ stderr.
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/common/logging.cpp b/src/common/logging.cpp
-index 5398e47133..69f150dadb 100644
+index 5a787e8213..79fccf77ca 100644
 --- a/src/common/logging.cpp
 +++ b/src/common/logging.cpp
-@@ -83,7 +83,7 @@ void otbrLogInit(const char *aIdent, otbrLogLevel aLevel, bool aPrintStderr)
-     assert(aIdent);
-     assert(aLevel >= OTBR_LOG_EMERG && aLevel <= OTBR_LOG_DEBUG);
+@@ -88,7 +88,7 @@ void otbrLogInit(const char *aProgramName, otbrLogLevel aLevel, bool aPrintStder
+     ident = strrchr(aProgramName, '/');
+     ident = (ident != nullptr) ? ident + 1 : aProgramName;
  
--    openlog(aIdent, (LOG_CONS | LOG_PID) | (aPrintStderr ? LOG_PERROR : 0), OTBR_SYSLOG_FACILITY_ID);
-+    openlog(aIdent, LOG_PID | (aPrintStderr ? LOG_PERROR : 0), LOG_USER);
+-    openlog(ident, (LOG_CONS | LOG_PID) | (aPrintStderr ? LOG_PERROR : 0), OTBR_SYSLOG_FACILITY_ID);
++    openlog(ident, LOG_PID | (aPrintStderr ? LOG_PERROR : 0), OTBR_SYSLOG_FACILITY_ID);
      sLevel        = aLevel;
      sDefaultLevel = sLevel;
  }
 -- 
-2.39.1
+2.42.0
 

--- a/openthread_border_router/0002-rest-support-deleting-the-dataset.patch
+++ b/openthread_border_router/0002-rest-support-deleting-the-dataset.patch
@@ -1,5 +1,7 @@
-From d9086b843d5da519fca876794d14026b14cc68ae Mon Sep 17 00:00:00 2001
-Message-ID: <d9086b843d5da519fca876794d14026b14cc68ae.1689665371.git.stefan@agner.ch>
+From 2c0c78e5f4dc85a63934fc0c32c035a9c5b5babd Mon Sep 17 00:00:00 2001
+Message-ID: <2c0c78e5f4dc85a63934fc0c32c035a9c5b5babd.1692864566.git.stefan@agner.ch>
+In-Reply-To: <e0792b7605e6d6cb2ebd491025aee7f84d1edbaa.1692864566.git.stefan@agner.ch>
+References: <e0792b7605e6d6cb2ebd491025aee7f84d1edbaa.1692864566.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Mon, 5 Jun 2023 23:41:50 +0200
 Subject: [PATCH] [rest] support deleting the dataset
@@ -120,5 +122,5 @@ index d79085dbfc..362e501471 100644
      void DeleteOutDatedDiagnostic(void);
      void UpdateDiag(std::string aKey, std::vector<otNetworkDiagTlv> &aDiag);
 -- 
-2.41.0
+2.42.0
 

--- a/openthread_border_router/CHANGELOG.md
+++ b/openthread_border_router/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.3.2
+
+- Bump to OTBR POSIX version 9e50efa8de (2023-08-23 21:28:30 -0700)
+  This updates mDNSResponder to 1790.80.10
+
 ## 2.3.1
 
 - Update firmare for Home Assistant SkyConnect and Yellow to the latest version

--- a/openthread_border_router/Dockerfile
+++ b/openthread_border_router/Dockerfile
@@ -18,7 +18,7 @@ ENV REST_API 1
 ENV DOCKER 1
 
 COPY 0001-Avoid-writing-to-system-console.patch /usr/src
-COPY 0001-rest-support-deleting-the-dataset.patch /usr/src
+COPY 0002-rest-support-deleting-the-dataset.patch /usr/src
 
 # Required and installed (script/bootstrap) can be removed after build
 ENV OTBR_BUILD_DEPS build-essential ninja-build cmake wget ca-certificates \
@@ -53,7 +53,7 @@ RUN \
     && git submodule update --init \
     && ./script/bootstrap \
     && patch -p1 < /usr/src/0001-Avoid-writing-to-system-console.patch \
-    && patch -p1 < /usr/src/0001-rest-support-deleting-the-dataset.patch \
+    && patch -p1 < /usr/src/0002-rest-support-deleting-the-dataset.patch \
     # Mimic rt_tables_install \
     && echo "88 openthread" >> /etc/iproute2/rt_tables \
     # Mimic otbr_install \

--- a/openthread_border_router/build.yaml
+++ b/openthread_border_router/build.yaml
@@ -3,5 +3,5 @@ build_from:
   aarch64: ghcr.io/home-assistant/aarch64-base-debian:bullseye
   amd64: ghcr.io/home-assistant/amd64-base-debian:bullseye
 args:
-  OTBR_VERSION: 8d12b242dbf2398e8df20aa4ee6d387a41abb537
+  OTBR_VERSION: 9e50efa8de3c9cf73936fc8a3e9ba32587d80066
   UNIVERSAL_SILABS_FLASHER: 0.0.13

--- a/openthread_border_router/config.yaml
+++ b/openthread_border_router/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 2.3.1
+version: 2.3.2
 slug: openthread_border_router
 name: OpenThread Border Router
 description: OpenThread Border Router add-on


### PR DESCRIPTION
This also updates the mDNSResponder to 1790.80.10 which solves 100% CPU usage of the mdnsd process.

The patch which avoids logging to console needs slight adjustments.