### PR TITLE
duckdns: Reduce log spam when updating IP address

### DIFF
--- a/duckdns/data/run.sh
+++ b/duckdns/data/run.sh
@@ -83,10 +83,10 @@ while true; do
 
     if [[ ${ipv6} == *:* ]]; then
         if answer="$(curl -s "https://www.duckdns.org/update?domains=${DOMAINS}&token=${TOKEN}&ipv6=${ipv6}&verbose=true")" && [ "${answer}" != 'KO' ]; then
-            if [[ "${answer}" == *UPDATED* ]]; then
-		bashio::log.info "${answer}"
+            if [[ "${answer}" == *NOCHANGE* ]]; then
+   		bashio::log.debug "${answer}"
 	    else
-   		bashio::log.debug "${answer}"	  			
+		bashio::log.info "${answer}"
       	    fi
         else
             bashio::log.warning "${answer}"

--- a/duckdns/data/run.sh
+++ b/duckdns/data/run.sh
@@ -83,7 +83,11 @@ while true; do
 
     if [[ ${ipv6} == *:* ]]; then
         if answer="$(curl -s "https://www.duckdns.org/update?domains=${DOMAINS}&token=${TOKEN}&ipv6=${ipv6}&verbose=true")" && [ "${answer}" != 'KO' ]; then
-            bashio::log.info "${answer}"
+            if [[ "${answer}" == *UPDATED* ]]; then
+		bashio::log.info "${answer}"
+	    else
+   		bashio::log.debug "${answer}"	  			
+      	    fi
         else
             bashio::log.warning "${answer}"
         fi
@@ -91,7 +95,11 @@ while true; do
 
     if [[ -z ${ipv4} || ${ipv4} == *.* ]]; then
         if answer="$(curl -s "https://www.duckdns.org/update?domains=${DOMAINS}&token=${TOKEN}&ip=${ipv4}&verbose=true")" && [ "${answer}" != 'KO' ]; then
-            bashio::log.info "${answer}"
+            if [[ "${answer}" == *UPDATED* ]]; then
+		bashio::log.info "${answer}"
+	    else
+   		bashio::log.debug "${answer}"	  			
+      	    fi
         else
             bashio::log.warning "${answer}"
         fi

--- a/duckdns/data/run.sh
+++ b/duckdns/data/run.sh
@@ -95,10 +95,10 @@ while true; do
 
     if [[ -z ${ipv4} || ${ipv4} == *.* ]]; then
         if answer="$(curl -s "https://www.duckdns.org/update?domains=${DOMAINS}&token=${TOKEN}&ip=${ipv4}&verbose=true")" && [ "${answer}" != 'KO' ]; then
-            if [[ "${answer}" == *UPDATED* ]]; then
-		bashio::log.info "${answer}"
+            if [[ "${answer}" == *NOCHANGE* ]]; then
+   		bashio::log.debug "${answer}"
 	    else
-   		bashio::log.debug "${answer}"	  			
+		bashio::log.info "${answer}"
       	    fi
         else
             bashio::log.warning "${answer}"


### PR DESCRIPTION
Reduce log level of "NOCHANGE" updates to debug.
This prevents the log beeing flooded with messages about IP updates where nothing noteworthy happend.