### PR TITLE
fix typo openwakeword

### DIFF
--- a/openwakeword/config.yaml
+++ b/openwakeword/config.yaml
@@ -3,7 +3,7 @@ version: 1.8.0
 slug: openwakeword
 name: openWakeWord
 description: openWakeWord using the Wyoming protocol
-url: https://github.com/home-assistant/addons/blob/master/openWakeWord
+url: https://github.com/home-assistant/addons/blob/master/openwakeword
 arch:
   - amd64
   - aarch64


### PR DESCRIPTION
when you click on the link in the addon, you get an error on GitHub due to the name of the addon not being written in all lower case letters