### PR TITLE
samba: Update to Alpine Linux 3.19

### DIFF
--- a/samba/CHANGELOG.md
+++ b/samba/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 12.3.0
+
+- Upgrade Alpine Linux to 3.19
+
 ## 12.2.0
 
 - Decrease Samba log level

--- a/samba/build.yaml
+++ b/samba/build.yaml
@@ -1,10 +1,10 @@
 ---
 build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-base:3.18
-  amd64: ghcr.io/home-assistant/amd64-base:3.18
-  armhf: ghcr.io/home-assistant/armhf-base:3.18
-  armv7: ghcr.io/home-assistant/armv7-base:3.18
-  i386: ghcr.io/home-assistant/i386-base:3.18
+  aarch64: ghcr.io/home-assistant/aarch64-base:3.19
+  amd64: ghcr.io/home-assistant/amd64-base:3.19
+  armhf: ghcr.io/home-assistant/armhf-base:3.19
+  armv7: ghcr.io/home-assistant/armv7-base:3.19
+  i386: ghcr.io/home-assistant/i386-base:3.19
 codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io

--- a/samba/config.yaml
+++ b/samba/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 12.2.0
+version: 12.3.0
 slug: samba
 name: Samba share
 description: Expose Home Assistant folders with SMB/CIFS


### PR DESCRIPTION
SSIA, this PR upgrades our samba add-on to Alpine Linux 3.19