### PR TITLE
multiprotocol: Bump multiprotocol addon version to 2.4.3

### DIFF
--- a/silabs-multiprotocol/config.yaml
+++ b/silabs-multiprotocol/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 2.4.2
+version: 2.4.3
 slug: silabs_multiprotocol
 name: Silicon Labs Multiprotocol
 description: Zigbee and OpenThread multiprotocol add-on


### PR DESCRIPTION
#3390 did not bump the version.