### PR TITLE
matter_server: Bump Python Matter server to 5.2.1 correctly

### DIFF
--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.0.4
+
+- Correctly bump Python Matter Server to [5.2.1](https://github.com/home-assistant-libs/python-matter-server/releases/tag/5.2.1)
+
 ## 5.0.3
 
 - Bump Python Matter Server to [5.2.1](https://github.com/home-assistant-libs/python-matter-server/releases/tag/5.2.1)

--- a/matter_server/build.yaml
+++ b/matter_server/build.yaml
@@ -1,7 +1,7 @@
 ---
 build_from:
-  aarch64: ghcr.io/home-assistant-libs/python-matter-server:5.1.4
-  amd64: ghcr.io/home-assistant-libs/python-matter-server:5.1.4
+  aarch64: ghcr.io/home-assistant-libs/python-matter-server:5.2.1
+  amd64: ghcr.io/home-assistant-libs/python-matter-server:5.2.1
 args:
   BASHIO_VERSION: 0.14.3
   TEMPIO_VERSION: 2021.09.0

--- a/matter_server/config.yaml
+++ b/matter_server/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 5.0.3
+version: 5.0.4
 slug: matter_server
 name: Matter Server
 description: Matter WebSocket Server for Home Assistant Matter support.


### PR DESCRIPTION
Fixes: https://github.com/home-assistant-libs/python-matter-server/issues/505