### PR TITLE
samba: Adjust to latest Supervisor changes

### DIFF
--- a/samba/CHANGELOG.md
+++ b/samba/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## 11.1.0
+## 12.0.0
 
+- Temporary remove access to add-on config shares, until Supervisor 2023.11.2 has been rolled out stable
 - Revert `config` share name change to avoid user facing change
 - Adjust location of Home Assistant config to match latest dev/beta Supervisor
 - Migrate add-on layout to S6 Overlay

--- a/samba/CHANGELOG.md
+++ b/samba/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 11.1.0
 
+- Revert `config` share name change to avoid user facing change
+- Adjust location of Home Assistant config to match latest dev/beta Supervisor
 - Migrate add-on layout to S6 Overlay
 
 ## 11.0.0

--- a/samba/config.yaml
+++ b/samba/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 11.1.0
+version: 12.0.0
 slug: samba
 name: Samba share
 description: Expose Home Assistant folders with SMB/CIFS
@@ -17,9 +17,8 @@ image: homeassistant/{arch}-addon-samba
 init: false
 map:
   - addons:rw
-  - all_addon_configs:rw
   - backup:rw
-  - homeassistant_config:rw
+  - config:rw
   - media:rw
   - share:rw
   - ssl:rw

--- a/samba/config.yaml
+++ b/samba/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 11.0.0
+version: 11.1.0
 slug: samba
 name: Samba share
 description: Expose Home Assistant folders with SMB/CIFS

--- a/samba/rootfs/usr/share/tempio/smb.gtpl
+++ b/samba/rootfs/usr/share/tempio/smb.gtpl
@@ -24,10 +24,10 @@
    dos charset = CP850
    unix charset = UTF-8
 
-[homeassistant]
+[config]
    browseable = yes
    writeable = yes
-   path = /homeassistant
+   path = /config
 
    valid users = {{ .username }}
    force user = root

--- a/samba/rootfs/usr/share/tempio/smb.gtpl
+++ b/samba/rootfs/usr/share/tempio/smb.gtpl
@@ -46,17 +46,6 @@
    veto files = /{{ .veto_files | join "/" }}/
    delete veto files = {{ eq (len .veto_files) 0 | ternary "no" "yes" }}
 
-[addon_configs]
-   browseable = yes
-   writeable = yes
-   path = /addon_configs
-
-   valid users = {{ .username }}
-   force user = root
-   force group = root
-   veto files = /{{ .veto_files | join "/" }}/
-   delete veto files = {{ eq (len .veto_files) 0 | ternary "no" "yes" }}
-
 [ssl]
    browseable = yes
    writeable = yes


### PR DESCRIPTION
## 12.0.0

- Temporary remove access to add-on config shares, until Supervisor 2023.11.2 has been rolled out stable
- Revert `config` share name change to avoid user facing change
- Adjust location of Home Assistant config to match latest dev/beta Supervisor
- Migrate add-on layout to S6 Overlay

fixes #3309
fixes #3302