### PR TITLE
openthread_border_router: Fix NAT64 configuration at startup

### DIFF
--- a/openthread_border_router/CHANGELOG.md
+++ b/openthread_border_router/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.4.1
+
+- Fix NAT64 enable script
+
 ## 2.4.0
 
 - Enable TREL

--- a/openthread_border_router/config.yaml
+++ b/openthread_border_router/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 2.4.0
+version: 2.4.1
 slug: openthread_border_router
 name: OpenThread Border Router
 description: OpenThread Border Router add-on


### PR DESCRIPTION
Make sure the otbr-agent-configure oneshot service gets properly installed. Without this, the script won't enable NAT64 (if enabled in the add-on configuration).