### PR TITLE
Bump zwave-js to 12.2.0 and add config option for safe mode

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.99
+
+### Features
+
+- Add-on: Add `timeouts` and `attempts` configuration options to adjust the defaults for the corresponding Z-Wave driver options. These are advanced configuration options that should not be adjusted in most cases and have therefore been hidden from the default view.
+
 ## 0.1.98
 
 ### Bug fixes

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Add-on: Add `timeouts` and `attempts` configuration options to adjust the defaults for the corresponding Z-Wave driver options. These are advanced configuration options that should not be adjusted in most cases and have therefore been hidden from the default view.
+- Add-on: Add `safe_mode` configuration option to put Z-Wave network in safe mode. This can be help with troubleshooting network issues and getting access to logs that you otherwise wouldn't be able to. This is an advanced configuration option that should not be adjusted in most cases and is therefore hidden from the default view.
 
 ## 0.1.98
 

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## 0.2.0
 
-### Breaking changes
-
-- Users that are on Home Assistant versions `2021.2.x` will no longer be able to receive add-on updates. Users still on this version are encouraged to update to a newer version which will support additional updates and will have many additional capabilities in the integration.
-
 ### Features
 
 - Add-on: Add `safe_mode` configuration option to put Z-Wave network in safe mode. This can be help with troubleshooting network issues and getting access to logs that you otherwise wouldn't be able to. This is an advanced configuration option that should not be adjusted in most cases and is therefore hidden from the default view.
@@ -19,6 +15,11 @@
 
 - Add NEO Cool Cam Repeater
 - Increase report timeout for Aeotec Multisensor 6 to 2s
+
+### Detailed changelogs
+
+- [Z-Wave JS 12.2.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v12.2.0)
+- [Z-Wave JS Server 1.32.2](https://github.com/zwave-js/zwave-js-server/releases/tag/1.32.2)
 
 ## 0.1.98
 

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Features
 
 - Add-on: Add `safe_mode` configuration option to put Z-Wave network in safe mode. This can be help with troubleshooting network issues and getting access to logs that you otherwise wouldn't be able to. This is an advanced configuration option that should not be adjusted in most cases and is therefore hidden from the default view.
-- Add-on: Introduce semantic versioning. Due to a bug in early versions of the Z-Wave JS integration, release versions had to be less than `2.x` in order to stay backwards compatible. This made it impossible to use semantic versioning. With semantic versioning, major version changes to the addon will now reflect major changes, such as a major version release of Z-Wave JS, or a significant change to the add-on structure. This should help users better understand the potential impact of an upgrade.
+- Add-on: Introduce semantic versioning. With semantic versioning, major version changes to the addon will now reflect e.g. a major version release of Z-Wave JS or a significant change to the add-on structure. This should help users better understand the potential impact of an upgrade.
 
 ### Bug fixes
 

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Add-on: Add `safe_mode` configuration option to put Z-Wave network in safe mode. This can be help with troubleshooting network issues and getting access to logs that you otherwise wouldn't be able to. This is an advanced configuration option that should not be adjusted in most cases and is therefore hidden from the default view.
+- Add-on: Add `safe_mode` configuration option to put Z-Wave network in safe mode. This can be help with troubleshooting network issues and getting access to logs that you otherwise wouldn't be able to, but will likely slow down your network and should therefore be used sparingly. This is an advanced configuration option that should not be adjusted in most cases and is therefore hidden from the default view.
 - Add-on: Introduce semantic versioning. With semantic versioning, major version changes to the addon will now reflect e.g. a major version release of Z-Wave JS or a significant change to the add-on structure. This should help users better understand the potential impact of an upgrade.
 
 ### Bug fixes

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Features
 
 - Add-on: Add `safe_mode` configuration option to put Z-Wave network in safe mode. This can be help with troubleshooting network issues and getting access to logs that you otherwise wouldn't be able to, but will likely slow down your network and should therefore be used sparingly. This is an advanced configuration option that should not be adjusted in most cases and is therefore hidden from the default view.
-- Add-on: Introduce semantic versioning. With semantic versioning, major version changes to the addon will now reflect e.g. a major version release of Z-Wave JS or a significant change to the add-on structure. This should help users better understand the potential impact of an upgrade.
+- Add-on: Switch to [semantic versioning](https://semver.org/). With this change, major version changes to the addon will now reflect e.g. a major version release of Z-Wave JS or a significant change to the add-on structure. This should help users better understand the potential impact of an upgrade.
 
 ### Bug fixes
 

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,10 +1,20 @@
 # Changelog
 
-## 0.1.99
+## 1.0.0
 
 ### Features
 
 - Add-on: Add `safe_mode` configuration option to put Z-Wave network in safe mode. This can be help with troubleshooting network issues and getting access to logs that you otherwise wouldn't be able to. This is an advanced configuration option that should not be adjusted in most cases and is therefore hidden from the default view.
+- Add-on: Introduce semantic versioning. Due to a bug in early versions of the Z-Wave JS integration, release versions had to be less than `2.x` in order to stay backwards compatible. This made it impossible to use semantic versioning. With semantic versioning, major version changes to the addon will now reflect major changes, such as a major version release of Z-Wave JS, or a significant change to the add-on structure. This should help users better understand the potential impact of an upgrade.
+
+### Bug fixes
+
+- Z-Wave JS: Includes several more fixes and workarounds for the problematic interaction between some controller firmware bugs and the automatic controller recovery introduced in the `v12` release
+
+### Config file changes
+
+- Add NEO Cool Cam Repeater
+- Increase report timeout for Aeotec Multisensor 6 to 2s
 
 ## 0.1.98
 

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Add-on: Add `safe_mode` configuration option to put Z-Wave network in safe mode. This can be help with troubleshooting network issues and getting access to logs that you otherwise wouldn't be able to, but will likely slow down your network and should therefore be used sparingly. This is an advanced configuration option that should not be adjusted in most cases and is therefore hidden from the default view.
+- Add-on: Add `safe_mode` configuration option to put Z-Wave network in safe mode. This can be used help with troubleshooting network issues, such as being unable to start it, but will likely slow down your network and should therefore be used sparingly. This is an advanced configuration option that should not be adjusted in most cases and is therefore hidden from the default view.
 - Add-on: Switch to [semantic versioning](https://semver.org/). With this change, major version changes to the addon will now reflect e.g. a major version release of Z-Wave JS or a significant change to the add-on structure. This should help users better understand the potential impact of an upgrade.
 
 ### Bug fixes

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.0.0
 
+### Breaking changes
+
+- Users that are on Home Assistant versions `2021.2.x` will no longer be able to receive add-on updates. Users still on this version are encouraged to update to a newer version which will support additional updates and will have many additional capabilities in the integration.
+
 ### Features
 
 - Add-on: Add `safe_mode` configuration option to put Z-Wave network in safe mode. This can be help with troubleshooting network issues and getting access to logs that you otherwise wouldn't be able to. This is an advanced configuration option that should not be adjusted in most cases and is therefore hidden from the default view.

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.0.0
+## 0.2.0
 
 ### Breaking changes
 

--- a/zwave_js/DOCS.md
+++ b/zwave_js/DOCS.md
@@ -138,17 +138,25 @@ This option sets the log level of Z-Wave JS. Valid options are:
 If no `log_level` is specified, the log level will be set to the level set in
 the Supervisor.
 
-### Option `emulate_hardware` (optional)
-
-If you don't have a USB stick, you can use a fake stick for testing purposes.
-It will not be able to control any real devices.
-
 ### Option `soft_reset`
 
 This setting tells the add-on how to handle soft-resets for 500 series controllers:
 1. Automatic - the add-on will decide whether soft-reset should be enabled or disabled for 500 series controllers. This is the default option and should work for most people.
 2. Enabled - Soft-reset will be explicitly enabled for 500 series controllers.
 3. Disabled - Soft-reset will be explicitly disabled for 500 series controllers.
+
+### Option `emulate_hardware` (optional)
+
+If you don't have a USB stick, you can use a fake stick for testing purposes.
+It will not be able to control any real devices.
+
+### Option `safe_mode` (optional)
+
+This setting puts your network in safe mode, which could significantly decrease
+the performance of your network but may also help get the network up and running
+so that you can troubleshoot issues, grab logs, etc. In most cases, users will
+never need to use this feature, so only change this setting if you know what you
+are doing and/or you are asked to.
 
 ### Option `network_key` (deprecated)
 

--- a/zwave_js/build.yaml
+++ b/zwave_js/build.yaml
@@ -10,4 +10,4 @@ codenotary:
   base_image: notary@home-assistant.io
 args:
   ZWAVEJS_SERVER_VERSION: 1.32.1
-  ZWAVEJS_VERSION: 12.1.1
+  ZWAVEJS_VERSION: 12.2.0

--- a/zwave_js/build.yaml
+++ b/zwave_js/build.yaml
@@ -9,5 +9,5 @@ codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
 args:
-  ZWAVEJS_SERVER_VERSION: 1.32.1
+  ZWAVEJS_SERVER_VERSION: 1.32.2
   ZWAVEJS_VERSION: 12.2.0

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -40,7 +40,7 @@ schema:
   timeouts:
     ack: int(1,)?
     byte: int(1,)?
-    response: int(500,20000)?
+    response: int(500,60000)?
     sendDataCallback: int(10000,)?
     report: int(500,10000)?
     nonce: int(3000,20000)?

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 1.0.0
+version: 0.2.0
 slug: zwave_js
 name: Z-Wave JS
 description: Control a Z-Wave network with Home Assistant Z-Wave JS

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -14,7 +14,7 @@ codenotary: notary@home-assistant.io
 discovery:
   - zwave_js
 hassio_api: true
-homeassistant: 2021.2.0b0
+homeassistant: 2021.3.0b0
 image: homeassistant/{arch}-addon-zwave_js
 init: false
 options:

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -14,7 +14,7 @@ codenotary: notary@home-assistant.io
 discovery:
   - zwave_js
 hassio_api: true
-homeassistant: 2021.3.0b0
+homeassistant: 2021.2.0b0
 image: homeassistant/{arch}-addon-zwave_js
 init: false
 options:

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.1.98
+version: 0.1.99
 slug: zwave_js
 name: Z-Wave JS
 description: Control a Z-Wave network with Home Assistant Z-Wave JS

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.1.99
+version: 1.0.0
 slug: zwave_js
 name: Z-Wave JS
 description: Control a Z-Wave network with Home Assistant Z-Wave JS

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -35,8 +35,24 @@ schema:
   s2_access_control_key: match(|[0-9a-fA-F]{32,32})?
   s2_authenticated_key: match(|[0-9a-fA-F]{32,32})?
   s2_unauthenticated_key: match(|[0-9a-fA-F]{32,32})?
-  emulate_hardware: bool?
   network_key: match(|[0-9a-fA-F]{32,32})?
+  emulate_hardware: bool?
+  timeouts:
+    ack: int(1,)?
+    byte: int(1,)?
+    response: int(500,20000)?
+    sendDataCallback: int(10000,)?
+    report: int(500,10000)?
+    nonce: int(3000,20000)?
+    retryJammed: int(10,5000)?
+    sendToSleep: int(10,5000)?
+    serialAPIStarted: int(1000,30000)?
+  attempts:
+    openSerialPort: int(500,20000)?
+    controller: int(1,3)?
+    sendData: int(1,5)?
+    sendDataJammed: int(1,10)?
+    nodeInterview: int(1,10)?
 stage: stable
 startup: services
 timeout: 30

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -37,22 +37,7 @@ schema:
   s2_unauthenticated_key: match(|[0-9a-fA-F]{32,32})?
   network_key: match(|[0-9a-fA-F]{32,32})?
   emulate_hardware: bool?
-  timeouts:
-    ack: int(1,)?
-    byte: int(1,)?
-    response: int(500,60000)?
-    sendDataCallback: int(10000,)?
-    report: int(500,10000)?
-    nonce: int(3000,20000)?
-    retryJammed: int(10,5000)?
-    sendToSleep: int(10,5000)?
-    serialAPIStarted: int(1000,30000)?
-  attempts:
-    openSerialPort: int(500,20000)?
-    controller: int(1,3)?
-    sendData: int(1,5)?
-    sendDataJammed: int(1,10)?
-    nodeInterview: int(1,10)?
+  safe_mode: bool?
 stage: stable
 startup: services
 timeout: 30

--- a/zwave_js/rootfs/etc/cont-init.d/config.sh
+++ b/zwave_js/rootfs/etc/cont-init.d/config.sh
@@ -84,7 +84,7 @@ done
 # flushed to disk
 if [[ ${flush_to_disk:+x} ]]; then
     bashio::log.info "Flushing config to disk due to creation of new key(s)..."
-    bashio::addon.options > "/data/options.json"
+    bashio::addon.options >"/data/options.json"
 fi
 
 s0_legacy=$(bashio::config "s0_legacy_key")
@@ -119,13 +119,12 @@ else
     bashio::log.info "Soft-reset disabled by user"
 fi
 
-presets=""
+safe_mode=""
 
 if bashio::config.true 'safe_mode'; then
     bashio::log.info "Safe mode enabled"
     bashio::log.warning "WARNING: While in safe mode, the performance of your Z-Wave network will be in a reduced state. This is only meant for debugging purposes."
-    presets=",
-    \"presets\": [\"SAFE_MODE\"]"
+    safe_mode="\"SAFE_MODE\""
 fi
 
 # Generate config
@@ -136,7 +135,7 @@ bashio::var.json \
     s2_unauthenticated "${s2_unauthenticated}" \
     log_level "${log_level}" \
     soft_reset "^${soft_reset}" \
-    presets "${presets}" |
+    safe_mode "${safe_mode}" |
     tempio \
         -template /usr/share/tempio/zwave_config.conf \
         -out /etc/zwave_config.json

--- a/zwave_js/rootfs/etc/cont-init.d/config.sh
+++ b/zwave_js/rootfs/etc/cont-init.d/config.sh
@@ -119,8 +119,29 @@ else
     bashio::log.info "Soft-reset disabled by user"
 fi
 
-timeouts=$(bashio::config 'timeouts' '{}')
-attempts=$(bashio::config 'attempts' '{}')
+timeouts_and_attempts=""
+
+if bashio::config.true 'safe_mode'; then
+    timeouts_and_attempts=",
+    \"timeouts\": {
+        \"ack\": 10000,
+        \"byte\": 10000,
+        \"response\": 60000,
+        \"sendDataCallback\": 650000,
+        \"report\": 10000,
+        \"nonce\": 20000,
+        \"retryJammed\": 5000,
+        \"sendToSleep\": 5000,
+        \"serialAPIStarted\": 30000
+    },
+    \"attempts\": {
+        \"openSerialPort\": 20000,
+        \"controller\": 3,
+        \"sendData\": 5,
+        \"sendDataJammed\": 10,
+        \"nodeInterview\": 10
+    }"
+fi
 
 # Generate config
 bashio::var.json \
@@ -130,8 +151,7 @@ bashio::var.json \
     s2_unauthenticated "${s2_unauthenticated}" \
     log_level "${log_level}" \
     soft_reset "^${soft_reset}" \
-    timeouts "${timeouts}" \
-    attempts "${attempts}" |
+    timeouts_and_attempts "${timeouts_and_attempts}" |
     tempio \
         -template /usr/share/tempio/zwave_config.conf \
         -out /etc/zwave_config.json

--- a/zwave_js/rootfs/etc/cont-init.d/config.sh
+++ b/zwave_js/rootfs/etc/cont-init.d/config.sh
@@ -119,28 +119,11 @@ else
     bashio::log.info "Soft-reset disabled by user"
 fi
 
-timeouts_and_attempts=""
+presets=""
 
 if bashio::config.true 'safe_mode'; then
-    timeouts_and_attempts=",
-    \"timeouts\": {
-        \"ack\": 10000,
-        \"byte\": 10000,
-        \"response\": 60000,
-        \"sendDataCallback\": 650000,
-        \"report\": 10000,
-        \"nonce\": 20000,
-        \"retryJammed\": 5000,
-        \"sendToSleep\": 5000,
-        \"serialAPIStarted\": 30000
-    },
-    \"attempts\": {
-        \"openSerialPort\": 20000,
-        \"controller\": 3,
-        \"sendData\": 5,
-        \"sendDataJammed\": 10,
-        \"nodeInterview\": 10
-    }"
+    presets=",
+    \"presets\": [\"SAFE_MODE\"]"
 fi
 
 # Generate config
@@ -151,7 +134,7 @@ bashio::var.json \
     s2_unauthenticated "${s2_unauthenticated}" \
     log_level "${log_level}" \
     soft_reset "^${soft_reset}" \
-    timeouts_and_attempts "${timeouts_and_attempts}" |
+    presets "${presets}" |
     tempio \
         -template /usr/share/tempio/zwave_config.conf \
         -out /etc/zwave_config.json

--- a/zwave_js/rootfs/etc/cont-init.d/config.sh
+++ b/zwave_js/rootfs/etc/cont-init.d/config.sh
@@ -119,11 +119,11 @@ else
     bashio::log.info "Soft-reset disabled by user"
 fi
 
-driver_presets=""
+presets=""
 
 if bashio::config.true 'safe_mode'; then
-    driver_presets=",
-    \"driverPresets\": [\"SAFE_MODE\"]"
+    presets=",
+    \"presets\": [\"SAFE_MODE\"]"
 fi
 
 # Generate config
@@ -134,7 +134,7 @@ bashio::var.json \
     s2_unauthenticated "${s2_unauthenticated}" \
     log_level "${log_level}" \
     soft_reset "^${soft_reset}" \
-    driver_presets "${driver_presets}" |
+    presets "${presets}" |
     tempio \
         -template /usr/share/tempio/zwave_config.conf \
         -out /etc/zwave_config.json

--- a/zwave_js/rootfs/etc/cont-init.d/config.sh
+++ b/zwave_js/rootfs/etc/cont-init.d/config.sh
@@ -122,6 +122,8 @@ fi
 presets=""
 
 if bashio::config.true 'safe_mode'; then
+    bashio::log.info "Safe mode enabled"
+    bashio::log.warning "WARNING: While in safe mode, the performance of your Z-Wave network will be in a reduced state. This is only meant for debugging purposes."
     presets=",
     \"presets\": [\"SAFE_MODE\"]"
 fi

--- a/zwave_js/rootfs/etc/cont-init.d/config.sh
+++ b/zwave_js/rootfs/etc/cont-init.d/config.sh
@@ -119,11 +119,11 @@ else
     bashio::log.info "Soft-reset disabled by user"
 fi
 
-presets=""
+driver_presets=""
 
 if bashio::config.true 'safe_mode'; then
-    presets=",
-    \"presets\": [\"SAFE_MODE\"]"
+    driver_presets=",
+    \"driverPresets\": [\"SAFE_MODE\"]"
 fi
 
 # Generate config
@@ -134,7 +134,7 @@ bashio::var.json \
     s2_unauthenticated "${s2_unauthenticated}" \
     log_level "${log_level}" \
     soft_reset "^${soft_reset}" \
-    presets "${presets}" |
+    driver_presets "${driver_presets}" |
     tempio \
         -template /usr/share/tempio/zwave_config.conf \
         -out /etc/zwave_config.json

--- a/zwave_js/rootfs/etc/cont-init.d/config.sh
+++ b/zwave_js/rootfs/etc/cont-init.d/config.sh
@@ -119,6 +119,9 @@ else
     bashio::log.info "Soft-reset disabled by user"
 fi
 
+timeouts=$(bashio::config 'timeouts' '{}')
+attempts=$(bashio::config 'attempts' '{}')
+
 # Generate config
 bashio::var.json \
     s0_legacy "${s0_legacy}" \
@@ -126,7 +129,9 @@ bashio::var.json \
     s2_authenticated "${s2_authenticated}" \
     s2_unauthenticated "${s2_unauthenticated}" \
     log_level "${log_level}" \
-    soft_reset "^${soft_reset}" |
+    soft_reset "^${soft_reset}" \
+    timeouts "${timeouts}" \
+    attempts "${attempts}" |
     tempio \
         -template /usr/share/tempio/zwave_config.conf \
         -out /etc/zwave_config.json

--- a/zwave_js/rootfs/usr/share/tempio/zwave_config.conf
+++ b/zwave_js/rootfs/usr/share/tempio/zwave_config.conf
@@ -14,5 +14,5 @@
         "S2_Authenticated": "{{ .s2_authenticated }}",
         "S2_Unauthenticated": "{{ .s2_unauthenticated }}"
     },
-    "enableSoftReset": {{ .soft_reset }}{{ .timeouts_and_attempts }}
+    "enableSoftReset": {{ .soft_reset }}{{ .presets }}
 }

--- a/zwave_js/rootfs/usr/share/tempio/zwave_config.conf
+++ b/zwave_js/rootfs/usr/share/tempio/zwave_config.conf
@@ -14,5 +14,5 @@
         "S2_Authenticated": "{{ .s2_authenticated }}",
         "S2_Unauthenticated": "{{ .s2_unauthenticated }}"
     },
-    "enableSoftReset": {{ .soft_reset }}{{ .presets }}
+    "enableSoftReset": {{ .soft_reset }}{{ .driver_presets }}
 }

--- a/zwave_js/rootfs/usr/share/tempio/zwave_config.conf
+++ b/zwave_js/rootfs/usr/share/tempio/zwave_config.conf
@@ -14,5 +14,8 @@
         "S2_Authenticated": "{{ .s2_authenticated }}",
         "S2_Unauthenticated": "{{ .s2_unauthenticated }}"
     },
-    "enableSoftReset": {{ .soft_reset }}{{ .presets }}
+    "enableSoftReset": {{ .soft_reset }},
+    "presets": [
+        {{ .safe_mode }}
+    ]
 }

--- a/zwave_js/rootfs/usr/share/tempio/zwave_config.conf
+++ b/zwave_js/rootfs/usr/share/tempio/zwave_config.conf
@@ -14,5 +14,7 @@
         "S2_Authenticated": "{{ .s2_authenticated }}",
         "S2_Unauthenticated": "{{ .s2_unauthenticated }}"
     },
+    "timeouts": {{ .timeouts }},
+    "attempts": {{ .attempts }},
     "enableSoftReset": {{ .soft_reset }}
 }

--- a/zwave_js/rootfs/usr/share/tempio/zwave_config.conf
+++ b/zwave_js/rootfs/usr/share/tempio/zwave_config.conf
@@ -14,5 +14,5 @@
         "S2_Authenticated": "{{ .s2_authenticated }}",
         "S2_Unauthenticated": "{{ .s2_unauthenticated }}"
     },
-    "enableSoftReset": {{ .soft_reset }}{{ .driver_presets }}
+    "enableSoftReset": {{ .soft_reset }}{{ .presets }}
 }

--- a/zwave_js/rootfs/usr/share/tempio/zwave_config.conf
+++ b/zwave_js/rootfs/usr/share/tempio/zwave_config.conf
@@ -14,7 +14,5 @@
         "S2_Authenticated": "{{ .s2_authenticated }}",
         "S2_Unauthenticated": "{{ .s2_unauthenticated }}"
     },
-    "timeouts": {{ .timeouts }},
-    "attempts": {{ .attempts }},
-    "enableSoftReset": {{ .soft_reset }}
+    "enableSoftReset": {{ .soft_reset }}{{ .timeouts_and_attempts }}
 }

--- a/zwave_js/rootfs/usr/share/tempio/zwave_config.conf
+++ b/zwave_js/rootfs/usr/share/tempio/zwave_config.conf
@@ -15,7 +15,5 @@
         "S2_Unauthenticated": "{{ .s2_unauthenticated }}"
     },
     "enableSoftReset": {{ .soft_reset }},
-    "presets": [
-        {{ .safe_mode }}
-    ]
+    "presets": {{ .presets }}
 }

--- a/zwave_js/translations/en.yaml
+++ b/zwave_js/translations/en.yaml
@@ -45,5 +45,18 @@ configuration:
       automatically detect whether or not this needs to be enabled. The
       default setting should work for most users, so only change this setting
       if you know what you are doing and/or you are asked to.
+  timeouts:
+    name: Timeouts in milliseconds
+    description: >-
+      This section overrides the various default timeouts. The defaults should
+      work for most users, so only change these if you know what you if you
+      know what you are doing and/or you are asked to.
+  attempts:
+    name: Attempts
+    description: >-
+      This section overrides the various default number of attempts to retry
+      before the driver gives up. The defaults should work for most users, so
+      only change these if you know what you if you know what you are doing
+      and/or you are asked to.
 network:
   3000/tcp: Z-Wave JS communication

--- a/zwave_js/translations/en.yaml
+++ b/zwave_js/translations/en.yaml
@@ -45,18 +45,13 @@ configuration:
       automatically detect whether or not this needs to be enabled. The
       default setting should work for most users, so only change this setting
       if you know what you are doing and/or you are asked to.
-  timeouts:
-    name: Timeouts in milliseconds
+  safe_mode:
+    name: Enable safe mode
     description: >-
-      This section overrides the various default timeouts. The defaults should
-      work for most users, so only change these if you know what you if you
-      know what you are doing and/or you are asked to.
-  attempts:
-    name: Attempts
-    description: >-
-      This section overrides the various default number of attempts to retry
-      before the driver gives up. The defaults should work for most users, so
-      only change these if you know what you if you know what you are doing
-      and/or you are asked to.
+      This setting puts your network in safe mode, which could significantly decrease
+      the performance of your network but may also help get the network up and running
+      so that you can troubleshoot issues, grab logs, etc. In most cases, users will
+      never need to use this feature, so only change this setting if you know what you
+      are doing and/or you are asked to.
 network:
   3000/tcp: Z-Wave JS communication

--- a/zwave_js/translations/en.yaml
+++ b/zwave_js/translations/en.yaml
@@ -48,10 +48,11 @@ configuration:
   safe_mode:
     name: Enable safe mode
     description: >-
-      This setting puts your network in safe mode, which could significantly decrease
-      the performance of your network but may also help get the network up and running
-      so that you can troubleshoot issues, grab logs, etc. In most cases, users will
-      never need to use this feature, so only change this setting if you know what you
-      are doing and/or you are asked to.
+      This setting puts your network in safe mode, which could significantly
+      decrease the performance of your network but may also help get the
+      network up and running so that you can troubleshoot issues, grab logs,
+      etc. In most cases, users will never need to use this feature, so only
+      change this setting if you know what you are doing and/or you are asked
+      to.
 network:
   3000/tcp: Z-Wave JS communication


### PR DESCRIPTION
In some cases, users may need to adjust the length of timeouts or number of attempts configured in the driver. We therefore add a new hidden option to enable a safe mode, which, when enabled, will set some defaults for the `timeouts` and `attempts` options.

I have not validated these values with @AlCalzone yet