### PR TITLE
letsencrypt: fix docs broken by missing closing tag

### DIFF
--- a/letsencrypt/DOCS.md
+++ b/letsencrypt/DOCS.md
@@ -209,6 +209,8 @@ Starting with Certbot version 2.0.0 (add-on version 5.0.0 and newer), ECDSA keys
   keytype: rsa
   ``` 
 
+</details>
+
 ## Example Configurations
 
 <details>


### PR DESCRIPTION
Closing tag was missing, causing Example Configurations and everything after that failing to show in rendered view.