### PR TITLE
mosquitto: add a link to the DOCS.md

### DIFF
--- a/mosquitto/README.md
+++ b/mosquitto/README.md
@@ -6,7 +6,7 @@ MQTT broker for Home Assistant.
 
 ## About
 
-You can use this add-on to install Eclipse Mosquitto, which is an open-source (EPL/EDL licensed) message broker that implements the MQTT protocol. Mosquitto is lightweight and is suitable for use on all devices from low power single board computers to full servers. For more information, please see [mosquitto].
+You can use this add-on to install Eclipse Mosquitto, which is an open-source (EPL/EDL licensed) message broker that implements the MQTT protocol. Mosquitto is lightweight and is suitable for use on all devices from low power single board computers to full servers. For more information, please see [the documentation](DOCS.md) and [mosquitto] and for more details.
 
 [mosquitto]: https://mosquitto.org
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg

--- a/mosquitto/README.md
+++ b/mosquitto/README.md
@@ -6,7 +6,7 @@ MQTT broker for Home Assistant.
 
 ## About
 
-You can use this add-on to install Eclipse Mosquitto, which is an open-source (EPL/EDL licensed) message broker that implements the MQTT protocol. Mosquitto is lightweight and is suitable for use on all devices from low power single board computers to full servers. For more information, please see [the documentation](DOCS.md) and [mosquitto] and for more details.
+You can use this add-on to install Eclipse Mosquitto, which is an open-source (EPL/EDL licensed) message broker that implements the MQTT protocol. Mosquitto is lightweight and is suitable for use on all devices from low power single board computers to full servers. For more information, please see [the documentation](DOCS.md) and [mosquitto] for more details.
 
 [mosquitto]: https://mosquitto.org
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg


### PR DESCRIPTION
This PR adds a direct link to the DOCS.md file for discoverability, to avoid confusion on where to find more information how to install and use this add-on.