### PR TITLE
samba: Add support for accessing add-on configs

### DIFF
--- a/samba/CHANGELOG.md
+++ b/samba/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 12.1.0
+
+- Use the new Home Assistant folder for the `config` share
+- Add support for accessing public add-on configurations
+
 ## 12.0.0
 
 - Temporary remove access to add-on config shares, until Supervisor 2023.11.2 has been rolled out stable

--- a/samba/config.yaml
+++ b/samba/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 12.0.0
+version: 12.1.0
 slug: samba
 name: Samba share
 description: Expose Home Assistant folders with SMB/CIFS
@@ -17,8 +17,9 @@ image: homeassistant/{arch}-addon-samba
 init: false
 map:
   - addons:rw
+  - all_addon_configs:rw
   - backup:rw
-  - config:rw
+  - homeassistant_config:rw
   - media:rw
   - share:rw
   - ssl:rw

--- a/samba/rootfs/usr/share/tempio/smb.gtpl
+++ b/samba/rootfs/usr/share/tempio/smb.gtpl
@@ -27,7 +27,7 @@
 [config]
    browseable = yes
    writeable = yes
-   path = /config
+   path = /homeassistant
 
    valid users = {{ .username }}
    force user = root
@@ -39,6 +39,17 @@
    browseable = yes
    writeable = yes
    path = /addons
+
+   valid users = {{ .username }}
+   force user = root
+   force group = root
+   veto files = /{{ .veto_files | join "/" }}/
+   delete veto files = {{ eq (len .veto_files) 0 | ternary "no" "yes" }}
+
+[addon_configs]
+   browseable = yes
+   writeable = yes
+   path = /addon_configs
 
    valid users = {{ .username }}
    force user = root


### PR DESCRIPTION
## 12.1.0

- Use the new Home Assistant folder for the `config` share
- Add support for accessing public add-on configurations