### PR TITLE
nginx_proxy: Fix issue #3132

### DIFF
--- a/nginx_proxy/CHANGELOG.md
+++ b/nginx_proxy/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.6.0
+
+- Add port to Host header to fix origin issues affecting ESPHome and other addons
+
 ## 3.5.0
 
 - Update Alpine to 3.18 (nginx 1.24.x)

--- a/nginx_proxy/config.yaml
+++ b/nginx_proxy/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 3.5.0
+version: 3.6.0
 hassio_api: true
 slug: nginx_proxy
 name: NGINX Home Assistant SSL proxy

--- a/nginx_proxy/rootfs/etc/nginx.conf
+++ b/nginx_proxy/rootfs/etc/nginx.conf
@@ -60,7 +60,7 @@ http {
 
         location / {
             proxy_pass http://homeassistant.local.hass.io:%%HA_PORT%%;
-            proxy_set_header Host $host;
+            proxy_set_header Host $http_host;
             proxy_redirect http:// https://;
             proxy_http_version 1.1;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
Issue #3132, affecting nginx_proxy, has been causing other addons to break for a long time. For example, part of the esphome addon is not usable through the nginx_proxy because of this bug. All the details are in the issue.

The fix is very simple: replace $host with $http_host, so the port gets included and the socket connection is not detected as cross-origin.

I've had this fix applied on a custom config since the issue was opened, without any problems, but I think it would be nice to fix it here for everyone.
