### PR TITLE
Bump zwave-js to 12.4.0

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.4.2
+
+### Features
+
+- Expose rebuild routes progress as a controller property
+
+### Bug fixes
+
+- On devices that should/must not support `Basic CC`, but use it for reporting, only the `currentValue` is now exposed. This allows applications to consider it a sensor, not an actor
+
+### Config file changes
+
+- Correct firmware version condition for Zooz ZSE40 v3.0
+
+### Detailed changelogs
+
+- [Z-Wave JS 12.4.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v12.4.0)
+- [Z-Wave JS 12.3.2](https://github.com/zwave-js/node-zwave-js/releases/tag/v12.3.2)
+
 ## 0.4.1
 
 ### Bug fixes

--- a/zwave_js/build.yaml
+++ b/zwave_js/build.yaml
@@ -10,4 +10,4 @@ codenotary:
   base_image: notary@home-assistant.io
 args:
   ZWAVEJS_SERVER_VERSION: 1.33.0
-  ZWAVEJS_VERSION: 12.3.1
+  ZWAVEJS_VERSION: 12.4.0

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.4.1
+version: 0.4.2
 slug: zwave_js
 name: Z-Wave JS
 description: Control a Z-Wave network with Home Assistant Z-Wave JS


### PR DESCRIPTION
- [Z-Wave JS 12.4.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v12.4.0)
- [Z-Wave JS 12.3.2](https://github.com/zwave-js/node-zwave-js/releases/tag/v12.3.2)

Main highlight is it allows us to support this task: https://github.com/zwave-js/certification-backlog/issues/28