### PR TITLE
samba: Add-on configs, healtcheck, Alpine 3.18

### DIFF
--- a/samba/CHANGELOG.md
+++ b/samba/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 11.0.0
+
+- The `config` share has been renamed to `homeassistant` to match upstream changes.
+- Add support for accessing public add-on configurations
+- Update to Alpine 3.18
+- Adds HEALTCHECK support
+
 ## 10.0.2
 
 - Enable IPv6 ULA and IPv4 link-local addresses by default

--- a/samba/Dockerfile
+++ b/samba/Dockerfile
@@ -6,10 +6,7 @@ ENV LANG C.UTF-8
 
 # Setup base
 RUN \
-    apk add --no-cache \
-        samba-common-tools \
-        samba-server \
-    \
+    apk add --no-cache samba \
     && mkdir -p /var/lib/samba \
     && touch \
         /etc/samba/lmhosts \
@@ -19,3 +16,6 @@ RUN \
 
 # Copy data
 COPY rootfs /
+
+HEALTHCHECK \
+    CMD smbclient -L '\\localhost' -U '%' -m SMB3

--- a/samba/build.yaml
+++ b/samba/build.yaml
@@ -1,10 +1,10 @@
 ---
 build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-base:3.17
-  amd64: ghcr.io/home-assistant/amd64-base:3.17
-  armhf: ghcr.io/home-assistant/armhf-base:3.17
-  armv7: ghcr.io/home-assistant/armv7-base:3.17
-  i386: ghcr.io/home-assistant/i386-base:3.17
+  aarch64: ghcr.io/home-assistant/aarch64-base:3.18
+  amd64: ghcr.io/home-assistant/amd64-base:3.18
+  armhf: ghcr.io/home-assistant/armhf-base:3.18
+  armv7: ghcr.io/home-assistant/armv7-base:3.18
+  i386: ghcr.io/home-assistant/i386-base:3.18
 codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io

--- a/samba/config.yaml
+++ b/samba/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 10.0.2
+version: 11.0.0
 slug: samba
 name: Samba share
 description: Expose Home Assistant folders with SMB/CIFS
@@ -16,12 +16,13 @@ host_network: true
 image: homeassistant/{arch}-addon-samba
 init: false
 map:
-  - config:rw
-  - ssl:rw
   - addons:rw
-  - share:rw
+  - all_addon_configs:rw
   - backup:rw
+  - homeassistant_config:rw
   - media:rw
+  - share:rw
+  - ssl:rw
 options:
   username: homeassistant
   password: null

--- a/samba/rootfs/usr/share/tempio/smb.gtpl
+++ b/samba/rootfs/usr/share/tempio/smb.gtpl
@@ -12,8 +12,8 @@
    log level = 2
 
    bind interfaces only = yes
-   interfaces = {{ .interfaces | join " " }}
-   hosts allow = {{ .allow_hosts | join " " }}
+   interfaces = 127.0.0.1 {{ .interfaces | join " " }}
+   hosts allow = 127.0.0.1 {{ .allow_hosts | join " " }}
 
    {{ if .compatibility_mode }}
    client min protocol = NT1
@@ -24,10 +24,10 @@
    dos charset = CP850
    unix charset = UTF-8
 
-[config]
+[homeassistant]
    browseable = yes
    writeable = yes
-   path = /config
+   path = /homeassistant
 
    valid users = {{ .username }}
    force user = root
@@ -39,6 +39,17 @@
    browseable = yes
    writeable = yes
    path = /addons
+
+   valid users = {{ .username }}
+   force user = root
+   force group = root
+   veto files = /{{ .veto_files | join "/" }}/
+   delete veto files = {{ eq (len .veto_files) 0 | ternary "no" "yes" }}
+
+[addon_configs]
+   browseable = yes
+   writeable = yes
+   path = /addon_configs
 
    valid users = {{ .username }}
    force user = root


### PR DESCRIPTION
- The `config` share has been renamed to `homeassistant` to match upstream changes.
- Add support for accessing public add-on configurations
- Update to Alpine 3.18
- Adds HEALTCHECK support