### PR TITLE
Bump zwave-js to 12.3.0 and add configuration option

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 0.3.0
+
+### Features
+
+- Add-On: Add `disable_controller_recovery` configuration option. When enabled, the driver will not attempt to automatically recover from an unresponsive controller and will instead either let the controller recover on its own or wait for the user to restart the add-on to attempt recovery. This is an advanced configuration option that should not be adjusted in most cases and is therefore hidden from the default view.
+
+### Bug fixes
+
+- Z-Wave JS: Ensure the default Basic CC values are only exposed if they should be
+- Z-Wave JS: Auto-remove failed SmartStart nodes when bootstrapping times out
+- Z-Wave JS: Improve how unresponsive controllers are handled
+
+### Config file changes
+
+- Tweak Heatit Z-TRM6 options
+- Add Ring Alarm Panic Button Gen2
+- Update fingerprints for Vesternet device
+
+### Detailed changelogs
+
+- [Z-Wave JS 12.3.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v12.3.0)
+
 ## 0.2.1
 
 ### Config file changes

--- a/zwave_js/DOCS.md
+++ b/zwave_js/DOCS.md
@@ -150,6 +150,17 @@ This setting tells the add-on how to handle soft-resets for 500 series controlle
 If you don't have a USB stick, you can use a fake stick for testing purposes.
 It will not be able to control any real devices.
 
+### Optional `disable_controller_recovery` (optional):
+
+This setting will disable Z-Wave JS's automatic recovery process when the
+controller appears to be unresponsive and will instead let the controller
+recover on its own if it's capable of doing so. While the controller is
+unresponsive, commands will start to fail and nodes may randomly get
+marked as dead. If a controller is not able to recover on its own, you
+will need to restart the add-on to attempt recovery. In most cases, users
+will never need to use this feature, so only change this setting if you
+know what you are doing and/or you are asked to.
+
 ### Option `safe_mode` (optional)
 
 This setting puts your network in safe mode, which could significantly decrease

--- a/zwave_js/build.yaml
+++ b/zwave_js/build.yaml
@@ -10,4 +10,4 @@ codenotary:
   base_image: notary@home-assistant.io
 args:
   ZWAVEJS_SERVER_VERSION: 1.33.0
-  ZWAVEJS_VERSION: 12.2.3
+  ZWAVEJS_VERSION: 12.3.0

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.2.1
+version: 0.3.0
 slug: zwave_js
 name: Z-Wave JS
 description: Control a Z-Wave network with Home Assistant Z-Wave JS

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -37,6 +37,7 @@ schema:
   s2_unauthenticated_key: match(|[0-9a-fA-F]{32,32})?
   network_key: match(|[0-9a-fA-F]{32,32})?
   emulate_hardware: bool?
+  disable_controller_recovery: bool?
   safe_mode: bool?
 stage: stable
 startup: services

--- a/zwave_js/rootfs/etc/cont-init.d/config.sh
+++ b/zwave_js/rootfs/etc/cont-init.d/config.sh
@@ -131,6 +131,13 @@ if bashio::config.true 'safe_mode'; then
     presets_array+=("SAFE_MODE")
 fi
 
+if bashio::config.true 'disable_controller_recovery'; then
+    bashio::log.info "Automatic controller recovery disabled"
+    bashio::log.warning "WARNING: If your controller becomes unresponsive, commands may start to fail and nodes may start to get marked as dead until the controller is able to recover on its own. If it doesn't recover on its own, you will need to restart the add-on manually to try to recover yourself."
+    # Add NO_CONTROLLER_RECOVERY to presets array
+    presets_array+=("NO_CONTROLLER_RECOVERY")
+fi
+
 # Convert presets array to JSON string and add to config
 if [[ ${#presets_array[@]} -eq 0 ]]; then
     presets="[]"

--- a/zwave_js/translations/en.yaml
+++ b/zwave_js/translations/en.yaml
@@ -45,6 +45,17 @@ configuration:
       automatically detect whether or not this needs to be enabled. The
       default setting should work for most users, so only change this setting
       if you know what you are doing and/or you are asked to.
+  disable_controller_recovery:
+    name: Disable automatic controller recovery
+    description: >-
+      This setting will disable Z-Wave JS's automatic recovery process when the
+      controller appears to be unresponsive and will instead let the controller
+      recover on its own if it's capable of doing so. While the controller is
+      unresponsive, commands will start to fail and nodes may randomly get
+      marked as dead. If a controller is not able to recover on its own, you
+      will need to restart the add-on to attempt recovery. In most cases, users
+      will never need to use this feature, so only change this setting if you
+      know what you are doing and/or you are asked to.
   safe_mode:
     name: Enable safe mode
     description: >-


### PR DESCRIPTION
Changelogs:
- [Z-Wave JS 12.3.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v12.3.0)

The included changes will hopefully help users who are having start up issues, but just in case we have also added support for the newly added preset `NO_CONTROLLER_RECOVERY` (see here for more details: https://github.com/zwave-js/node-zwave-js/pull/6480)

~~This has not been tested yet. While I will get to it eventually, any additional support in testing would be appreciated.~~ EDIT: As far as I can tell, everything looks good!

@AlCalzone let me know if you have any thoughts on the changelog