### PR TITLE
Bump zwave-js to 12.0.0 and zwave-js-server to 1.32.0

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Features
 
-- Detect an unresponsive stick and reset it
+- Unresponsive controllers are now detected and automatically restarted if possible
 - Battery-powered devices are sent back to sleep after 250 ms with no command (down from 1000 ms). This should result in significant battery savings for devices that frequently wake up.
 - We no longer rebuild the @serialport/bindings-cpp package from source
 

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## 0.1.91
+
+### Features
+
+- Detect an unresponsive stick and reset it
+- The default time after which battery-powered devices with no pending commands are sent back to sleep is now 250 ms (down from 1000ms)
+
+### Bug fixes
+
+- A bug in the 7.19.x SDK has surfaced where the controller gets stuck in the middle of a transmission. Previously this would go unnoticed because the failed commands would cause the nodes to be marked dead until the controller finally recovered. Since v11.12.0 however, Z-Wave JS would consider the controller jammed and retry the last command indefinitely. This situation is now detected and Z-Wave JS attempts to recover by soft-resetting the controller when this happens.
+- Removed auto-disabling of soft-reset capability
+- Default to RF protection state Unprotected if not given for Protection CC V2+
+
+### Config file changes
+
+- Add warnings about broken controller firmware versions
+- Add Heatit Z-Water 2
+- Add Shelly Wave 1PM
+- Add Heatit Z-TRM6
+- Increase poll delay for ZW500D
+- Add fingerprint for Simon IO Master Roller Blind
+- Add HOPPE eHandle ConnectSense
+- Add parameters to Zooz ZEN17 from firmware 1.30
+- Update Zooz ZEN32 config to the latest firmware, include 800 series
+
+### Detailed changelogs
+
+- [Z-Wave JS 11.14.3](https://github.com/zwave-js/node-zwave-js/releases/tag/v11.14.3)
+- [Z-Wave JS 12.0.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v12.0.0)
+- [Z-Wave JS Server 1.32.0](https://github.com/zwave-js/zwave-js-server/releases/tag/1.32.0)
+
 ## 0.1.90
 
 ### Bug fixes

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -17,7 +17,7 @@
 - A bug in the 7.19.x SDK has surfaced where the controller gets stuck in the middle of a transmission. Previously this would go unnoticed because the failed commands would cause the nodes to be marked dead until the controller finally recovered. Since v11.12.0 however, Z-Wave JS would consider the controller jammed and retry the last command indefinitely. This situation is now detected and Z-Wave JS attempts to recover by soft-resetting the controller when this happens.
 - Removed auto-disabling of soft-reset capability
 - Default to RF protection state Unprotected if not given for Protection CC V2+
-
+- Devices that send notifications from endpoints, e.g. Aeotec Wallmote, are now properly supported
 ### Config file changes
 
 - Add warnings about broken controller firmware versions

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking changes
 
-- Firmware updates may no longer work properly in Home Assistant versions 2023.9.x and earlier due to a breaking change upstream that couldn't be made backwards compatible.They will be fixed in 2023.10.0. As a result of this breaking change, Checking for updates no longer requires communication with the device and therefore reduces the risk of corrupting manufacturer information. This also means that updates for battery-powered devices can be detected without waking up the devices. 
+- Firmware updates may no longer work properly in Home Assistant versions 2023.9.x and earlier due to a breaking change upstream that couldn't be made backwards compatible. Firmware updates will work once again starting in 2023.10.0. As a result of this breaking change, Checking for updates no longer requires communication with the device and therefore reduces the risk of corrupting manufacturer information. This also means that updates for battery-powered devices can be detected without waking up the devices. 
 
 ### Features
 

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -4,19 +4,22 @@
 
 ### Breaking changes
 
-- Firmware updates may no longer work properly in Home Assistant versions 2023.9.x and earlier due to a breaking change upstream that couldn't be made backwards compatible. Firmware updates will work once again starting in 2023.10.0. As a result of this breaking change, Checking for updates no longer requires communication with the device and therefore reduces the risk of corrupting manufacturer information. This also means that updates for battery-powered devices can be detected without waking up the devices. 
+- Firmware updates may no longer work properly in Home Assistant versions 2023.9.x and earlier due to a breaking change upstream that couldn't be made backward compatible. Firmware updates will work once again starting in 2023.10.0. As a result of this breaking change, Checking for updates no longer requires communication with the device and, therefore, reduces the risk of corrupting manufacturer information. This also means that updates for battery-powered devices can be detected without waking up the devices.
+
 
 ### Features
 
-- Unresponsive controllers are now detected and automatically restarted if possible
+- Unresponsive controllers are now detected and automatically restarted if possible.
 - Battery-powered devices are sent back to sleep after 250 ms with no command (down from 1000 ms). This should result in significant battery savings for devices that frequently wake up.
-- We no longer rebuild the @serialport/bindings-cpp package from source
+- We no longer rebuild the @serialport/bindings-cpp package from source.
+
 
 ### Bug fixes
 
-- A bug in the 7.19.x SDK has surfaced where the controller gets stuck in the middle of a transmission. Previously this would go unnoticed because the failed commands would cause the nodes to be marked dead until the controller finally recovered. Since v11.12.0 however, Z-Wave JS would consider the controller jammed and retry the last command indefinitely. This situation is now detected and Z-Wave JS attempts to recover by soft-resetting the controller when this happens.
-- Fixed an issue where supporting controllers would no longer be automatically restarted after failing to do so once
-- Devices that send notifications from endpoints, e.g. Aeotec Wallmote, are now properly supported
+- A bug in the 7.19.x SDK has surfaced where the controller gets stuck in the middle of a transmission. Previously, this would go unnoticed because the failed commands would cause the nodes to be marked dead until the controller finally recovered. Since v11.12.0, however, Z-Wave JS would consider the controller jammed and retry the last command indefinitely. This situation is now detected, and Z-Wave JS attempts to recover by soft resetting the controller when this happens.
+- Fixed an issue where supporting controllers would no longer be automatically restarted after failing to do so once.
+- Devices that send notifications from endpoints, like Aeotec Wallmote, are now properly supported.
+
 
 ### Config file changes
 

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking changes
 
-- Firmware updates may no longer work properly in Home Assistant versions 2023.9.x and earlier due to a breaking change upstream that couldn't be made backward compatible, but will work once again starting in 2023.10.0. This breaking change ultimately improves firmware updates, as checking for updates no longer requires communication with the device and, therefore, reduces the risk of corrupting manufacturer information. This also means that updates for battery-powered devices can be detected without waking up the devices.
+- Firmware updates may no longer work properly in Home Assistant versions 2023.9.x and earlier due to a breaking change upstream that couldn't be made backward compatible, but will work once again starting in 2023.10.0. This breaking change ultimately improves firmware updates, as checking for updates no longer requires communication with the device, therefore reducing the risk of corrupting manufacturer information. This also means that updates for battery-powered devices can be detected without waking up the devices.
 
 
 ### Features

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.1.91
 
+### Breaking changes
+
+- Firmware updates may no longer work properly in Home Assistant versions 2023.9.x and earlier due to a breaking change upstream that couldn't be made backwards compatible. They will be fixed in 2023.10.0 .
+
 ### Features
 
 - Detect an unresponsive stick and reset it

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - Detect an unresponsive stick and reset it
 - The default time after which battery-powered devices with no pending commands are sent back to sleep is now 250 ms (down from 1000ms)
-- We no long rebuild the @serialport/bindings-cpp package from source
+- We no longer rebuild the @serialport/bindings-cpp package from source
 
 ### Bug fixes
 

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking changes
 
-- Firmware updates may no longer work properly in Home Assistant versions 2023.9.x and earlier due to a breaking change upstream that couldn't be made backward compatible. Firmware updates will work once again starting in 2023.10.0. As a result of this breaking change, Checking for updates no longer requires communication with the device and, therefore, reduces the risk of corrupting manufacturer information. This also means that updates for battery-powered devices can be detected without waking up the devices.
+- Firmware updates may no longer work properly in Home Assistant versions 2023.9.x and earlier due to a breaking change upstream that couldn't be made backward compatible, but will work once again starting in 2023.10.0. This breaking change ultimately improves firmware updates, as checking for updates no longer requires communication with the device and, therefore, reduces the risk of corrupting manufacturer information. This also means that updates for battery-powered devices can be detected without waking up the devices.
 
 
 ### Features

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -4,20 +4,20 @@
 
 ### Breaking changes
 
-- Firmware updates may no longer work properly in Home Assistant versions 2023.9.x and earlier due to a breaking change upstream that couldn't be made backwards compatible. They will be fixed in 2023.10.0 .
+- Firmware updates may no longer work properly in Home Assistant versions 2023.9.x and earlier due to a breaking change upstream that couldn't be made backwards compatible.They will be fixed in 2023.10.0. As a result of this breaking change, Checking for updates no longer requires communication with the device and therefore reduces the risk of corrupting manufacturer information. This also means that updates for battery-powered devices can be detected without waking up the devices. 
 
 ### Features
 
 - Detect an unresponsive stick and reset it
-- The default time after which battery-powered devices with no pending commands are sent back to sleep is now 250 ms (down from 1000ms)
+- Battery-powered devices are sent back to sleep after 250 ms with no command (down from 1000 ms). This should result in significant battery savings for devices that frequently wake up.
 - We no longer rebuild the @serialport/bindings-cpp package from source
 
 ### Bug fixes
 
 - A bug in the 7.19.x SDK has surfaced where the controller gets stuck in the middle of a transmission. Previously this would go unnoticed because the failed commands would cause the nodes to be marked dead until the controller finally recovered. Since v11.12.0 however, Z-Wave JS would consider the controller jammed and retry the last command indefinitely. This situation is now detected and Z-Wave JS attempts to recover by soft-resetting the controller when this happens.
-- Removed auto-disabling of soft-reset capability
-- Default to RF protection state Unprotected if not given for Protection CC V2+
+- Fixed an issue where supporting controllers would no longer be automatically restarted after failing to do so once
 - Devices that send notifications from endpoints, e.g. Aeotec Wallmote, are now properly supported
+
 ### Config file changes
 
 - Add warnings about broken controller firmware versions

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Detect an unresponsive stick and reset it
 - The default time after which battery-powered devices with no pending commands are sent back to sleep is now 250 ms (down from 1000ms)
+- We no long rebuild the @serialport/bindings-cpp package from source
 
 ### Bug fixes
 

--- a/zwave_js/Dockerfile
+++ b/zwave_js/Dockerfile
@@ -21,7 +21,6 @@ RUN \
         "zwave-js@${ZWAVEJS_VERSION}" \
         "@zwave-js/server@${ZWAVEJS_SERVER_VERSION}" \
     \
-    && npm rebuild --build-from-source @serialport/bindings-cpp \
     && apk del --no-cache \
         .build-dependencies
 

--- a/zwave_js/build.yaml
+++ b/zwave_js/build.yaml
@@ -9,5 +9,5 @@ codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
 args:
-  ZWAVEJS_SERVER_VERSION: 1.31.0
-  ZWAVEJS_VERSION: 11.14.2
+  ZWAVEJS_SERVER_VERSION: 1.32.0
+  ZWAVEJS_VERSION: 12.0.0

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.1.90
+version: 0.1.91
 slug: zwave_js
 name: Z-Wave JS
 description: Control a Z-Wave network with Home Assistant Z-Wave JS


### PR DESCRIPTION
### Detailed changelogs

- [Z-Wave JS 11.14.3](https://github.com/zwave-js/node-zwave-js/releases/tag/v11.14.3)
- [Z-Wave JS 12.0.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v12.0.0)
- [Z-Wave JS Server 1.32.0](https://github.com/zwave-js/zwave-js-server/releases/tag/1.32.0)

> NOTE: I removed rebuilding @serialports/bindings-cpp from source, and on my HA Blue, the server was able to start up fine, but that's only one datapoint

Local build came up clean!