### PR TITLE
nginx_proxy: Improve domain description

### DIFF
--- a/nginx_proxy/DOCS.md
+++ b/nginx_proxy/DOCS.md
@@ -51,7 +51,7 @@ cloudflare: false
 
 ### Option: `domain` (required)
 
-The domain name to use for the proxy.
+The server's fully qualified domain name to use for the proxy.
 
 ### Option: `certfile` (required)
 


### PR DESCRIPTION
### Option: `domain` (required)

The `domain` configuration description was not clear, stating the value should be the domain name (example.com) instead of the fully qualified domain name of the sever (server.example.com).  This was shown in the example yaml configuration, but not clear here

change:
   The domain name to use for the proxy.
to: 
   The server's fully qualified domain name to use for the proxy.