### PR TITLE
Fix DirectAdmin DNS challenge support by using dns prefix

### DIFF
--- a/letsencrypt/CHANGELOG.md
+++ b/letsencrypt/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.0.5
+
+- Fix DirectAdmin DNS challenge support
+
 ## 5.0.4
 
 - Add Namecheap DNS challenge support

--- a/letsencrypt/config.yaml
+++ b/letsencrypt/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 5.0.4
+version: 5.0.5
 slug: letsencrypt
 name: Let's Encrypt
 description: Manage certificate from Let's Encrypt

--- a/letsencrypt/rootfs/etc/cont-init.d/file-structure.sh
+++ b/letsencrypt/rootfs/etc/cont-init.d/file-structure.sh
@@ -8,9 +8,9 @@ mkdir -p /data/letsencrypt
 # Setup Let's encrypt config
 echo -e "dns_desec_token = $(bashio::config 'dns.desec_token')\n" \
       "dns_digitalocean_token = $(bashio::config 'dns.digitalocean_token')\n" \
-      "directadmin_url = $(bashio::config 'dns.directadmin_url')\n" \
-      "directadmin_username = $(bashio::config 'dns.directadmin_username')\n" \
-      "directadmin_password = $(bashio::config 'dns.directadmin_password')\n" \
+      "dns_directadmin_url = $(bashio::config 'dns.directadmin_url')\n" \
+      "dns_directadmin_username = $(bashio::config 'dns.directadmin_username')\n" \
+      "dns_directadmin_password = $(bashio::config 'dns.directadmin_password')\n" \
       "dns_dnsimple_token = $(bashio::config 'dns.dnsimple_token')\n" \
       "dns_dnsmadeeasy_api_key = $(bashio::config 'dns.dnsmadeeasy_api_key')\n" \
       "dns_dnsmadeeasy_secret_key = $(bashio::config 'dns.dnsmadeeasy_secret_key')\n" \

--- a/letsencrypt/rootfs/etc/services.d/lets-encrypt/run
+++ b/letsencrypt/rootfs/etc/services.d/lets-encrypt/run
@@ -96,7 +96,7 @@ elif [ "${CHALLENGE}" == "dns" ] && [ "${DNS_PROVIDER}" == "dns-directadmin" ]; 
     bashio::config.require 'dns.directadmin_url'
     bashio::config.require 'dns.directadmin_username'
     bashio::config.require 'dns.directadmin_password'
-    PROVIDER_ARGUMENTS+=("--authenticator" "directadmin" "--directadmin-credentials" "/data/dnsapikey" "--directadmin-propagation-seconds" "${PROPAGATION_SECONDS}")
+    PROVIDER_ARGUMENTS+=("--authenticator" "${DNS_PROVIDER}" "--${DNS_PROVIDER}-credentials" "/data/dnsapikey" "--${DNS_PROVIDER}-propagation-seconds" "${PROPAGATION_SECONDS}")
 
 #DuckDNS
 elif [ "${CHALLENGE}" == "dns" ] && [ "${DNS_PROVIDER}" == "dns-duckdns" ]; then


### PR DESCRIPTION
It seems that the current DirectAdmin certbot plug-in documentation is a bit outdated. The options as well as the configuration require the "dns" prefix just like any other plug-ins.

Fixes: #3336