### PR TITLE
matter_server: Bump Python Matter server to 5.5.1

### DIFF
--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 5.1.0
+
+- Bump Python Matter Server to [5.5.0](https://github.com/home-assistant-libs/python-matter-server/releases/tag/5.5.0)
+- Bind Python WebSocket on internal interface only by default
+
 ## 5.0.4
 
 - Correctly bump Python Matter Server to [5.2.1](https://github.com/home-assistant-libs/python-matter-server/releases/tag/5.2.1)

--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 5.1.0
 
-- Bump Python Matter Server to [5.5.0](https://github.com/home-assistant-libs/python-matter-server/releases/tag/5.5.0)
+- Bump Python Matter Server to [5.5.1](https://github.com/home-assistant-libs/python-matter-server/releases/tag/5.5.1)
 - Bind Python WebSocket on internal interface only by default
 
 ## 5.0.4

--- a/matter_server/DOCS.md
+++ b/matter_server/DOCS.md
@@ -17,6 +17,13 @@ Start the Matter Server add-on to make the WebSocket available to Home
 Assistant Core. Install the [Matter integration][matter_integration]
 in Home Assistant Core.
 
+### Access WebSocket interface externally (advanced)
+
+By default, the Python Matter Server's WebSocket interface is only exposed
+internally. It is still possible to enable access through the host interface
+To do so, click on "Show disabled ports" and enter a port (e.g. 5580) in the
+Matter Server WebSocket server port field.
+
 ## Configuration
 
 Add-on configuration:

--- a/matter_server/build.yaml
+++ b/matter_server/build.yaml
@@ -1,7 +1,7 @@
 ---
 build_from:
-  aarch64: ghcr.io/home-assistant-libs/python-matter-server:5.2.1
-  amd64: ghcr.io/home-assistant-libs/python-matter-server:5.2.1
+  aarch64: ghcr.io/home-assistant-libs/python-matter-server:5.5.0
+  amd64: ghcr.io/home-assistant-libs/python-matter-server:5.5.0
 args:
   BASHIO_VERSION: 0.14.3
   TEMPIO_VERSION: 2021.09.0

--- a/matter_server/build.yaml
+++ b/matter_server/build.yaml
@@ -1,7 +1,7 @@
 ---
 build_from:
-  aarch64: ghcr.io/home-assistant-libs/python-matter-server:5.5.0
-  amd64: ghcr.io/home-assistant-libs/python-matter-server:5.5.0
+  aarch64: ghcr.io/home-assistant-libs/python-matter-server:5.5.1
+  amd64: ghcr.io/home-assistant-libs/python-matter-server:5.5.1
 args:
   BASHIO_VERSION: 0.14.3
   TEMPIO_VERSION: 2021.09.0

--- a/matter_server/config.yaml
+++ b/matter_server/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 5.0.4
+version: 5.1.0
 slug: matter_server
 name: Matter Server
 description: Matter WebSocket Server for Home Assistant Matter support.

--- a/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
+++ b/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
@@ -7,6 +7,7 @@ bashio::log.info "Starting Matter Server..."
 declare server_port
 declare log_level
 declare primary_interface
+extra_args=()
 
 log_level=$(bashio::string.lower "$(bashio::config log_level invalid)")
 if [ "$log_level" = "invalid" ]; then
@@ -26,9 +27,9 @@ if ! bashio::var.has_value "${server_port}"; then
 fi
 
 # Reenable once Matter Server can bind to a specific IP
-#if ! bashio::var.has_value "${server_port}"; then
-#    export CHIP_WS_SERVER_HOST="$(bashio::addon.ip_address)"
-#fi
+if ! bashio::var.has_value "${server_port}"; then
+    extra_args+=('--listen-address' "$(bashio::addon.ip_address)")
+fi
 
 primary_interface="$(bashio::api.supervisor 'GET' '/network/info' '' 'first(.interfaces[] | select (.primary == true)) .interface')"
 if [ -z ${primary_interface} ]; then
@@ -45,9 +46,9 @@ if bashio::config.true "beta"; then
     exec /usr/bin/gdb --quiet -ex="set confirm off" -ex run -ex backtrace -ex "quit \$_exitcode" --args /usr/local/bin/python \
          /usr/local/bin/matter-server --storage-path "/data" --port "${server_port}" \
                        --log-level "${log_level}" --primary-interface "${primary_interface}" \
-                       --fabricid 2 --vendorid 4939
+                       --fabricid 2 --vendorid 4939 "${extra_args[@]}"
 else
     exec /usr/local/bin/matter-server --storage-path "/data" --port "${server_port}" \
                        --log-level "${log_level}" --primary-interface "${primary_interface}" \
-                       --fabricid 2 --vendorid 4939
+                       --fabricid 2 --vendorid 4939 "${extra_args[@]}"
 fi

--- a/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
+++ b/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
@@ -24,10 +24,6 @@ fi
 server_port="$(bashio::addon.port 5580)"
 if ! bashio::var.has_value "${server_port}"; then
     server_port=5580
-fi
-
-# Reenable once Matter Server can bind to a specific IP
-if ! bashio::var.has_value "${server_port}"; then
     extra_args+=('--listen-address' "$(bashio::addon.ip_address)")
 fi
 


### PR DESCRIPTION
This also binds the Matter Server WebSocket on internal interface only by default.