### PR TITLE
Bump zwave-js to 11.13.1 and zwave-js-server to 1.31.0

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -17,6 +17,9 @@ Z-Wave JS Server: Added support for controller identify event
 - Z-Wave JS: Fixed an issue where 700 series controllers were not soft-reset after NVM backup when soft-reset was disabled via config
 - Z-Wave JS: Discard Meter CC and Multilevel Sensor CC reports when the node they supposedly come from does not support them
 - Z-Wave JS: Abort inclusion when a node with the same ID is already part of the network
+- Z-Wave JS: Fixed a startup crash that happens when the controller returns an empty list of nodes
+- Z-Wave JS: Fixed an issue where API calls would be rejected early or incorrectly resolved while the driver was still retrying a command to an unresponsive node
+- Z-Wave JS: Fixed an issue where the controller would be considered jammed if it responds with a Fail status, even after transmitting
 
 ### Config file changes
 
@@ -30,6 +33,7 @@ Z-Wave JS Server: Added support for controller identify event
 - [Bump Z-Wave JS to 11.11.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v11.11.0)
 - [Bump Z-Wave JS to 11.12.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v11.12.0)
 - [Bump Z-Wave JS to 11.13.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v11.13.0)
+- [Bump Z-Wave JS to 11.13.1](https://github.com/zwave-js/node-zwave-js/releases/tag/v11.13.1)
 
 ## 0.1.87
 

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## 0.1.88
+
+### Features
+
+Z-Wave JS: Applications can now report on controller status
+Z-Wave JS Server: Added support for controller identify event
+
+### Bug fixes
+
+- Z-Wave JS: Fixed a regression from v11.10.1 where the controller's firmware version was not fully queried
+- Z-Wave JS: Change order of commands so the startup does not fail when a controller is already set to use 16-bit node IDs and soft-reset is disabled
+- Z-Wave JS: Soft-reset is now always enabled on 700+ series controllers 
+- Z-Wave JS: Queried user codes and their status are now preserved during re-interview when they won't be re-queried automatically
+- Z-Wave JS: Fixed an issue where nodes were being marked as dead because the controller couldn't transmit.
+- Z-Wave JS: Fixed an issue where 700 series controllers were not soft-reset after NVM backup when soft-reset was disabled via config
+- Z-Wave JS: Discard Meter CC and Multilevel Sensor CC reports when the node they supposedly come from does not support them
+- Z-Wave JS: Abort inclusion when a node with the same ID is already part of the network
+
+### Config file changes
+
+- Disable Supervision for Kwikset HC620 to work around a device bug causing it to flood the network
+- Add fingerprint for Ring Outdoor Contact Sensor
+- Remove unnecessary endpoint functionality for CT100
+- Correct reporting frequency parameter values for Sensative AB Strips Comfort / Drips Multisensor
+
+### Detailed changelogs
+- [Bump Z-Wave JS Server to 1.31.0](https://github.com/zwave-js/zwave-js-server/releases/tag/1.31.0)
+- [Bump Z-Wave JS to 11.11.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v11.11.0)
+- [Bump Z-Wave JS to 11.12.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v11.12.0)
+- [Bump Z-Wave JS to 11.13.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v11.13.0)
+
 ## 0.1.87
 
 ### Bug fixes

--- a/zwave_js/build.yaml
+++ b/zwave_js/build.yaml
@@ -9,5 +9,5 @@ codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
 args:
-  ZWAVEJS_SERVER_VERSION: 1.30.0
-  ZWAVEJS_VERSION: 11.10.1
+  ZWAVEJS_SERVER_VERSION: 1.31.0
+  ZWAVEJS_VERSION: 11.13.0

--- a/zwave_js/build.yaml
+++ b/zwave_js/build.yaml
@@ -10,4 +10,4 @@ codenotary:
   base_image: notary@home-assistant.io
 args:
   ZWAVEJS_SERVER_VERSION: 1.31.0
-  ZWAVEJS_VERSION: 11.13.0
+  ZWAVEJS_VERSION: 11.13.1

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.1.87
+version: 0.1.88
 slug: zwave_js
 name: Z-Wave JS
 description: Control a Z-Wave network with Home Assistant Z-Wave JS


### PR DESCRIPTION
### Detailed changelogs
- [Bump Z-Wave JS Server to 1.31.0](https://github.com/zwave-js/zwave-js-server/releases/tag/1.31.0)
- [Bump Z-Wave JS to 11.11.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v11.11.0)
- [Bump Z-Wave JS to 11.12.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v11.12.0)
- [Bump Z-Wave JS to 11.13.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v11.13.0)
- [Bump Z-Wave JS to 11.13.1](https://github.com/zwave-js/node-zwave-js/releases/tag/v11.13.1)

~~I have not had a chance to test this yet so if anyone wants to merge it, please confirm that you tested it first~~

tested and looks ok 👍🏾 