### PR TITLE
nginx_proxy: Listen on IPv6 by default

### DIFF
--- a/nginx_proxy/rootfs/etc/nginx.conf
+++ b/nginx_proxy/rootfs/etc/nginx.conf
@@ -15,14 +15,14 @@ http {
     server_tokens off;
 
     server_names_hash_bucket_size 128;
-	
+
     # intermediate configuration
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
     ssl_prefer_server_ciphers off;
 
     #include /data/cloudflare.conf;
-	
+
     server {
         server_name _;
         listen 80 default_server;
@@ -36,6 +36,7 @@ http {
 
         # These shouldn't need to be changed
         listen 80;
+        listen [::]:80;
         return 301 https://$host$request_uri;
     }
 
@@ -52,6 +53,7 @@ http {
         ssl_dhparam /data/dhparams.pem;
 
         listen 443 ssl http2;
+        listen [::]:443 ssl http2;
         %%HSTS%%
 
         proxy_buffering off;


### PR DESCRIPTION
This makes nginx listen on IPv6. That's it.
There is no functionality change to the IPv4 path that has existed so far.

Benefits include:
- The `trusted_networks` auth backend in core now works with IPv6 when using nginx
- Enables using IPv6 to expose the homeassistant install to the world (with some extra config also allows getting a cert via LE)

I've used an extra listening directive instead of `[::]:443 ipv6only=off` because with that config ipv4 gets ipv6-mapped in access logs and people might not want that.

### Related issues

https://github.com/home-assistant/supervisor/issues/2133