### PR TITLE
nginx_proxy: Support longer domains name

### DIFF
--- a/nginx_proxy/CHANGELOG.md
+++ b/nginx_proxy/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.7.0
+
+- Modify `server_names_hash_bucket_size` to add support for longer domain names
+  
 ## 3.6.0
 
 - Add port to Host header to fix origin issues affecting ESPHome and other addons

--- a/nginx_proxy/config.yaml
+++ b/nginx_proxy/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 3.6.0
+version: 3.7.0
 hassio_api: true
 slug: nginx_proxy
 name: NGINX Home Assistant SSL proxy

--- a/nginx_proxy/rootfs/etc/nginx.conf
+++ b/nginx_proxy/rootfs/etc/nginx.conf
@@ -14,7 +14,7 @@ http {
 
     server_tokens off;
 
-    server_names_hash_bucket_size 64;
+    server_names_hash_bucket_size 128;
 	
     # intermediate configuration
     ssl_protocols TLSv1.2 TLSv1.3;


### PR DESCRIPTION
Add support for longer domain name, modifying `server_names_hash_bucket_size` from 64 to 128