### PR TITLE
nginx_proxy: Update documentation

### DIFF
--- a/nginx_proxy/DOCS.md
+++ b/nginx_proxy/DOCS.md
@@ -10,14 +10,10 @@ Follow these steps to get the add-on installed on your system:
 
 ## How to use
 
-The NGINX Proxy add-on is commonly used in conjunction with the [Duck DNS](https://github.com/home-assistant/addons/tree/master/duckdns) add-on to set up secure remote access to your Home Assistant instance. The following instructions covers this scenario.
+The NGINX Proxy add-on is commonly used in conjunction with the [Duck DNS](https://github.com/home-assistant/addons/tree/master/duckdns) and/or the [Let's Encrypt](https://github.com/home-assistant/addons/tree/master/letsencrypt) add-on to set up secure remote access to your Home Assistant instance. The following instructions covers this scenario.
 
-1. The certificate to your registered domain should already be created via the [Duck DNS](https://github.com/home-assistant/addons/tree/master/duckdns) add-on or another method. Make sure that the certificate files exist in the `/ssl` directory.
-2. In the `configuration.yaml` file, some options in the `http:` section are no longer necessary for this scenario, and should be commented out or removed:
-   - `ssl_certificate`
-   - `ssl_key`
-   - `server_port`
-3. And you need to add the `trusted_proxies` section (requests from reverse proxies will be blocked if these options are not set).
+1. The certificate to your registered domain should already be created via [Duck DNS](https://github.com/home-assistant/addons/tree/master/duckdns), [Let's Encrypt](https://github.com/home-assistant/addons/tree/master/letsencrypt) or another method. Make sure that the certificate files exist in the `/ssl` directory.
+2. You must add the following section to your [Home Assistant configuration.yaml](https://www.home-assistant.io/docs/configuration/). If the `http` section is using the `ssl_certificate`, `ssl_key` or `server_port` keys, make sure to remove them.
 
    ```yaml
    http:
@@ -25,13 +21,13 @@ The NGINX Proxy add-on is commonly used in conjunction with the [Duck DNS](https
      trusted_proxies:
        - 172.30.33.0/24
    ```
+3. In the nginx addon configuration, change the `domain` option to the domain name you registered (from DuckDNS or any other domain you control).
+4. Leave all other options as-is.
+5. Save configuration.
+6. Start the add-on.
+7. Have some patience and wait a couple of minutes.
+8. Check the add-on log output to see the result.
 
-4. In the nginx addon configuration, change the `domain` option to the domain name you registered (from DuckDNS or any other domain you control).
-5. Leave all other options as-is.
-6. Save configuration.
-7. Start the add-on.
-8. Have some patience and wait a couple of minutes.
-9. Check the add-on log output to see the result.
 
 ## Configuration
 
@@ -85,6 +81,10 @@ This is so the `ip_ban_enabled` feature can be used and work correctly in /confi
 ## Known issues and limitations
 
 - By default, port 80 is disabled in the add-on configuration in case the port is needed for other components or add-ons like `emulated_hue`.
+
+## Troubleshooting
+
+- `400 Bad Request` response for requests over this proxy mean you are probably missing the `trusted_proxies` configuration option, see above.
 
 ## Support
 


### PR DESCRIPTION
- Make the difference between global configuration and add-on configuration clear.
- Include reference to 400 bad request (symptom of missing configuration)
- Add reference to Let's Encrypt.
- Demote the note about no longer relevant configuration options.

See also #3289.