### PR TITLE
ssh: Alpine 3.19, CLI 4.29, ttyd 1.7.4

### DIFF
--- a/ssh/CHANGELOG.md
+++ b/ssh/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 9.9.0
+
+- Upgrade to Alpine Linux 3.19
+- Upgrade Home Assistant CLI to 4.29.0
+- Upgrade libwebsockets to 4.3.3
+- Upgrade ttyd to 1.7.4
+
 ## 9.8.1
 
 - Add `/config` symlink to for backward and docs compatibility.

--- a/ssh/build.yaml
+++ b/ssh/build.yaml
@@ -1,14 +1,14 @@
 ---
 build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-base:3.18
-  amd64: ghcr.io/home-assistant/amd64-base:3.18
-  armhf: ghcr.io/home-assistant/armhf-base:3.18
-  armv7: ghcr.io/home-assistant/armv7-base:3.18
-  i386: ghcr.io/home-assistant/i386-base:3.18
+  aarch64: ghcr.io/home-assistant/aarch64-base:3.19
+  amd64: ghcr.io/home-assistant/amd64-base:3.19
+  armhf: ghcr.io/home-assistant/armhf-base:3.19
+  armv7: ghcr.io/home-assistant/armv7-base:3.19
+  i386: ghcr.io/home-assistant/i386-base:3.19
 codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
 args:
-  CLI_VERSION: 4.26.0
-  LIBWEBSOCKETS_VERSION: 4.3.2
-  TTYD_VERSION: 1.7.3
+  CLI_VERSION: 4.29.0
+  LIBWEBSOCKETS_VERSION: 4.3.3
+  TTYD_VERSION: 1.7.4

--- a/ssh/config.yaml
+++ b/ssh/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 9.8.1
+version: 9.9.0
 slug: ssh
 name: Terminal & SSH
 description: Allow logging in remotely to Home Assistant using SSH

--- a/ssh/rootfs/etc/services.d/ttyd/run
+++ b/ssh/rootfs/etc/services.d/ttyd/run
@@ -5,4 +5,4 @@
 bashio::log.info "Starting Web Terminal..."
 cd /root || bashio::exit.nok "Can't find root folder!"
 
-exec ttyd -p 8099 tmux -u new -A -s homeassistant bash -l
+exec ttyd --writable -p 8099 tmux -u new -A -s homeassistant bash -l


### PR DESCRIPTION
Bumps the SSH add-on to version 9.9.0

## 9.9.0

- Upgrade to Alpine Linux 3.19
- Upgrade Home Assistant CLI to 4.29.0
- Upgrade libwebsockets to 4.3.3
- Upgrade ttyd to 1.7.4

The ttyd upgrade needed the new libwebsockets, and the (new) explicit flag to make the terminal writable (instead of the new read-only default).

