### PR TITLE
Add support for addon_configs to zwave_js

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Add-On: Allow custom device config files to be manually installed in `/addon_configs/core_zwave_js/custom_device_configs`
 - Add-On: Provide access to Z-Wave JS cache files for debugging in `/addon_configs/core_zwave_js/cache`
-- Add-On: Add configuration option to log to file. When enabled, logs will be written to `/addon_configs/core_zwave_js/zwave_js.log`
+- Add-On: Add configuration option to log to file. When enabled, logs will be written to `/addon_configs/core_zwave_js` with the `.log` file extension
 
 ## 0.3.0
 

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.3.1
+
+### Features
+
+- Add-On: Allow custom device config files to be manually installed in `/addon_configs/core_zwave_js/custom_device_configs`
+- Add-On: Provide access to Z-Wave JS cache files for debugging in `/addon_configs/core_zwave_js/cache`
+- Add-On: Add configuration option to log to file. When enabled, logs will be written to `/addon_configs/core_zwave_js/zwave_js.log`
+
 ## 0.3.0
 
 ### Features

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.3.1
+## 0.4.0
 
 ### Features
 

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ### Features
 
-- Add-On: Allow custom device config files to be manually installed in `/addon_configs/core_zwave_js/custom_device_configs`
 - Add-On: Provide access to Z-Wave JS cache files for debugging in `/addon_configs/core_zwave_js/cache`
 - Add-On: Add configuration option to log to file. When enabled, logs will be written to `/addon_configs/core_zwave_js` with the `.log` file extension
 

--- a/zwave_js/DOCS.md
+++ b/zwave_js/DOCS.md
@@ -140,8 +140,8 @@ the Supervisor.
 
 ### Optional `log_to_file`
 
-When this option is enabled, logs will be written to the `/addon_configs/core_zwave_js` folder.
-Log filenames will begin with `zwave_` and will end with `.log`.
+When this option is enabled, logs will be written to the `/addon_configs/core_zwave_js`
+folder with the `.log` file extension.
 
 ### Option `soft_reset`
 

--- a/zwave_js/DOCS.md
+++ b/zwave_js/DOCS.md
@@ -138,6 +138,11 @@ This option sets the log level of Z-Wave JS. Valid options are:
 If no `log_level` is specified, the log level will be set to the level set in
 the Supervisor.
 
+### Optional `log_to_file`
+
+When this option is enabled, logs will be written to the `/addon_configs/core_zwave_js` folder.
+Log filenames will begin with `zwave_` and will end with `.log`.
+
 ### Option `soft_reset`
 
 This setting tells the add-on how to handle soft-resets for 500 series controllers:
@@ -175,6 +180,12 @@ In previous versions of the addon, this was the only key that was needed. With
 the introduction of S2 security inclusion in zwave-js, this option has been
 deprecated in favor of `s0_legacy_key`. If still set, the `network_key` value will be
 migrated to `s0_legacy_key` on first startup.
+
+## Custom device config files
+
+In some cases, it may be useful for Z-Wave JS to use custom device config files. To
+load custom device config files into Z-Wave JS, put them in
+`/addon_configs/core_zwave_js/custom_device_configs` before starting the add-on.
 
 ## Known issues and limitations
 

--- a/zwave_js/DOCS.md
+++ b/zwave_js/DOCS.md
@@ -187,6 +187,17 @@ the introduction of S2 security inclusion in zwave-js, this option has been
 deprecated in favor of `s0_legacy_key`. If still set, the `network_key` value will be
 migrated to `s0_legacy_key` on first startup.
 
+### Troubleshooting network issues
+
+There are several features available in the add-on that can help you in troubleshooting network issues and/or providing data to either the Home Assistant or Z-Wave JS team to help in tracing an issue:
+
+1. **Update the log level:** It is extremely helpful when opening a GitHub issue to set the `log_level` configuration option to `debug` and capture when the issue occurs.
+2. **Log to file:** The `log_to_file` and `log_max_files` configuration options allow you to enable and configure that. Note that in order to access the log files, you will need to be able to access the filesystem of your HA instance, which you can do with the file editor, samba, or ssh add-ons among others.
+3. **Access Z-Wave JS cache:** Z-Wave JS stores information it discovers about your network in cache files so that your devices don't have to be reinterviewed on every startup. In some cases, when opening a GitHub issue, you may be asked to provide the cache files. You can access them in `/addon_configs/core_zwave_js/cache`. Note that in order to access the cache, you will need to be able to access the filesystem of your HA instance, which you can do with the file editor, samba, or ssh add-ons among others.
+4. **Change soft reset behavior:** By default, the addon will choose whether or not to soft reset the controller at startup automatically. In most cases that shouldn't be changed, but if asked to make a change when troubleshooting an issue, you can do so using the `soft_reset` configuration option.
+5. **Disable controller recovery:** By default, if the network controller appears to be jammed, Z-Wave JS will automatically try to restore the controller to a healthy state. In most cases that shouldn't be changed, but if asked to make a change when troubleshooting an issue, you can do so using the `disable_controller_recovery` configuration option.
+6. **Enable safe mode:** When Z-Wave JS is having trouble starting up, it can sometimes be hard to get useful logs to troubleshoot the issue. By setting `safe_mode` to true, Z-Wave JS may be able to start up in cases where it wouldn't with the `safe_mode` set to false. Note that enabling `safe_mode` will have a negative impact on the performance of your network and should be used sparingly.
+
 ## Known issues and limitations
 
 - Your hardware needs to be compatible with the Z-Wave JS library

--- a/zwave_js/DOCS.md
+++ b/zwave_js/DOCS.md
@@ -181,12 +181,6 @@ the introduction of S2 security inclusion in zwave-js, this option has been
 deprecated in favor of `s0_legacy_key`. If still set, the `network_key` value will be
 migrated to `s0_legacy_key` on first startup.
 
-## Custom device config files
-
-In some cases, it may be useful for Z-Wave JS to use custom device config files. To
-load custom device config files into Z-Wave JS, put them in
-`/addon_configs/core_zwave_js/custom_device_configs` before starting the add-on.
-
 ## Known issues and limitations
 
 - Your hardware needs to be compatible with the Z-Wave JS library

--- a/zwave_js/DOCS.md
+++ b/zwave_js/DOCS.md
@@ -138,18 +138,18 @@ This option sets the log level of Z-Wave JS. Valid options are:
 If no `log_level` is specified, the log level will be set to the level set in
 the Supervisor.
 
-### Option `log_to_file`
+### Option `log_to_file` (optional)
 
 When this option is enabled, logs will be written to the `/addon_configs/core_zwave_js`
 folder with the `.log` file extension.
 
-### Option `log_max_files`
+### Option `log_max_files` (optional)
 
 When `log_to_file` is true, Z-Wave JS will create a log file for each
 day. This option allows you to control the maximum number of files that
 Z-Wave JS will keep.
 
-### Option `soft_reset`
+### Option `soft_reset` (optional)
 
 This setting tells the add-on how to handle soft-resets for 500 series controllers:
 1. Automatic - the add-on will decide whether soft-reset should be enabled or disabled for 500 series controllers. This is the default option and should work for most people.

--- a/zwave_js/DOCS.md
+++ b/zwave_js/DOCS.md
@@ -138,10 +138,16 @@ This option sets the log level of Z-Wave JS. Valid options are:
 If no `log_level` is specified, the log level will be set to the level set in
 the Supervisor.
 
-### Optional `log_to_file`
+### Option `log_to_file`
 
 When this option is enabled, logs will be written to the `/addon_configs/core_zwave_js`
 folder with the `.log` file extension.
+
+### Option `log_max_files`
+
+When `log_to_file` is true, Z-Wave JS will create a log file for each
+day. This option allows you to control the maximum number of files that
+Z-Wave JS will keep.
 
 ### Option `soft_reset`
 

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.3.1
+version: 0.4.0
 slug: zwave_js
 name: Z-Wave JS
 description: Control a Z-Wave network with Home Assistant Z-Wave JS

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.3.0
+version: 0.3.1
 slug: zwave_js
 name: Z-Wave JS
 description: Control a Z-Wave network with Home Assistant Z-Wave JS
@@ -17,9 +17,12 @@ hassio_api: true
 homeassistant: 2021.2.0b0
 image: homeassistant/{arch}-addon-zwave_js
 init: false
+map:
+  - addon_config:rw
 options:
   device: null
   log_level: info
+  log_to_file: false
   soft_reset: Automatic
   s0_legacy_key: ""
   s2_access_control_key: ""
@@ -30,6 +33,7 @@ ports:
 schema:
   device: device(subsystem=tty)
   log_level: list(silly|debug|verbose|http|info|warn|error)?
+  log_to_file: bool?
   soft_reset: list(Automatic|Enabled|Disabled)?
   s0_legacy_key: match(|[0-9a-fA-F]{32,32})?
   s2_access_control_key: match(|[0-9a-fA-F]{32,32})?

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -34,9 +34,9 @@ ports:
 schema:
   device: device(subsystem=tty)
   log_level: list(silly|debug|verbose|http|info|warn|error)?
-  log_to_file: bool
-  log_max_files: int(1,)
-  soft_reset: list(Automatic|Enabled|Disabled)
+  log_to_file: bool?
+  log_max_files: int(1,)?
+  soft_reset: list(Automatic|Enabled|Disabled)?
   s0_legacy_key: match(|[0-9a-fA-F]{32,32})?
   s2_access_control_key: match(|[0-9a-fA-F]{32,32})?
   s2_authenticated_key: match(|[0-9a-fA-F]{32,32})?

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -23,6 +23,7 @@ options:
   device: null
   log_level: info
   log_to_file: false
+  log_max_files: 7
   soft_reset: Automatic
   s0_legacy_key: ""
   s2_access_control_key: ""
@@ -33,8 +34,9 @@ ports:
 schema:
   device: device(subsystem=tty)
   log_level: list(silly|debug|verbose|http|info|warn|error)?
-  log_to_file: bool?
-  soft_reset: list(Automatic|Enabled|Disabled)?
+  log_to_file: bool
+  log_max_files: int(1,)
+  soft_reset: list(Automatic|Enabled|Disabled)
   s0_legacy_key: match(|[0-9a-fA-F]{32,32})?
   s2_access_control_key: match(|[0-9a-fA-F]{32,32})?
   s2_authenticated_key: match(|[0-9a-fA-F]{32,32})?

--- a/zwave_js/rootfs/etc/cont-init.d/config.sh
+++ b/zwave_js/rootfs/etc/cont-init.d/config.sh
@@ -146,6 +146,7 @@ else
 fi
 
 log_to_file=$(bashio::config "log_to_file")
+log_max_files=$(bashio::config "log_max_files")
 
 # Generate config
 bashio::var.json \
@@ -155,6 +156,7 @@ bashio::var.json \
     s2_unauthenticated "${s2_unauthenticated}" \
     log_level "${log_level}" \
     log_to_file "${log_to_file}" \
+    log_max_files "${log_max_files}" \
     soft_reset "^${soft_reset}" \
     presets "${presets}" |
     tempio \

--- a/zwave_js/rootfs/etc/cont-init.d/config.sh
+++ b/zwave_js/rootfs/etc/cont-init.d/config.sh
@@ -145,6 +145,8 @@ else
     presets="$(printf '%s\n' "${presets_array[@]}" | jq -R . | jq -s .)"
 fi
 
+log_to_file=$(bashio::config "log_to_file")
+
 # Generate config
 bashio::var.json \
     s0_legacy "${s0_legacy}" \
@@ -152,6 +154,7 @@ bashio::var.json \
     s2_authenticated "${s2_authenticated}" \
     s2_unauthenticated "${s2_unauthenticated}" \
     log_level "${log_level}" \
+    log_to_file "${log_to_file}" \
     soft_reset "^${soft_reset}" \
     presets "${presets}" |
     tempio \

--- a/zwave_js/rootfs/etc/cont-init.d/structure.sh
+++ b/zwave_js/rootfs/etc/cont-init.d/structure.sh
@@ -2,5 +2,16 @@
 # ==============================================================================
 # Setup folder structure
 # ==============================================================================
-mkdir -p /data/cache
 mkdir -p /data/db
+
+if bashio::fs.directory_exists '/data/cache'; then
+    mv /data/cache /config/cache
+fi
+
+if ! bashio::fs.directory_exists '/config/cache'; then
+    mkdir -p /config/cache
+fi
+
+if ! bashio::fs.directory_exists '/config/custom_device_configs'; then
+    mkdir -p /config/custom_device_configs
+fi

--- a/zwave_js/rootfs/etc/cont-init.d/structure.sh
+++ b/zwave_js/rootfs/etc/cont-init.d/structure.sh
@@ -12,7 +12,3 @@ fi
 if ! bashio::fs.directory_exists '/config/cache'; then
     mkdir -p /config/cache
 fi
-
-if ! bashio::fs.directory_exists '/config/custom_device_configs'; then
-    mkdir -p /config/custom_device_configs
-fi

--- a/zwave_js/rootfs/etc/cont-init.d/structure.sh
+++ b/zwave_js/rootfs/etc/cont-init.d/structure.sh
@@ -5,6 +5,7 @@
 mkdir -p /data/db
 
 if bashio::fs.directory_exists '/data/cache'; then
+    bashio::log.info "Migrating 'cache' folder from private storage to /addon_configs/core_zwave_js"
     mv /data/cache /config/cache
 fi
 

--- a/zwave_js/rootfs/etc/services.d/zwave_js/run
+++ b/zwave_js/rootfs/etc/services.d/zwave_js/run
@@ -9,22 +9,6 @@ if bashio::config.true 'emulate_hardware'; then
     SERIAL_DEVICE="--mock-driver"
 fi
 
-if bashio::fs.directory_exists '/data/cache'; then
-    bashio::log.info "Migrating 'cache' folder to '/addon_configs/core_zwave_js/cache'"
-    mv /data/cache /config/cache
-fi
-
-if ! bashio::fs.directory_exists '/config/cache'; then
-    bashio::log.info "Creating 'cache' folder in '/addon_configs/core_zwave_js'"
-    mkdir -p /config/cache
-fi
-
-if ! bashio::fs.directory_exists '/config/custom_device_configs'; then
-bashio::log.info "Creating 'custom_device_configs' folder in '/addon_configs/core_zwave_js'"
-    mkdir -p /config/custom_device_configs
-fi
-
-
 # Send out discovery information to Home Assistant
 ./discovery &
 

--- a/zwave_js/rootfs/etc/services.d/zwave_js/run
+++ b/zwave_js/rootfs/etc/services.d/zwave_js/run
@@ -9,6 +9,22 @@ if bashio::config.true 'emulate_hardware'; then
     SERIAL_DEVICE="--mock-driver"
 fi
 
+if bashio::fs.directory_exists '/data/cache'; then
+    bashio::log.info "Migrating 'cache' folder to '/addon_configs/core_zwave_js/cache'"
+    mv /data/cache /config/cache
+fi
+
+if ! bashio::fs.directory_exists '/config/cache'; then
+    bashio::log.info "Creating 'cache' folder in '/addon_configs/core_zwave_js'"
+    mkdir -p /config/cache
+fi
+
+if ! bashio::fs.directory_exists '/config/custom_device_configs'; then
+bashio::log.info "Creating 'custom_device_configs' folder in '/addon_configs/core_zwave_js'"
+    mkdir -p /config/custom_device_configs
+fi
+
+
 # Send out discovery information to Home Assistant
 ./discovery &
 

--- a/zwave_js/rootfs/usr/share/tempio/zwave_config.conf
+++ b/zwave_js/rootfs/usr/share/tempio/zwave_config.conf
@@ -3,6 +3,7 @@
         "enabled": true,
         "level": "{{ .log_level }}",
         "logToFile": {{ .log_to_file }},
+        "maxFiles": {{ .log_max_files }},
         "filename": "/config/zwave",
         "forceConsole": true
     },

--- a/zwave_js/rootfs/usr/share/tempio/zwave_config.conf
+++ b/zwave_js/rootfs/usr/share/tempio/zwave_config.conf
@@ -8,7 +8,6 @@
     },
     "storage": {
         "cacheDir": "/config/cache",
-        "deviceConfigPriorityDir": "/config/custom_device_configs",
         "throttle": "slow"
     },
     "securityKeys": {

--- a/zwave_js/rootfs/usr/share/tempio/zwave_config.conf
+++ b/zwave_js/rootfs/usr/share/tempio/zwave_config.conf
@@ -2,10 +2,13 @@
     "logConfig": {
         "enabled": true,
         "level": "{{ .log_level }}",
+        "logToFile": {{ .log_to_file }},
+        "filename": "/config/zwave",
         "forceConsole": true
     },
     "storage": {
-        "cacheDir": "/data/cache",
+        "cacheDir": "/config/cache",
+        "deviceConfigPriorityDir": "/config/custom_device_configs",
         "throttle": "slow"
     },
     "securityKeys": {

--- a/zwave_js/translations/en.yaml
+++ b/zwave_js/translations/en.yaml
@@ -14,8 +14,8 @@ configuration:
   log_to_file:
     name: Log to File?
     description: >-
-      When this option is enabled, logs will be written to the `/addon_configs/core_zwave_js`
-      folder. Log filenames will begin with `zwave_` and will end with `.log`.
+      When this option is enabled, logs will be written to the
+      `/addon_configs/core_zwave_js` folder with the `.log` file extension.
   network_key:
     name: Network Key
     description: >-

--- a/zwave_js/translations/en.yaml
+++ b/zwave_js/translations/en.yaml
@@ -16,6 +16,12 @@ configuration:
     description: >-
       When this option is enabled, logs will be written to the
       `/addon_configs/core_zwave_js` folder with the `.log` file extension.
+  log_max_files:
+    name: Max number of log files to keep
+    description: >-
+      When `log_to_file` is true, Z-Wave JS will create a log file for each
+      day. This option allows you to control the maximum number of files that
+      Z-Wave JS will keep.
   network_key:
     name: Network Key
     description: >-

--- a/zwave_js/translations/en.yaml
+++ b/zwave_js/translations/en.yaml
@@ -11,6 +11,11 @@ configuration:
   log_level:
     name: Log Level
     description: This option sets the log level of Z-Wave JS.
+  log_to_file:
+    name: Log to File?
+    description: >-
+      When this option is enabled, logs will be written to the `/addon_configs/core_zwave_js`
+      folder. Log filenames will begin with `zwave_` and will end with `.log`.
   network_key:
     name: Network Key
     description: >-


### PR DESCRIPTION
This will let users:
1. Access their cache files
2. ~~Use custom device config files~~ Removed
3. Optionally log to file (and specify the max number of files/days of logs to keep)

For the last one, we can opt to make this enabled by default with no configuration option, but I like the idea of giving the user the option so that they can avoid unnecessary I/O if they don't plan to access the log files.