### PR TITLE
whisper: Exit with error on unsupported CPU (missing AVX)

### DIFF
--- a/whisper/CHANGELOG.md
+++ b/whisper/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.1
+
+- Handle unsupported CPU configurations
+
 ## 1.0.0
 
 - Upgrade to `wyoming-whisper` 1.0.1

--- a/whisper/config.yaml
+++ b/whisper/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 1.0.0
+version: 1.0.1
 slug: whisper
 name: Whisper
 description: Speech-to-text with Whisper

--- a/whisper/rootfs/etc/s6-overlay/s6-rc.d/whisper/run
+++ b/whisper/rootfs/etc/s6-overlay/s6-rc.d/whisper/run
@@ -3,6 +3,11 @@
 # ==============================================================================
 # Start Whisper service
 # ==============================================================================
+
+if [ "$(uname -m)" == "x86_64" ] && ! grep -qw 'avx' /proc/cpuinfo; then
+    bashio::exit.nok "Your CPU does not support the Advanced Vector Extensions required by Whisper."
+fi
+
 exec python3 -m wyoming_faster_whisper \
     --uri 'tcp://0.0.0.0:10300' \
     --model "$(bashio::config 'model')" \


### PR DESCRIPTION
As discussed in https://github.com/home-assistant/addons/issues/3035 CTranslate2 requires the AVX extension. Check if the extension is supported by the CPU before running the add-on. This should give the user a better clue as to why the add-on is not working.

Refers to: #3035, #3355