### PR TITLE
Bump zwave-js to 12.0.4

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.1.97
+
+### Bug fixes
+
+- Z-Wave JS: Fixed a crash that could happen while logging dropped sensor readings.
+- Z-Wave JS: Change the default timeout to handle slow 500 series controllers.
+
+### Config file changes
+
+- Treat Basic Set as events for TKB TZ35S/D and TZ55S/D
+- Add Zooz ZAC38 Range Extender
+- Corrected the label of the notification event `0x0a` to be `Emergency Alarm`
+
+### Detailed changelogs
+
+- - [Z-Wave JS 12.0.4](https://github.com/zwave-js/node-zwave-js/releases/tag/v12.0.4)
+
 ## 0.1.96
 
 ### Bug fixes

--- a/zwave_js/build.yaml
+++ b/zwave_js/build.yaml
@@ -10,4 +10,4 @@ codenotary:
   base_image: notary@home-assistant.io
 args:
   ZWAVEJS_SERVER_VERSION: 1.32.1
-  ZWAVEJS_VERSION: 12.0.3
+  ZWAVEJS_VERSION: 12.0.4

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.1.96
+version: 0.1.97
 slug: zwave_js
 name: Z-Wave JS
 description: Control a Z-Wave network with Home Assistant Z-Wave JS


### PR DESCRIPTION
- [Z-Wave JS 12.0.4](https://github.com/zwave-js/node-zwave-js/releases/tag/v12.0.4)