### PR TITLE
letsencrypt: bump version to 5.0.7

### DIFF
--- a/letsencrypt/config.yaml
+++ b/letsencrypt/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 5.0.6
+version: 5.0.7
 slug: letsencrypt
 name: Let's Encrypt
 description: Manage certificate from Let's Encrypt


### PR DESCRIPTION
The latest changes were not pushed because the config version wasn't changed. Bump the version to push the new images.