### PR TITLE
DuckDNS Use host network

### DIFF
--- a/duckdns/DOCS.md
+++ b/duckdns/DOCS.md
@@ -84,9 +84,12 @@ a service like https://api.ipify.org/ or https://ipv4.text.wtfismyip.com
 ### Option: `ipv6` (optional)
 
 By default, Duck DNS will auto detect your IPv6 address and use that.
-This option allows you to specify an interface name from which the IPv6 address should be retrieved.
-You can also override the auto-detection and specify an
-IPv6 address manually.
+This option allows you to specify an interface name from which the IPv6
+address should be retrieved. Use `default` to choose the primary network
+interface automatically.
+
+If you set this option to an IPv6 address, this static address will be used
+instead.
 
 Retrieving the IPv6 address over a URL is not supported.
 

--- a/duckdns/DOCS.md
+++ b/duckdns/DOCS.md
@@ -84,12 +84,11 @@ a service like https://api.ipify.org/ or https://ipv4.text.wtfismyip.com
 ### Option: `ipv6` (optional)
 
 By default, Duck DNS will auto detect your IPv6 address and use that.
-This option allows you to override the auto-detection and specify an
+This option allows you to specify an interface name from which the IPv6 address should be retrieved.
+You can also override the auto-detection and specify an
 IPv6 address manually.
 
-If you specify a URL here, contents of the resource it points to will be
-fetched and used as the address. This enables getting the address using
-a service like https://api6.ipify.org/ or https://ipv6.text.wtfismyip.com
+Retrieving the IPv6 address over a URL is not supported.
 
 ### Option: `token`
 

--- a/duckdns/config.yaml
+++ b/duckdns/config.yaml
@@ -12,6 +12,7 @@ arch:
   - amd64
   - i386
 hassio_api: true
+host_network: true
 init: false
 image: homeassistant/{arch}-addon-duckdns
 map:

--- a/duckdns/config.yaml
+++ b/duckdns/config.yaml
@@ -12,7 +12,7 @@ arch:
   - amd64
   - i386
 hassio_api: true
-host_network: true
+host_network: false
 init: false
 image: homeassistant/{arch}-addon-duckdns
 map:

--- a/duckdns/data/run.sh
+++ b/duckdns/data/run.sh
@@ -65,8 +65,8 @@ fi
 # Run duckdns
 while true; do
 
-    [[ ${IPV4} != *:/* ]] && ipv4=${IPV4} || ipv4=$(curl -s -m 10 "${IPV4}")
-    [[ ${IPV6} != *:/* ]] && ipv6=${IPV6} || ipv6=$(curl -s -m 10 "${IPV6}")
+    [[ ${IPV4} != *:/* ]] && ipv4=${IPV4} || ipv4=$(curl -s -m 10 "${IPV4}") || bashio::log.warn "Couldn't retrieve ipv4 from server"
+    [[ ${IPV6} != *:/* ]] && ipv6=${IPV6} || ipv6=$(curl -s -m 10 "${IPV6}") || bashio::log.warn "Couldn't retrieve ipv6 from server"
 
     # Get IPv6-address from host interface
     if [[ -n "$IPV6" && ${ipv6} != *:* ]]; then

--- a/duckdns/data/run.sh
+++ b/duckdns/data/run.sh
@@ -65,8 +65,8 @@ fi
 # Run duckdns
 while true; do
 
-    [[ ${IPV4} != *:/* ]] && ipv4=${IPV4} || ipv4=$(curl -s -m 10 "${IPV4}") || bashio::log.warn "Couldn't retrieve ipv4 from server"
-    [[ ${IPV6} != *:/* ]] && ipv6=${IPV6} || ipv6=$(curl -s -m 10 "${IPV6}") || bashio::log.warn "Couldn't retrieve ipv6 from server"
+    [[ ${IPV4} != *:/* ]] && ipv4=${IPV4} || ipv4=$(curl -s -m 10 "${IPV4}") || bashio::log.warning "Couldn't retrieve ipv4 from server"
+    [[ ${IPV6} != *:/* ]] && ipv6=${IPV6} || ipv6=$(curl -s -m 10 "${IPV6}") || bashio::log.warning "Couldn't retrieve ipv6 from server"
 
     # Get IPv6-address from host interface
     if [[ -n "$IPV6" && ${ipv6} != *:* ]]; then

--- a/duckdns/data/run.sh
+++ b/duckdns/data/run.sh
@@ -41,14 +41,11 @@ function le_renew() {
   LE_UPDATE="$(date +%s)"
 }
 
-echo "start"
-
 # Register/generate certificate if terms accepted
 if bashio::config.true 'lets_encrypt.accept_terms'; then
   # Init folder structs
   mkdir -p "${CERT_DIR}"
   mkdir -p "${WORK_DIR}"
-  echo "sure"
 
   # Clean up possible stale lock file
   if [ -e "${WORK_DIR}/lock" ]; then
@@ -65,11 +62,8 @@ if bashio::config.true 'lets_encrypt.accept_terms'; then
   fi
 fi
 
-echo "run"
-
 # Run duckdns
 while true; do
-  echo "while"
 
   ipv4="none"
   if [[ ${IPV4} != "none" ]]; then
@@ -126,9 +120,9 @@ while true; do
     # Send update to duckdns if IPv6 was retrieved
     if [[ ${ipv6} == *:* ]]; then
       # Could retrieve IPv6, send the update
-      echo "Send update https://www.duckdns.org/update?domains=${DOMAINS}&token=${TOKEN}&ipv6=${ipv6}&verbose=true"
+      bashio::log.info "Send update https://www.duckdns.org/update?domains=${DOMAINS}&token=${TOKEN}&ipv6=${ipv6}&verbose=true"
       if answer="$(curl -s "https://www.duckdns.org/update?domains=${DOMAINS}&token=${TOKEN}&ipv6=${ipv6}&verbose=true")" && [ "${answer}" != 'KO' ]; then
-        echo "${answer}"
+        bashio::log.info "${answer}"
       else
         bashio::log.warning "Error: Sending IP address ${ipv6}: DuckDNS answered: ${answer}"
       fi


### PR DESCRIPTION
DuckDNS access can't make a connection via IPv6 as docker containers do not allow access. In consequence, it is impossible to update the ipv6 address.

Using the host network fixes this issue.

See issue #3427 