### PR TITLE
nginx_proxy: Support extra user-defined network ports and http block configuration

### DIFF
--- a/nginx_proxy/DOCS.md
+++ b/nginx_proxy/DOCS.md
@@ -41,6 +41,7 @@ hsts: "max-age=31536000; includeSubDomains"
 customize:
   active: false
   default: "nginx_proxy_default*.conf"
+  http_root: "nginx_proxy_http*.conf"
   servers: "nginx_proxy/*.conf"
 cloudflare: false
 ```
@@ -93,6 +94,10 @@ server {
 ### Option `customize.default` (required)
 
 The filename of the NGINX configuration for the default server, found in the `/share` directory.
+
+### Option `customize.http_root` (required)
+
+The filename of the NGINX configuration for additional instance-wide `http` block options, found in the `/share` directory.
 
 ### Option `customize.servers` (required)
 

--- a/nginx_proxy/DOCS.md
+++ b/nginx_proxy/DOCS.md
@@ -65,6 +65,31 @@ Value for the [`Strict-Transport-Security`][hsts] HTTP header to send. If empty,
 
 If true, additional NGINX configuration files for the default server and additional servers are read from files in the `/share` directory specified by the `default` and `servers` variables.
 
+If you would like to host additional `server` blocks on different, non-443, ports, the NGINX addon supports this via five ports reserved for custom uses.
+These ports can be configured in the addon's Network settings and are disabled by default. To use one, assign the port you want to access externally
+in the setting (you may need to toggle the `Show disabled ports` option first) and then use the corresponding reserved port in your custom server definition. 
+
+The additional TCP ports that can be used inside of configuration files are:
+- `11150`
+- `11151`
+- `11152`
+- `11153`
+- `11154`
+
+This example configuration listens for TLS/SSL connections on the first reserved port, `11150`:
+```nginx
+server {
+  listen 11150 ssl http2;
+  listen [::]:11150 ssl http2;
+
+  server_name subdomain.example.com;
+
+  location / {
+    return 200 'This is an example';
+  }
+}
+```
+
 ### Option `customize.default` (required)
 
 The filename of the NGINX configuration for the default server, found in the `/share` directory.

--- a/nginx_proxy/config.yaml
+++ b/nginx_proxy/config.yaml
@@ -25,6 +25,7 @@ options:
   customize:
     active: false
     default: nginx_proxy_default*.conf
+    http_root: nginx_proxy_http*.conf
     servers: nginx_proxy/*.conf
 ports:
   443/tcp: 443
@@ -43,4 +44,5 @@ schema:
   customize:
     active: bool
     default: str
+    http_root: str
     servers: str

--- a/nginx_proxy/config.yaml
+++ b/nginx_proxy/config.yaml
@@ -29,6 +29,11 @@ options:
 ports:
   443/tcp: 443
   80/tcp: null
+  11150/tcp: null
+  11151/tcp: null
+  11152/tcp: null
+  11153/tcp: null
+  11154/tcp: null
 schema:
   domain: str
   hsts: str

--- a/nginx_proxy/rootfs/etc/nginx.conf
+++ b/nginx_proxy/rootfs/etc/nginx.conf
@@ -21,6 +21,8 @@ http {
     ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
     ssl_prefer_server_ciphers off;
 
+    #include /share/nginx_proxy_http*.conf;
+
     #include /data/cloudflare.conf;
 	
     server {

--- a/nginx_proxy/rootfs/etc/s6-overlay/s6-rc.d/nginx/run
+++ b/nginx_proxy/rootfs/etc/s6-overlay/s6-rc.d/nginx/run
@@ -60,6 +60,8 @@ sed -i "s/%%HSTS%%/$HSTS/g" /etc/nginx.conf
 if bashio::config.true 'customize.active'; then
     CUSTOMIZE_DEFAULT=$(bashio::config 'customize.default')
     sed -i "s|#include /share/nginx_proxy_default.*|include /share/$CUSTOMIZE_DEFAULT;|" /etc/nginx.conf
+    CUSTOMIZE_HTTP=$(bashio::config 'customize.http_root')
+    sed -i "s|#include /share/nginx_proxy_http.*|include /share/$CUSTOMIZE_HTTP;|" /etc/nginx.conf
     CUSTOMIZE_SERVERS=$(bashio::config 'customize.servers')
     sed -i "s|#include /share/nginx_proxy/.*|include /share/$CUSTOMIZE_SERVERS;|" /etc/nginx.conf
 fi

--- a/nginx_proxy/translations/en.yaml
+++ b/nginx_proxy/translations/en.yaml
@@ -27,3 +27,8 @@ configuration:
 network:
   443/tcp: HTTPS (SSL) Port
   80/tcp: HTTP (non-SSL) Port
+  11150/tcp: User-configurable Port 1
+  11151/tcp: User-configurable Port 2
+  11152/tcp: User-configurable Port 3
+  11153/tcp: User-configurable Port 4
+  11154/tcp: User-configurable Port 5


### PR DESCRIPTION
So in summary, the commits here provide two new features in the NGINX proxy:
1. Add 5 customizable ports that can used to bind extra `server`s within the existing `share/nginx_proxy/` customization.
2. Add a new customization file that allows users to put statements inside the [default `http` block](https://github.com/home-assistant/addons/blob/cee0ab684d8fa88d330774cfac9961f4afa3ac6e/nginx_proxy/rootfs/etc/nginx.conf#L9)

My use case is making a specific `server` to re-serve a home assistant integration's URLs in a more protected manner. By having a dedicated server block and port, I can be sure no unintended locations are reachable from it and also apply more external firewall rules with the added separation.

As far as I can tell, there's no way to dynamically apply a container:host port mapping to an addon, so multiple unused and default-off mappings were added to allow a reasonable amount of flexibility for users going onward.

I'd also like to apply rate limiting to custom NGINX server blocks, which needs a `limit_req_zone` statement [inside of the top-level `http` context to work](https://nginx.org/en/docs/http/ngx_http_limit_req_module.html#limit_req_zone) in order to work.

Both commits tested in my local HAOS deployment and seems to work fine.

### UI Examples
<img width="1030" alt="image" src="https://github.com/home-assistant/addons/assets/20936452/77ced301-aae8-4d21-b17a-72c224ea73c9">

<img width="1030" alt="image" src="https://github.com/home-assistant/addons/assets/20936452/18214b73-b5fb-434a-8c11-5a3bb3ca606d">


### Considered Alternatives
 - Use the same domain and port by putting new config data in `/share/nginx_proxy_default*.conf`? In my use case, there's no way to then stop the `location /` block from running if my new `location` doesn't match, which is a problem.
 - Use a different domain and listen on `443` as well? SNI-based routing makes this a non-starter.
 - Use the existing `tcp/80` mapping with your own external port? Using this port results in TLS errors because it attempts to redirect HTTPS traffic to a HTTP listener.
 - Fork the addon long term? This is a hassle to maintain and keep up to date with the upstream source here, and I'm sure there's someone else who has wanted functionality like this.....