### PR TITLE
letsencrypt: Add option to change key type

### DIFF
--- a/letsencrypt/CHANGELOG.md
+++ b/letsencrypt/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.0.9
+
+- Add option to specify Private Key type
+
 ## 5.0.8
 
 - Add Dreamhost DNS challenge support

--- a/letsencrypt/DOCS.md
+++ b/letsencrypt/DOCS.md
@@ -125,6 +125,15 @@ dreamhost_api_key: ''
 
 </details>
 
+<details>
+  <summary>Changing the key type</summary>
+  
+  Starting with Certbot version 2.0.0 (aaddon version 5.0.0), ECDSA keys are now the default. They utilize a more secure cryptography algorithm, however, they are not supported everywhere yet. For instance, Tasmota does not support MQTTS with an ECDSA key. If your use case does not support ECDSA keys, you can change them with the `keytype` parameter.
+
+  ```yaml
+  keytype: rsa
+  ``` 
+
 
 ## Example Configurations
 
@@ -161,6 +170,24 @@ dreamhost_api_key: ''
 
 </details>
 
+<details>
+  <summary>RSA key</summary>
+
+  ```yaml
+  email: your.email@example.com
+  domains:
+    - home-assistant.io
+  certfile: fullchain.pem
+  keyfile: privkey.pem
+  keytype: rsa
+  challenge: dns
+  dns:
+    provider: dns-cloudflare
+    cloudflare_email: your.email@example.com
+    cloudflare_api_key: 31242lk3j4ljlfdwsjf0
+  ```
+
+</details>
 
 <details>
   <summary>Azure DNS challenge</summary>

--- a/letsencrypt/DOCS.md
+++ b/letsencrypt/DOCS.md
@@ -128,7 +128,7 @@ dreamhost_api_key: ''
 <details>
   <summary>Changing the key type</summary>
   
-  Starting with Certbot version 2.0.0 (aaddon version 5.0.0), ECDSA keys are now the default. They utilize a more secure cryptography algorithm, however, they are not supported everywhere yet. For instance, Tasmota does not support MQTTS with an ECDSA key. If your use case does not support ECDSA keys, you can change them with the `keytype` parameter.
+  Starting with Certbot version 2.0.0 (add-on version 5.0.0 and newer), ECDSA keys are now the default. These keys utilize a more secure cryptography algorithm, however, they are not supported everywhere yet. For instance, Tasmota does not support MQTTS with an ECDSA key. If your use case does not support ECDSA keys, you can change them with the `keytype` parameter.
 
   ```yaml
   keytype: rsa

--- a/letsencrypt/config.yaml
+++ b/letsencrypt/config.yaml
@@ -20,6 +20,7 @@ options:
   domains:
     - null
   email: null
+  keytype: ecdsa
   keyfile: privkey.pem
   certfile: fullchain.pem
   challenge: http
@@ -30,6 +31,7 @@ schema:
   domains:
     - str
   email: email
+  keytype: list(ecdsa|rsa)
   keyfile: str
   certfile: str
   challenge: list(dns|http)

--- a/letsencrypt/config.yaml
+++ b/letsencrypt/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 5.0.8
+version: 5.0.9
 slug: letsencrypt
 name: Let's Encrypt
 description: Manage certificate from Let's Encrypt

--- a/letsencrypt/config.yaml
+++ b/letsencrypt/config.yaml
@@ -31,7 +31,7 @@ schema:
   domains:
     - str
   email: email
-  keytype: list(ecdsa|rsa)
+  keytype: list(ecdsa|rsa)?
   keyfile: str
   certfile: str
   challenge: list(dns|http)

--- a/letsencrypt/rootfs/etc/services.d/lets-encrypt/run
+++ b/letsencrypt/rootfs/etc/services.d/lets-encrypt/run
@@ -4,6 +4,7 @@
 # ==============================================================================
 CERT_DIR=/data/letsencrypt
 WORK_DIR=/data/workdir
+KEY_ARGUMENTS=()
 PROVIDER_ARGUMENTS=()
 ACME_CUSTOM_SERVER_ARGUMENTS=()
 
@@ -183,6 +184,11 @@ if bashio::config.has_value 'acme_server' ; then
     fi
 fi
 
+# Add key arguments if appropriate config entries exist
+if bashio::config.has_value 'keytype' ; then
+  KEY_ARGUMENTS+=("--key-type" "${KEYTYPE}")
+fi
+
 # Gather all domains into a plaintext file
 DOMAIN_ARR=()
 for line in $DOMAINS; do
@@ -194,14 +200,14 @@ echo "$DOMAINS" > /data/domains.gen
 if [ "$CHALLENGE" == "dns" ]; then
     certbot certonly --non-interactive --keep-until-expiring --expand \
         --email "$EMAIL" --agree-tos \
-        --key-type $KEYTYPE \
+        "${KEY_ARGUMENTS[@]}" \
         --config-dir "$CERT_DIR" --work-dir "$WORK_DIR" \
         --preferred-challenges "$CHALLENGE" "${DOMAIN_ARR[@]}" "${PROVIDER_ARGUMENTS[@]}" \
         --preferred-chain "ISRG Root X1"
 else
     certbot certonly --non-interactive --keep-until-expiring --expand \
         --email "$EMAIL" --agree-tos \
-        --key-type $KEYTYPE \
+        "${KEY_ARGUMENTS[@]}" \
         --config-dir "$CERT_DIR" --work-dir "$WORK_DIR" \
         --preferred-challenges "$CHALLENGE" "${DOMAIN_ARR[@]}" "${ACME_CUSTOM_SERVER_ARGUMENTS[@]}" --standalone \
         --preferred-chain "ISRG Root X1"

--- a/letsencrypt/rootfs/etc/services.d/lets-encrypt/run
+++ b/letsencrypt/rootfs/etc/services.d/lets-encrypt/run
@@ -9,6 +9,7 @@ ACME_CUSTOM_SERVER_ARGUMENTS=()
 
 EMAIL=$(bashio::config 'email')
 DOMAINS=$(bashio::config 'domains')
+KEYTYPE=$(bashio::config 'keytype')
 KEYFILE=$(bashio::config 'keyfile')
 CERTFILE=$(bashio::config 'certfile')
 CHALLENGE=$(bashio::config 'challenge')
@@ -193,12 +194,14 @@ echo "$DOMAINS" > /data/domains.gen
 if [ "$CHALLENGE" == "dns" ]; then
     certbot certonly --non-interactive --keep-until-expiring --expand \
         --email "$EMAIL" --agree-tos \
+        --key-type $KEYTYPE \
         --config-dir "$CERT_DIR" --work-dir "$WORK_DIR" \
         --preferred-challenges "$CHALLENGE" "${DOMAIN_ARR[@]}" "${PROVIDER_ARGUMENTS[@]}" \
         --preferred-chain "ISRG Root X1"
 else
     certbot certonly --non-interactive --keep-until-expiring --expand \
         --email "$EMAIL" --agree-tos \
+        --key-type $KEYTYPE \
         --config-dir "$CERT_DIR" --work-dir "$WORK_DIR" \
         --preferred-challenges "$CHALLENGE" "${DOMAIN_ARR[@]}" "${ACME_CUSTOM_SERVER_ARGUMENTS[@]}" --standalone \
         --preferred-chain "ISRG Root X1"

--- a/letsencrypt/translations/en.yaml
+++ b/letsencrypt/translations/en.yaml
@@ -8,6 +8,11 @@ configuration:
   email:
     name: Email
     description: The email address that will be registered for the certificate.
+  keytype:
+    name: Private Key type
+    description: >-
+      The cryptographic algorithm to use for the Private Key. If you're unsure
+      which one you need, leave it set to ecdsa.
   keyfile:
     name: Private Key File
     description: Path to where the Private Key File will be placed.


### PR DESCRIPTION
Adds option to change the Private Key type. This might be necessary as some devices do not support ECDSA keys (like Tasmotas with MQTTS).

As some services require one or the other type, in the future it might be beneficial for generating both types (or perhaps generating multiple different certificates).