### PR TITLE
duckdns: Support wildcard certs for subdomains in DuckDNS addon (resolves #336)

### DIFF
--- a/duckdns/data/run.sh
+++ b/duckdns/data/run.sh
@@ -10,7 +10,7 @@ LE_UPDATE="0"
 if bashio::config.has_value "ipv4"; then IPV4=$(bashio::config 'ipv4'); else IPV4=""; fi
 if bashio::config.has_value "ipv6"; then IPV6=$(bashio::config 'ipv6'); else IPV6=""; fi
 TOKEN=$(bashio::config 'token')
-DOMAINS=$(bashio::config 'domains | join(",")')
+DOMAINS=$(bashio::config 'domains | join(",")' | sed 's/[^,]*[ > ]//g') # Handle domains of the form "*.xxx.duckdns.org > xxx.duckdns.org"
 WAIT_TIME=$(bashio::config 'seconds')
 ALGO=$(bashio::config 'lets_encrypt.algo')
 


### PR DESCRIPTION
This PR resolves the issue described in [this comment](https://github.com/home-assistant/addons/issues/336#issuecomment-1234475344) on issue #336 (copied below for convenience) which occurs when the domains array contains entries of the form `"*.xxx.duckdns.org > xxx.duckdns.org"`. This type of entry is used to obtain wildcard certificates from Let's Encrypt / dehydrated.

>> There's a quick workaround if you only need to use subdomains of "xxx.duckdns.org". Configure the addon with:
"domains": [
  "*.xxx.duckdns.org > xxx.duckdns.org"
]
This will create a wildcard certificate for "*.xxx.duckdns.org" with "xxx.duckdns.org" as an alias (required by dehydrated). The certificate will not be valid for "xxx.duckdns.org", but only for its subdomains.

>It doesn't work propertly. It generate wildcard certificate but doesn't update IP on DuckDNS.org.
In log only empty warnings:
[18:52:58] WARNING: 

The `sed` substitution `'s/[^,]*[ > ]//g'` matches all occurrences of strings which do not contain a `,` (so that after the `join(",")` at most one match is found per entry in the domain array) that end with the characters ` > ` and removes them leaving only valid domains according to the [DuckDNS API](https://www.duckdns.org/spec.jsp). Note that this transformation will not impact Let's Encrypt because the `$DOMAINS` variable is only used by DuckDNS. The `le_renew` function grabs the domains from the config directly on line 23:

https://github.com/home-assistant/addons/blob/72fac56dae57fe3573a1e568b248fa304cca2b1b/duckdns/data/run.sh#L23C1-L24C1

### Testing

1. Wrote the following script to test the sed substitution:

```
#!/usr/bin/with-contenv bashio

TEST_DOMAINS=$(bashio::config 'test_domains | join(",")' | sed 's/[^,]*[ > ]//g')
echo $TEST_DOMAINS
```
Added the following field to the json object in `/tmp/.bashio/addons.self.options.config.cache` 
```
"test_domains": ["*.example.duckdns.org > example.duckdns.org","test.duckdns.org","*.sample.duckdns.org > sample.duckdns.org","subdomain.duckdns.org","demo.duckdns.org"],
```
Ran the script and received the following output:
```
example.duckdns.org,test.duckdns.org,sample.duckdns.org,subdomain.duckdns.org,demo.duckdns.org
```
2. Modified my IP address on duckdns.org and ran the new version of this `run.sh` from within the add-on. IP was correctly reset to my actual IP.