### PR TITLE
ssh: Add-on configs, Alpine 3.18

### DIFF
--- a/ssh/CHANGELOG.md
+++ b/ssh/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 9.8.0
+
+- The `config` share has been renamed to `homeassistant` to match upstream changes.
+- Add support for accessing public add-on configurations
+- Upgrade to Alpine 3.18
+
 ## 9.7.1
 
 - Upgrade Home Assistant CLI to 4.26.0

--- a/ssh/CHANGELOG.md
+++ b/ssh/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 9.8.0
 
-- The `config` share has been renamed to `homeassistant` to match upstream changes.
+- Please note: the `/config` folder has been renamed to `/homeassistant`.
 - Add support for accessing public add-on configurations
 - Upgrade to Alpine 3.18
 

--- a/ssh/build.yaml
+++ b/ssh/build.yaml
@@ -1,10 +1,10 @@
 ---
 build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-base:3.17
-  amd64: ghcr.io/home-assistant/amd64-base:3.17
-  armhf: ghcr.io/home-assistant/armhf-base:3.17
-  armv7: ghcr.io/home-assistant/armv7-base:3.17
-  i386: ghcr.io/home-assistant/i386-base:3.17
+  aarch64: ghcr.io/home-assistant/aarch64-base:3.18
+  amd64: ghcr.io/home-assistant/amd64-base:3.18
+  armhf: ghcr.io/home-assistant/armhf-base:3.18
+  armv7: ghcr.io/home-assistant/armv7-base:3.18
+  i386: ghcr.io/home-assistant/i386-base:3.18
 codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io

--- a/ssh/config.yaml
+++ b/ssh/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 9.7.1
+version: 9.8.0
 slug: ssh
 name: Terminal & SSH
 description: Allow logging in remotely to Home Assistant using SSH
@@ -20,12 +20,13 @@ image: homeassistant/{arch}-addon-ssh
 ingress: true
 init: false
 map:
-  - config:rw
-  - ssl:rw
   - addons:rw
-  - share:rw
+  - all_addon_configs:rw
   - backup:rw
+  - homeassistant_config:rw
   - media:rw
+  - share:rw
+  - ssl:rw
 options:
   authorized_keys: []
   password: ""

--- a/ssh/rootfs/etc/cont-init.d/profile.sh
+++ b/ssh/rootfs/etc/cont-init.d/profile.sh
@@ -2,7 +2,7 @@
 # ==============================================================================
 # Setup persistent user settings
 # ==============================================================================
-readonly DIRECTORIES=(addons backup config share ssl)
+readonly DIRECTORIES=(addon_configs addons backup homeassistant media share ssl)
 
 # Persist shell history by redirecting .bash_history to /data
 if ! bashio::fs.file_exists /data/.bash_profile; then
@@ -30,4 +30,3 @@ for dir in "${DIRECTORIES[@]}"; do
     ln -s "/${dir}" "${HOME}/${dir}" \
         || bashio::log.warning "Failed linking common directory: ${dir}"
 done
-


### PR DESCRIPTION
- Please note: the `/config` folder has been renamed to `/homeassistant`.
- Add support for accessing public add-on configurations
- Upgrade to Alpine 3.18
