### PR TITLE
Bump zwave-js to 12.3.1

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.4.1
+
+### Bug fixes
+
+- Fixed an issue where the unresponsive controller recovery could do the wrong thing and block all outgoing communication.
+
+### Config file changes
+
+- Add missing units and firmware condition for Heatit Z-Temp2
+- Correct device label for Airzone Aidoo Control HVAC unit
+
+### Detailed changelogs
+
+- [Z-Wave JS 12.3.1](https://github.com/zwave-js/node-zwave-js/releases/tag/v12.3.1)
+
 ## 0.4.0
 
 ### Features

--- a/zwave_js/build.yaml
+++ b/zwave_js/build.yaml
@@ -10,4 +10,4 @@ codenotary:
   base_image: notary@home-assistant.io
 args:
   ZWAVEJS_SERVER_VERSION: 1.33.0
-  ZWAVEJS_VERSION: 12.3.0
+  ZWAVEJS_VERSION: 12.3.1

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.4.0
+version: 0.4.1
 slug: zwave_js
 name: Z-Wave JS
 description: Control a Z-Wave network with Home Assistant Z-Wave JS


### PR DESCRIPTION
Forgot to include this in the 0.4.0 release.

Changelog: [Z-Wave JS 12.3.1](https://github.com/zwave-js/node-zwave-js/releases/tag/v12.3.1)