### PR TITLE
Re-add rebuilding serialports bindings from src to zwave_js

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-- Continue rebuilding @serialport/bindings-cpp from source as the problem is fixed on some CPU platforms but not all (the functionality was removed in the last release)
+- Revert change to stop rebuilding @serialport/bindings-cpp from source as the problem is fixed on some CPU platforms but not all
 
 ## 0.1.91
 

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.92
+
+### Bug fixes
+
+- Re-add rebuilding @serialport/bindings-cpp as the problem is fixed on some CPU platforms but not all
+
 ## 0.1.91
 
 ### Breaking changes

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-- Re-add rebuilding @serialport/bindings-cpp as the problem is fixed on some CPU platforms but not all
+- Re-add rebuilding @serialport/bindings-cpp from source as the problem is fixed on some CPU platforms but not all
 
 ## 0.1.91
 

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-- Continue rebuilding @serialport/bindings-cpp from source (removed in last release) as the problem is fixed on some CPU platforms but not all
+- Continue rebuilding @serialport/bindings-cpp from source as the problem is fixed on some CPU platforms but not all (the functionality was removed in the last release)
 
 ## 0.1.91
 

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-- Re-add rebuilding @serialport/bindings-cpp from source as the problem is fixed on some CPU platforms but not all
+- Continue rebuilding @serialport/bindings-cpp from source (removed in last release) as the problem is fixed on some CPU platforms but not all
 
 ## 0.1.91
 

--- a/zwave_js/Dockerfile
+++ b/zwave_js/Dockerfile
@@ -21,6 +21,7 @@ RUN \
         "zwave-js@${ZWAVEJS_VERSION}" \
         "@zwave-js/server@${ZWAVEJS_SERVER_VERSION}" \
     \
+    && npm rebuild --build-from-source @serialport/bindings-cpp \
     && apk del --no-cache \
         .build-dependencies
 

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.1.91
+version: 0.1.92
 slug: zwave_js
 name: Z-Wave JS
 description: Control a Z-Wave network with Home Assistant Z-Wave JS


### PR DESCRIPTION
From https://discord.com/channels/330944238910963714/332357267364249621/1156396447298760704 it appears that while this isn't needed for as many CPU platforms as before, it's still needed in some cases