### PR TITLE
silabs-multiprotocol: Make the OTBR infrastructure network interface configurable

### DIFF
--- a/silabs-multiprotocol/DOCS.md
+++ b/silabs-multiprotocol/DOCS.md
@@ -75,15 +75,15 @@ Add-on configuration:
 | Configuration      | Description                                            |
 |--------------------|--------------------------------------------------------|
 | device (mandatory) | Serial service where the Silicon Labs radio is attached |
-| baudrate           | Serial port baudrate (depends on firmware)   |
+| baudrate           | Serial port baudrate (depends on firmware)             |
 | flow_control       | If hardware flow control should be enabled (depends on firmware) |
-| autoflash_firmware | Automatically install/update firmware (Home Assistant SkyConnect/Yellow) |
 | network_device     | Host and port where CPC daemon can find the Silicon Labs radio (takes precedence over device) |
+| autoflash_firmware | Automatically install/update firmware (Home Assistant SkyConnect/Yellow) |
 | cpcd_trace         | Co-Processor Communication tracing (trace in log)      |
-| otbr_enable        | Enable OpenThread BorderRouter                         |
-| otbr_log_level     | Set the log level of the OpenThread BorderRouter Agent     |
+| otbr_enable        | Enable OpenThread Border Router                        |
+| otbr_log_level     | Set the log level of the OpenThread Border Router Agent |
 | otbr_infra_if      | HA host network interface name to bind the "infrastructure" side of the OpenThread Border Router to |
-| otbr_firewall      | Enable OpenThread Border Router firewall to block unnecessary traffic |
+| otbr_firewall      | Configure firewall to block unnecessary traffic to/from the OpenThread Border Router |
 
 ## Architecture
 

--- a/silabs-multiprotocol/DOCS.md
+++ b/silabs-multiprotocol/DOCS.md
@@ -82,6 +82,7 @@ Add-on configuration:
 | cpcd_trace         | Co-Processor Communication tracing (trace in log)      |
 | otbr_enable        | Enable OpenThread BorderRouter                         |
 | otbr_log_level     | Set the log level of the OpenThread BorderRouter Agent     |
+| otbr_infra_if      | HA host network interface name to bind the "infrastructure" side of the OpenThread Border Router to |
 | otbr_firewall      | Enable OpenThread Border Router firewall to block unnecessary traffic |
 
 ## Architecture

--- a/silabs-multiprotocol/config.yaml
+++ b/silabs-multiprotocol/config.yaml
@@ -23,10 +23,22 @@ privileged:
   - NET_ADMIN
 image: homeassistant/{arch}-addon-silabs-multiprotocol
 init: false
+schema:
+  device: device(subsystem=tty)?
+  baudrate: list(57600|115200|230400|460800|921600)
+  flow_control: bool?
+  network_device: str?
+  autoflash_firmware: bool
+  cpcd_trace: bool
+  otbr_enable: bool
+  otbr_log_level: list(debug|info|notice|warning|error|critical|alert|emergency)
+  otbr_infra_if: str?
+  otbr_firewall: bool
 options:
   device: null
   baudrate: "460800"
   flow_control: true
+  network_device: null
   autoflash_firmware: true
   cpcd_trace: false
   otbr_enable: true
@@ -41,16 +53,5 @@ ports_description:
   9999/tcp: EmberZNet EZSP/ASH port
   8080/tcp: OpenThread Web port
   8081/tcp: OpenThread REST API port
-schema:
-  device: device(subsystem=tty)?
-  baudrate: list(57600|115200|230400|460800|921600)
-  flow_control: bool?
-  network_device: str?
-  autoflash_firmware: bool
-  cpcd_trace: bool
-  otbr_enable: bool
-  otbr_log_level: list(debug|info|notice|warning|error|critical|alert|emergency)
-  otbr_infra_if: str?
-  otbr_firewall: bool
 stage: experimental
 startup: services

--- a/silabs-multiprotocol/config.yaml
+++ b/silabs-multiprotocol/config.yaml
@@ -31,6 +31,7 @@ options:
   cpcd_trace: false
   otbr_enable: true
   otbr_log_level: notice
+  otbr_infra_if: null
   otbr_firewall: true
 ports:
   9999/tcp: null
@@ -49,6 +50,7 @@ schema:
   cpcd_trace: bool
   otbr_enable: bool
   otbr_log_level: list(debug|info|notice|warning|error|critical|alert|emergency)
+  otbr_infra_if: str?
   otbr_firewall: bool
 stage: experimental
 startup: services

--- a/silabs-multiprotocol/rootfs/etc/s6-overlay/s6-rc.d/otbr-agent/run
+++ b/silabs-multiprotocol/rootfs/etc/s6-overlay/s6-rc.d/otbr-agent/run
@@ -5,40 +5,40 @@
 
 . /etc/s6-overlay/scripts/otbr-agent-common
 
-declare otbr_infra_if
 declare device
 declare baudrate
 declare flow_control
 declare otbr_log_level
 declare otbr_log_level_int
+declare otbr_infra_if
 declare otbr_rest_listen
 declare otbr_rest_listen_port
 
 otbr_log_level=$(bashio::string.lower "$(bashio::config otbr_log_level)")
 case "${otbr_log_level}" in
     debug)
-        otbr_log_level_int="7"
+        otbr_log_level_int='7'
         ;;
     info)
-        otbr_log_level_int="6"
+        otbr_log_level_int='6'
         ;;
     notice)
-        otbr_log_level_int="5"
+        otbr_log_level_int='5'
         ;;
     warning)
-        otbr_log_level_int="4"
+        otbr_log_level_int='4'
         ;;
     error)
-        otbr_log_level_int="3"
+        otbr_log_level_int='3'
         ;;
     critical)
-        otbr_log_level_int="2"
+        otbr_log_level_int='2'
         ;;
     alert)
-        otbr_log_level_int="1"
+        otbr_log_level_int='1'
         ;;
     emergency)
-        otbr_log_level_int="0"
+        otbr_log_level_int='0'
         ;;
     *)
         bashio::exit.nok "Unknown otbr_log_level: ${otbr_log_level}"
@@ -58,26 +58,26 @@ else
     fi
 fi
 
-mkdir -p /data/thread && ln -sft /var/lib /data/thread || bashio::exit.nok "Could not create directory /var/lib/thread to store Thread data."
+mkdir -p /data/thread && ln -sft /var/lib /data/thread || bashio::exit.nok 'Could not create directory /var/lib/thread to store Thread data.'
 
 if bashio::config.true 'otbr_firewall'; then
-    bashio::log.info "Setup OTBR firewall..."
+    bashio::log.info 'Setup OTBR firewall...'
     ipset create -exist otbr-ingress-deny-src hash:net family inet6
     ipset create -exist otbr-ingress-deny-src-swap hash:net family inet6
     ipset create -exist otbr-ingress-allow-dst hash:net family inet6
     ipset create -exist otbr-ingress-allow-dst-swap hash:net family inet6
 
     ip6tables -N $otbr_forward_ingress_chain
-    ip6tables -I FORWARD 1 -o $thread_if -j $otbr_forward_ingress_chain
+    ip6tables -I FORWARD 1 -o "${thread_if}" -j $otbr_forward_ingress_chain
 
-    ip6tables -A $otbr_forward_ingress_chain -m pkttype --pkt-type unicast -i ${thread_if} -j DROP
+    ip6tables -A $otbr_forward_ingress_chain -m pkttype --pkt-type unicast -i "${thread_if}" -j DROP
     ip6tables -A $otbr_forward_ingress_chain -m set --match-set otbr-ingress-deny-src src -j DROP
     ip6tables -A $otbr_forward_ingress_chain -m set --match-set otbr-ingress-allow-dst dst -j ACCEPT
     ip6tables -A $otbr_forward_ingress_chain -m pkttype --pkt-type unicast -j DROP
     ip6tables -A $otbr_forward_ingress_chain -j ACCEPT
 
     ip6tables -N $otbr_forward_egress_chain
-    ip6tables -I FORWARD 2 -i $thread_if -j $otbr_forward_egress_chain
+    ip6tables -I FORWARD 2 -i "${thread_if}" -j $otbr_forward_egress_chain
     ip6tables -A $otbr_forward_egress_chain -j ACCEPT
 else
     # Make sure ip6tables (as used by Docker) allow IP forwarding
@@ -86,25 +86,25 @@ else
     ip6tables-legacy -P FORWARD ACCEPT
 fi
 
-otbr_rest_listen="::"
+otbr_rest_listen='::'
 otbr_rest_listen_port="$(bashio::addon.port 8081)"
 
 # If user port is not set, listen on local interface only
 if ! bashio::var.has_value "${otbr_rest_listen_port}"; then
     otbr_rest_listen="$(bashio::addon.ip_address)"
-    otbr_rest_listen_port="8081"
+    otbr_rest_listen_port='8081'
 elif [ "${otbr_rest_listen_port}" != "8081" ]; then
-    bashio::log.warning "Custom OpenThread REST API port is not supported. Using 8081."
-    otbr_rest_listen_port="8081"
+    bashio::log.warning 'Custom OpenThread REST API port is not supported. Using 8081.'
+    otbr_rest_listen_port='8081'
 fi
 
 # Store REST API listen information for check script
 echo "${otbr_rest_listen}" > /tmp/otbr-agent-rest-api
 echo "${otbr_rest_listen_port}" >> /tmp/otbr-agent-rest-api
 
-bashio::log.info "Starting otbr-agent..."
+bashio::log.info 'Starting otbr-agent...'
 exec s6-notifyoncheck -d -s 300 -w 300 -n 0 \
-    "/usr/sbin/otbr-agent" -I ${thread_if} -B "${otbr_infra_if}" \
+    "/usr/sbin/otbr-agent" -I "${thread_if}" -B "${otbr_infra_if}" \
         --rest-listen-address "${otbr_rest_listen}" \
         -d${otbr_log_level_int} -v \
         "spinel+cpc://cpcd_0?iid=2&iid-list=0"

--- a/silabs-multiprotocol/rootfs/etc/s6-overlay/s6-rc.d/otbr-agent/run
+++ b/silabs-multiprotocol/rootfs/etc/s6-overlay/s6-rc.d/otbr-agent/run
@@ -5,7 +5,7 @@
 
 . /etc/s6-overlay/scripts/otbr-agent-common
 
-declare backbone_if
+declare otbr_infra_if
 declare device
 declare baudrate
 declare flow_control
@@ -13,8 +13,6 @@ declare otbr_log_level
 declare otbr_log_level_int
 declare otbr_rest_listen
 declare otbr_rest_listen_port
-
-backbone_if="$(bashio::api.supervisor 'GET' '/network/info' '' 'first(.interfaces[] | select (.primary == true)) .interface')"
 
 otbr_log_level=$(bashio::string.lower "$(bashio::config otbr_log_level)")
 case "${otbr_log_level}" in
@@ -47,9 +45,17 @@ case "${otbr_log_level}" in
         ;;
 esac
 
-if [ -z ${backbone_if} ]; then
-    bashio::log.warning "No primary network interface found! Using static eth0."
-    backbone_if="eth0"
+if bashio::config.has_value 'otbr_infra_if'; then
+    otbr_infra_if="$(bashio::config 'otbr_infra_if')"
+    bashio::log.info "Using configured network interface ${otbr_infra_if} for otbr_infra_if."
+else
+    otbr_infra_if="$(bashio::api.supervisor 'GET' '/network/info' '' 'first(.interfaces[] | select (.primary == true)) .interface')"
+    if [ -n "${otbr_infra_if}" ]; then
+        bashio::log.info "Using primary network interface ${otbr_infra_if} for otbr_infra_if."
+    else
+        bashio::log.warning 'No primary network interface found!  Using static eth0 for otbr_infra_if.'
+        otbr_infra_if='eth0'
+    fi
 fi
 
 mkdir -p /data/thread && ln -sft /var/lib /data/thread || bashio::exit.nok "Could not create directory /var/lib/thread to store Thread data."
@@ -98,7 +104,7 @@ echo "${otbr_rest_listen_port}" >> /tmp/otbr-agent-rest-api
 
 bashio::log.info "Starting otbr-agent..."
 exec s6-notifyoncheck -d -s 300 -w 300 -n 0 \
-    "/usr/sbin/otbr-agent" -I ${thread_if} -B "${backbone_if}" \
+    "/usr/sbin/otbr-agent" -I ${thread_if} -B "${otbr_infra_if}" \
         --rest-listen-address "${otbr_rest_listen}" \
         -d${otbr_log_level_int} -v \
         "spinel+cpc://cpcd_0?iid=2&iid-list=0"

--- a/silabs-multiprotocol/translations/en.yaml
+++ b/silabs-multiprotocol/translations/en.yaml
@@ -25,7 +25,7 @@ configuration:
     description: Enable tracing for the Co-Processor Communication daemon.
   otbr_enable:
     name: Enable OpenThread Border Router
-    description: Enable OpenThread Border Router agent.
+    description: Enable the OpenThread Border Router.
   otbr_log_level:
     name: OpenThread Border Router agent log level
     description: >-
@@ -39,7 +39,8 @@ configuration:
   otbr_firewall:
     name: OTBR firewall
     description: >-
-      Use OpenThread Border Router firewall to block unnecessary traffic.
+      Configure firewall to block unnecessary traffic to/from the OpenThread
+      Border Router.
 network:
   9999/tcp: EmberZNet EZSP/ASH port
   8080/tcp: OpenThread Web port

--- a/silabs-multiprotocol/translations/en.yaml
+++ b/silabs-multiprotocol/translations/en.yaml
@@ -30,6 +30,12 @@ configuration:
     name: OpenThread Border Router agent log level
     description: >-
       Set logging level of the OpenThread Border Router agent (otbr-agent).
+  otbr_infra_if:
+    name: OpenThread Border Router infrastructure interface
+    description: >-
+      HA host network interface name to bind the "infrastructure" side (vs the
+      "Thread" side) of the OpenThread Border Router to.  By default, the
+      first interface with an associated default route is used.
   otbr_firewall:
     name: OTBR firewall
     description: >-


### PR DESCRIPTION
The OpenThread Border Router agent currently only supports routing between a single "infrastructure" network interface and a single Thread network interface per agent process.  (Multiple "infrastructure" interfaces can be specified, but this is for fail-over purposes and only one will be used at a time.)

Thread device commissioning in HA currently requires an Android device which can communicate both with the Thread device via Bluetooth and with the OpenThread Border Router "infrastructure" interface via IPv6 with Router Advertisements and mDNS.

Prior to this commit, the first HA host interface with an associated default route was always used as the OTBR "infrastructure" interface.  This caused problems if the HA host has multiple interfaces and the Android device needed for commissioning is on a different network than the automatically-selected interface.

To address that, this commit permits the user to configure the "infrastructure" interface.

(Side note: Historically, the "infrastructure" interface was sometimes conflated with the "backbone" interface, but those have now been unified under the term "infrastructure": https://github.com/openthread/openthread/pull/9638 )