### PR TITLE
openthread_border_router: Fix TREL and enable channel manager

### DIFF
--- a/openthread_border_router/0001-channel-monitor-disable-by-default.patch
+++ b/openthread_border_router/0001-channel-monitor-disable-by-default.patch
@@ -1,0 +1,33 @@
+From f84792cd229e9c3c4f5921cf92d280810dc56716 Mon Sep 17 00:00:00 2001
+Message-ID: <f84792cd229e9c3c4f5921cf92d280810dc56716.1704584255.git.stefan@agner.ch>
+From: Stefan Agner <stefan@agner.ch>
+Date: Sun, 7 Jan 2024 00:35:53 +0100
+Subject: [PATCH] [channel-monitor] disable by default
+
+Leave the channel monitor disabled by default. The impact on production
+systems is not entirly clear. The channel scan could lead to missed
+packets. Disabling by default allows to enable the feature at compile
+time so developers and users can enable it at runtime for testing.
+
+Signed-off-by: Stefan Agner <stefan@agner.ch>
+---
+ src/core/thread/thread_netif.cpp | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/src/core/thread/thread_netif.cpp b/src/core/thread/thread_netif.cpp
+index 8e6848832..c79660de8 100644
+--- a/src/core/thread/thread_netif.cpp
++++ b/src/core/thread/thread_netif.cpp
+@@ -59,9 +59,6 @@ void ThreadNetif::Up(void)
+ 
+     // Enable the MAC just in case it was disabled while the Interface was down.
+     Get<Mac::Mac>().SetEnabled(true);
+-#if OPENTHREAD_CONFIG_CHANNEL_MONITOR_ENABLE
+-    IgnoreError(Get<Utils::ChannelMonitor>().Start());
+-#endif
+     Get<MeshForwarder>().Start();
+ 
+     mIsUp = true;
+-- 
+2.43.0
+

--- a/openthread_border_router/CHANGELOG.md
+++ b/openthread_border_router/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Enable TREL support on infrastructure link
 - Enable Channel Monitor support (disabled by default)
+- Bump to OTBR POSIX version 657e775cd9 (2024-01-05 17:10:13 -0800)
 
 ## 2.4.2
 

--- a/openthread_border_router/CHANGELOG.md
+++ b/openthread_border_router/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.4.3
 
 - Enable TREL support on infrastructure link
+- Enable Channel Monitor support (disabled by default)
 
 ## 2.4.2
 

--- a/openthread_border_router/CHANGELOG.md
+++ b/openthread_border_router/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.4.3
+
+- Enable TREL support on infrastructure link
+
 ## 2.4.2
 
 - Update firmare for Home Assistant SkyConnect and Yellow to the latest version

--- a/openthread_border_router/Dockerfile
+++ b/openthread_border_router/Dockerfile
@@ -83,6 +83,8 @@ RUN \
         -DOT_POSIX_NAT64_CIDR="192.168.255.0/24" \
         -DOTBR_DNS_UPSTREAM_QUERY=ON \
         -DOT_CHANNEL_MONITOR=ON \
+        -DOT_COAP=OFF \
+        -DOT_COAPS=OFF \
         && cd build/otbr/ \
         && ninja \
         && ninja install) \

--- a/openthread_border_router/Dockerfile
+++ b/openthread_border_router/Dockerfile
@@ -18,6 +18,7 @@ ENV DOCKER 1
 
 COPY 0001-Avoid-writing-to-system-console.patch /usr/src
 COPY 0002-rest-support-deleting-the-dataset.patch /usr/src
+COPY 0001-channel-monitor-disable-by-default.patch /usr/src
 
 # Required and installed (script/bootstrap) can be removed after build
 ENV OTBR_BUILD_DEPS build-essential ninja-build cmake wget ca-certificates \
@@ -54,6 +55,8 @@ RUN \
     && ./script/bootstrap \
     && patch -p1 < /usr/src/0001-Avoid-writing-to-system-console.patch \
     && patch -p1 < /usr/src/0002-rest-support-deleting-the-dataset.patch \
+    && (cd third_party/openthread/repo && \
+        patch -p1 < /usr/src/0001-channel-monitor-disable-by-default.patch) \
     # Mimic rt_tables_install \
     && echo "88 openthread" >> /etc/iproute2/rt_tables \
     # Mimic otbr_install \
@@ -79,6 +82,7 @@ RUN \
         -DOTBR_NAT64=ON \
         -DOT_POSIX_NAT64_CIDR="192.168.255.0/24" \
         -DOTBR_DNS_UPSTREAM_QUERY=ON \
+        -DOT_CHANNEL_MONITOR=ON \
         && cd build/otbr/ \
         && ninja \
         && ninja install) \

--- a/openthread_border_router/build.yaml
+++ b/openthread_border_router/build.yaml
@@ -3,5 +3,5 @@ build_from:
   aarch64: ghcr.io/home-assistant/aarch64-base-debian:bullseye
   amd64: ghcr.io/home-assistant/amd64-base-debian:bullseye
 args:
-  OTBR_VERSION: 27ed99f3751f738bc7647256d3f54f2af54d72f3
+  OTBR_VERSION: 657e775cd9ca757af7487da2fb039aee645c3d65
   UNIVERSAL_SILABS_FLASHER: 0.0.16

--- a/openthread_border_router/config.yaml
+++ b/openthread_border_router/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 2.4.2
+version: 2.4.3
 slug: openthread_border_router
 name: OpenThread Border Router
 description: OpenThread Border Router add-on

--- a/openthread_border_router/rootfs/etc/s6-overlay/s6-rc.d/otbr-agent/run
+++ b/openthread_border_router/rootfs/etc/s6-overlay/s6-rc.d/otbr-agent/run
@@ -115,4 +115,5 @@ exec s6-notifyoncheck -d -s 300 -w 300 -n 0 \
     "/usr/sbin/otbr-agent" -I ${thread_if} -B "${backbone_if}" \
         --rest-listen-address "${otbr_rest_listen}" \
         -d${otbr_log_level_int} -v \
-        "spinel+hdlc+uart://${device}?uart-baudrate=${baudrate}${flow_control}"
+        "spinel+hdlc+uart://${device}?uart-baudrate=${baudrate}${flow_control}" \
+        "trel://${backbone_if}"


### PR DESCRIPTION
Enable TREL by default on the primary network interface (which we consider as infrastructure interface).

Enable the channel manager, but leave it off by default. This allows to use `ot-ctl channel monitor start` and `ot-ctl channel monitor` to see which IEEE 802.15.4 channel is least busy.

Remove the CoAP API support as they are not required for the Home Assistant use case.