### PR TITLE
openthread_border_router: Enable DNS resolver and increase TX power

### DIFF
--- a/openthread_border_router/CHANGELOG.md
+++ b/openthread_border_router/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.4.5
 
 - Set default transmit power on startup
+- Enable DNS when NAT64 is enabled
 
 ## 2.4.4
 

--- a/openthread_border_router/CHANGELOG.md
+++ b/openthread_border_router/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Set default transmit power on startup
 - Enable DNS when NAT64 is enabled
 - Bump universal SiLabs flasher to 0.0.17
+- Bump to OTBR POSIX version 13d583e361 (2024-01-26 09:51:26 -0800)
 
 ## 2.4.4
 

--- a/openthread_border_router/CHANGELOG.md
+++ b/openthread_border_router/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.4.5
+
+- Set default transmit power on startup
+
 ## 2.4.4
 
 - Fix Thread network interface (wpan0) route metric

--- a/openthread_border_router/CHANGELOG.md
+++ b/openthread_border_router/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Set default transmit power on startup
 - Enable DNS when NAT64 is enabled
+- Bump universal SiLabs flasher to 0.0.17
 
 ## 2.4.4
 

--- a/openthread_border_router/build.yaml
+++ b/openthread_border_router/build.yaml
@@ -3,5 +3,5 @@ build_from:
   aarch64: ghcr.io/home-assistant/aarch64-base-debian:bullseye
   amd64: ghcr.io/home-assistant/amd64-base-debian:bullseye
 args:
-  OTBR_VERSION: 02421b0ea6422a71150f786168a470d5d87a6d81
+  OTBR_VERSION: 13d583e361c7038b967b601d5e5f6739b0bcf736
   UNIVERSAL_SILABS_FLASHER: 0.0.17

--- a/openthread_border_router/build.yaml
+++ b/openthread_border_router/build.yaml
@@ -4,4 +4,4 @@ build_from:
   amd64: ghcr.io/home-assistant/amd64-base-debian:bullseye
 args:
   OTBR_VERSION: 02421b0ea6422a71150f786168a470d5d87a6d81
-  UNIVERSAL_SILABS_FLASHER: 0.0.16
+  UNIVERSAL_SILABS_FLASHER: 0.0.17

--- a/openthread_border_router/config.yaml
+++ b/openthread_border_router/config.yaml
@@ -44,5 +44,4 @@ schema:
   otbr_log_level: list(debug|info|notice|warning|error|critical|alert|emergency)
   firewall: bool
   nat64: bool
-stage: experimental
 startup: services

--- a/openthread_border_router/config.yaml
+++ b/openthread_border_router/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 2.4.4
+version: 2.4.5
 slug: openthread_border_router
 name: OpenThread Border Router
 description: OpenThread Border Router add-on

--- a/openthread_border_router/rootfs/etc/s6-overlay/scripts/otbr-agent-configure.sh
+++ b/openthread_border_router/rootfs/etc/s6-overlay/scripts/otbr-agent-configure.sh
@@ -7,3 +7,6 @@ if bashio::config.true 'nat64'; then
     bashio::log.info "Enabling NAT64."
     ot-ctl nat64 enable
 fi
+
+# Set higher transmit power
+ot-ctl txpower 6

--- a/openthread_border_router/rootfs/etc/s6-overlay/scripts/otbr-agent-configure.sh
+++ b/openthread_border_router/rootfs/etc/s6-overlay/scripts/otbr-agent-configure.sh
@@ -9,5 +9,6 @@ if bashio::config.true 'nat64'; then
     ot-ctl dns server upstream enable
 fi
 
-# Set higher transmit power
+# To avoid asymmetric link quality the TX power from the controller should not
+# exceed that of what other Thread routers devices typically use.
 ot-ctl txpower 6

--- a/openthread_border_router/rootfs/etc/s6-overlay/scripts/otbr-agent-configure.sh
+++ b/openthread_border_router/rootfs/etc/s6-overlay/scripts/otbr-agent-configure.sh
@@ -6,6 +6,7 @@
 if bashio::config.true 'nat64'; then
     bashio::log.info "Enabling NAT64."
     ot-ctl nat64 enable
+    ot-ctl dns server upstream enable
 fi
 
 # Set higher transmit power

--- a/openthread_border_router/translations/en.yaml
+++ b/openthread_border_router/translations/en.yaml
@@ -25,7 +25,9 @@ configuration:
       Use OpenThread Border Router firewall to block unnecessary traffic.
   nat64:
     name: NAT64
-    description: Enable IPv6 to IPv4 network address translation.
+    description: >-
+      Enable IPv6 to IPv4 network address translation. This allows Thread
+      devices to communicate with devices on the Internet.
 network:
   8080/tcp: OpenThread Web port
   8081/tcp: OpenThread REST API port


### PR DESCRIPTION
Enable DNS when NAT64 is enabled.

The firmware's default TX power of 0dBm is rather low. Set a the default TX power to 6dBm. Initial tests show that link quality increases quite a bit. To avoid asymmetric link quality the TX power from the controller should not exceed that of what other Thread routers devices typically use.

Update to the latest Universal Silicon Labs flasher 0.0.17.

Lastly also bump to the latest upstream OTBR.