### PR TITLE
Bump openwakeword to 1.8.1 (remove batching)

### DIFF
--- a/openwakeword/CHANGELOG.md
+++ b/openwakeword/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.8.1
+
+- Remove batching from wake word processing since not all models support it
+
 ## 1.8.0
 
 - Include fix for potential deadlock

--- a/openwakeword/build.yaml
+++ b/openwakeword/build.yaml
@@ -6,4 +6,4 @@ codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
 args:
-  OPENWAKEWORD_LIB_VERSION: 1.8.0
+  OPENWAKEWORD_LIB_VERSION: 1.8.1

--- a/openwakeword/config.yaml
+++ b/openwakeword/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 1.8.0
+version: 1.8.1
 slug: openwakeword
 name: openWakeWord
 description: openWakeWord using the Wyoming protocol


### PR DESCRIPTION
- Bump `wyoming-openwakeword` to 1.8.1
- Removes batching for final part of wake word processing (some models don't support this)
- Intended to fix: https://github.com/home-assistant/addons/issues/3277