### PR TITLE
Bump zwave-js-server to 1.32.1

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-- Z-Wave JS Server: For users that opted in to data collection, a missing return caused the server to try to soft reset the controller. This has now been resolved.
+- Z-Wave JS Server: For users that have opted in to data collection in their Home Assistant Z-Wave configuration, a missing return caused the server to try to soft reset the controller during Home Assistant startup for Home Assiststant versions 2023.9.x or less. This has now been resolved.
 
 ### Detailed changelog
 

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.1.93
+
+### Bug fixes
+
+- Revert change to stop rebuilding @serialport/bindings-cpp from source as the problem is fixed on some CPU platforms but not all
+
+### Detailed changelog
+
+- [Z-Wave JS Server 1.32.1](https://github.com/zwave-js/zwave-js-server/releases/tag/1.32.1)
+
 ## 0.1.92
 
 ### Bug fixes

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-- Revert change to stop rebuilding @serialport/bindings-cpp from source as the problem is fixed on some CPU platforms but not all
+- Z-Wave JS Server: For users that opted in to data collection, a missing return caused the server to try to soft reset the controller. This has now been resolved.
 
 ### Detailed changelog
 

--- a/zwave_js/build.yaml
+++ b/zwave_js/build.yaml
@@ -9,5 +9,5 @@ codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
 args:
-  ZWAVEJS_SERVER_VERSION: 1.32.0
+  ZWAVEJS_SERVER_VERSION: 1.32.1
   ZWAVEJS_VERSION: 12.0.0

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.1.92
+version: 0.1.93
 slug: zwave_js
 name: Z-Wave JS
 description: Control a Z-Wave network with Home Assistant Z-Wave JS


### PR DESCRIPTION
[Z-Wave JS Server 1.32.1](https://github.com/zwave-js/zwave-js-server/releases/tag/1.32.1)

Fixes https://github.com/home-assistant/core/issues/100987 and https://community.home-assistant.io/t/updated-ha-2023-9-2-2023-9-3-and-now-z-wave-add-on-no-longer-works/619202/5