### PR TITLE
Expose alternative ports

### DIFF
--- a/nginx_proxy/CHANGELOG.md
+++ b/nginx_proxy/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.5.1
+
+- Added alternative ports 
+
 ## 3.5.0
 
 - Update Alpine to 3.18 (nginx 1.24.x)

--- a/nginx_proxy/config.yaml
+++ b/nginx_proxy/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 3.5.0
+version: 3.5.1
 hassio_api: true
 slug: nginx_proxy
 name: NGINX Home Assistant SSL proxy
@@ -29,6 +29,8 @@ options:
 ports:
   443/tcp: 443
   80/tcp: null
+  8443/tcp: null
+  8080/tcp: null
 schema:
   domain: str
   hsts: str

--- a/nginx_proxy/translations/en.yaml
+++ b/nginx_proxy/translations/en.yaml
@@ -27,3 +27,6 @@ configuration:
 network:
   443/tcp: HTTPS (SSL) Port
   80/tcp: HTTP (non-SSL) Port
+  8443/tcp: Alternative HTTPS (SSL) Port
+  8080/tcp: Alternative HTTP (non-SSL) Port
+  


### PR DESCRIPTION
I have added alternative ports on which listening can be added via customisation, e.g. for an alternative certificate, disabled http/2 or yet another configuration. Ports are not forwarded by default, so they do not affect standard configurations.