### PR TITLE
letsencrypt: Fix typo in DNS providers section

### DIFF
--- a/letsencrypt/DOCS.md
+++ b/letsencrypt/DOCS.md
@@ -37,7 +37,7 @@ There are two options to obtain certificates.
 ### DNS providers
 
 <details>
-  <summary>Supported DNS providerss</summary>
+  <summary>Supported DNS providers</summary>
 
 ```txt
 dns-azure


### PR DESCRIPTION
"Supported DNS providers" had an extra 's'