### PR TITLE
openthread_border_router: Fix container shutdown during startup

### DIFF
--- a/openthread_border_router/CHANGELOG.md
+++ b/openthread_border_router/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.4.7
+
+- Better fix for container shutdown in case of OTBR agent failures
+
 ## 2.4.6
 
 - Bump to OTBR POSIX version 9bdaa91016 (2024-02-15 08:50:34 -0800)

--- a/openthread_border_router/config.yaml
+++ b/openthread_border_router/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 2.4.6
+version: 2.4.7
 slug: openthread_border_router
 name: OpenThread Border Router
 description: OpenThread Border Router add-on

--- a/openthread_border_router/rootfs/etc/s6-overlay/s6-rc.d/otbr-agent/finish
+++ b/openthread_border_router/rootfs/etc/s6-overlay/s6-rc.d/otbr-agent/finish
@@ -51,9 +51,7 @@ bashio::log.info "OTBR firewall teardown completed."
 
 if test "$e" -ne 0; then
     echo "$e" > /run/s6-linux-init-container-results/exitcode
-    # It seems this is required to properly initiate shutdown, at least when
-    # otbr-agent exits with an error e.g. in case the REST port is used.
-    # See: https://github.com/just-containers/s6-overlay/issues/566
-    kill $(pidof s6-rc) || true
     /run/s6/basedir/bin/halt
+    # Consider any otbr-agent exit as permanent failure according to s6
+    exit 125
 fi


### PR DESCRIPTION
When otbr-agent fails during startup properly shutdown again works best by using exit code 125 in the finish script. This indicates a permanent failure for this service. This makes sure that the container shuts down which is the behavior the Supervisor expects.