### PR TITLE
DuckDNS: Updated documentation for IPv6, removed IPv6 address retrieval over server, and added more logging

### DIFF
--- a/duckdns/DOCS.md
+++ b/duckdns/DOCS.md
@@ -84,12 +84,14 @@ a service like https://api.ipify.org/ or https://ipv4.text.wtfismyip.com
 ### Option: `ipv6` (optional)
 
 By default, Duck DNS will auto detect your IPv6 address and use that.
-This option allows you to override the auto-detection and specify an
-IPv6 address manually.
+This option allows you to specify an interface name from which the IPv6
+address should be retrieved. Use `default` to choose the primary network
+interface automatically.
 
-If you specify a URL here, contents of the resource it points to will be
-fetched and used as the address. This enables getting the address using
-a service like https://api6.ipify.org/ or https://ipv6.text.wtfismyip.com
+If you set this option to an IPv6 address, this static address will be used
+instead.
+
+Retrieving the IPv6 address over a URL is not supported.
 
 ### Option: `token`
 


### PR DESCRIPTION
The DuckDNS documentation states that it is possible to retrieve the IPv6 address over a server. This is not possible as the docker container cannot communicate over IPv6. This PullRequest clarified this in the documentation and removed the corresponding line from the code. Moreover, more logging information was added to make it easier to find the error in the configuration.

See issue #3427 and previous comments in pull request #3442 by @agners 