### PR TITLE
Fix deprecation warning in GitHub Action

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Get changed files
         id: changed_files
-        uses: jitterbit/get-changed-files@v1
+        uses: masesgroup/retrieve-changed-files@v3.0.0
 
       - name: Get add-ons
         id: addons


### PR DESCRIPTION
Use masesgroup/retrieve-changed-files@v3.0.0 as drop-in replacement for jitterbit/get-changed-files@v1. The former solves set-output warnings and is maintained.