### PR TITLE
Bump zwave-js to 12.4.1 and zwave-js-server to 1.34.0

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.4.3
+
+### Features
+
+- Z-Wave JS Server: Enable server to listen on IPv6 interfaces
+
+### Bug fixes
+
+- Handle more cases of unexpected Serial API restarts
+
+### Config file changes
+
+- Add wakeup instructions for Nexia ZSENS930
+- Correct parameter 5 size for Zooz ZEN34
+
+### Detailed changelogs
+
+- [Z-Wave JS 12.4.1](https://github.com/zwave-js/node-zwave-js/releases/tag/v12.4.1)
+- [Z-Wave JS Server 1.34.0](https://github.com/zwave-js/zwave-js-server/releases/tag/1.34.0)
+
 ## 0.4.2
 
 ### Features

--- a/zwave_js/build.yaml
+++ b/zwave_js/build.yaml
@@ -9,5 +9,5 @@ codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
 args:
-  ZWAVEJS_SERVER_VERSION: 1.33.0
-  ZWAVEJS_VERSION: 12.4.0
+  ZWAVEJS_SERVER_VERSION: 1.34.0
+  ZWAVEJS_VERSION: 12.4.1

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.4.2
+version: 0.4.3
 slug: zwave_js
 name: Z-Wave JS
 description: Control a Z-Wave network with Home Assistant Z-Wave JS


### PR DESCRIPTION
- [Z-Wave JS 12.4.1](https://github.com/zwave-js/node-zwave-js/releases/tag/v12.4.1)
- [Z-Wave JS Server 1.34.0](https://github.com/zwave-js/zwave-js-server/releases/tag/1.34.0)

Main change is to allow us to get the current rebuild routes progress on initial state