### PR TITLE
letsencrypt: Fix DirectAdmin DNS challenge support

### DIFF
--- a/letsencrypt/CHANGELOG.md
+++ b/letsencrypt/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.0.2
+
+- Fix DirectAdmin DNS challenge support
+
 ## 5.0.1
 
 - Add DuckDNS DNS challenge support

--- a/letsencrypt/config.yaml
+++ b/letsencrypt/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 5.0.1
+version: 5.0.2
 slug: letsencrypt
 name: Let's Encrypt
 description: Manage certificate from Let's Encrypt

--- a/letsencrypt/rootfs/etc/services.d/lets-encrypt/run
+++ b/letsencrypt/rootfs/etc/services.d/lets-encrypt/run
@@ -91,7 +91,7 @@ elif [ "${CHALLENGE}" == "dns" ] && [ "${DNS_PROVIDER}" == "dns-directadmin" ]; 
     bashio::config.require 'dns.directadmin_url'
     bashio::config.require 'dns.directadmin_username'
     bashio::config.require 'dns.directadmin_password'
-    PROVIDER_ARGUMENTS+=("--authenticator" "${DNS_PROVIDER}" "--${DNS_PROVIDER}-credentials" "/data/dnsapikey" "--${DNS_PROVIDER}-propagation-seconds" "${PROPAGATION_SECONDS}")
+    PROVIDER_ARGUMENTS+=("--authenticator" "directadmin" "--directadmin-credentials" "/data/dnsapikey" "--directadmin-propagation-seconds" "${PROPAGATION_SECONDS}")
 
 #DuckDNS
 elif [ "${CHALLENGE}" == "dns" ] && [ "${DNS_PROVIDER}" == "dns-duckdns" ]; then


### PR DESCRIPTION
It seems that the DirectAdmin Certbot plug-in does not use the "dns-" suffix like other DNS based challenge plug-ins use. Make sure the add-on config remains backwards compatible and just pass the correct arguments to use the DirectAdmin plug-in with Certbot.

Fixes: #3335