### PR TITLE
Bump zwave-js to 12.4.3

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.4.4
+
+### Bug fixes
+
+- Reduce idle CPU load
+
+### Config file changes
+
+- Add 2nd product ID for Ring Panic Button Gen2
+- Disable Supervision for Alfred DB1 Digital Deadbolt Lock to work around battery drain issue
+- Extend version range for Vesternet VES-ZW-DIM-001
+
+### Detailed changelogs
+
+- [Z-Wave JS 12.4.2](https://github.com/zwave-js/node-zwave-js/releases/tag/v12.4.2)
+- [Z-Wave JS 12.4.3](https://github.com/zwave-js/node-zwave-js/releases/tag/v12.4.3)
+
 ## 0.4.3
 
 ### Features

--- a/zwave_js/build.yaml
+++ b/zwave_js/build.yaml
@@ -10,4 +10,4 @@ codenotary:
   base_image: notary@home-assistant.io
 args:
   ZWAVEJS_SERVER_VERSION: 1.34.0
-  ZWAVEJS_VERSION: 12.4.1
+  ZWAVEJS_VERSION: 12.4.3

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.4.3
+version: 0.4.4
 slug: zwave_js
 name: Z-Wave JS
 description: Control a Z-Wave network with Home Assistant Z-Wave JS


### PR DESCRIPTION
Per Al's request

Changelogs
- [Z-Wave JS 12.4.2](https://github.com/zwave-js/node-zwave-js/releases/tag/v12.4.2)
- [Z-Wave JS 12.4.3](https://github.com/zwave-js/node-zwave-js/releases/tag/v12.4.3)