### PR TITLE
Bump deCONZ to v2.23.1

### DIFF
--- a/deconz/CHANGELOG.md
+++ b/deconz/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.21.0
+
+- Bump deCONZ to 2.23.1
+- 
 ## 6.20.0
 
 - Bump deCONZ to 2.22.2

--- a/deconz/build.yaml
+++ b/deconz/build.yaml
@@ -7,4 +7,4 @@ codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
 args:
-  DECONZ_VERSION: 2.22.02
+  DECONZ_VERSION: 2.23.01

--- a/deconz/config.yaml
+++ b/deconz/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 6.20.0
+version: 6.21.0
 slug: deconz
 name: deCONZ
 description: >-


### PR DESCRIPTION
Update to the latest stable deconz release [v2.23.1](https://github.com/dresden-elektronik/deconz-rest-plugin/releases/tag/v2.23.1)