### PR TITLE
Bump zwave-js to 11.14.0

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 ### Detailed changelogs
 
-- https://github.com/zwave-js/node-zwave-js/releases/tag/v11.14.0
+- [Z-Wave JS 11.14.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v11.14.0)
 
 ## 0.1.88
 

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,11 +1,32 @@
 # Changelog
 
+## 0.1.89
+
+### Features
+
+- Z-Wave JS: Optimized the order of node communication during startup to ensure responsive nodes are ready first
+
+### Bug fixes
+
+- Z-Wave JS: The start/stop time and date values in `Schedule Entry Lock` CC commands are now validated
+- Z-Wave JS: Fixed an issue where `hasDeviceConfigChanged` would return the opposite of what it should, triggering repair issues for users on HA version >= 2023.9.0b0.
+
+### Config file changes
+
+- Delay value refresh for ZW500D
+- Update several Zooz devices to their 800 series revisions
+- Extend version range for Vesternet VES-ZW-DIM-001
+
+### Detailed changelogs
+
+- https://github.com/zwave-js/node-zwave-js/releases/tag/v11.14.0
+
 ## 0.1.88
 
 ### Features
 
-Z-Wave JS: Applications can now report on controller status
-Z-Wave JS Server: Added support for controller identify event
+- Z-Wave JS: Applications can now report on controller status
+- Z-Wave JS Server: Added support for controller identify event
 
 ### Bug fixes
 

--- a/zwave_js/build.yaml
+++ b/zwave_js/build.yaml
@@ -10,4 +10,4 @@ codenotary:
   base_image: notary@home-assistant.io
 args:
   ZWAVEJS_SERVER_VERSION: 1.31.0
-  ZWAVEJS_VERSION: 11.13.1
+  ZWAVEJS_VERSION: 11.14.0

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.1.88
+version: 0.1.89
 slug: zwave_js
 name: Z-Wave JS
 description: Control a Z-Wave network with Home Assistant Z-Wave JS


### PR DESCRIPTION
Changelog: https://github.com/zwave-js/node-zwave-js/releases/tag/v11.14.0

Main bug fix here is the one for `hasDeviceConfigChanged` which is triggering repair issues for 2023.9 beta users.

Everything came up clean on testing.

