### PR TITLE
nginx_proxy: Support integration with letsencrypt addon

### DIFF
--- a/letsencrypt/DOCS.md
+++ b/letsencrypt/DOCS.md
@@ -27,6 +27,7 @@ There are two options to obtain certificates.
 
 - Requires Port 80 to be available from the internet and your domain assigned to the externally assigned IP address
 - Doesn’t allow wildcard certificates (*.yourdomain.com).
+- When using the nginx addon, you can configure it to forward HTTP challenges to this addon using the `letsencrypt` option. Make sure to use a port other than `80` for this plugin in that case.
 
 ### 2. DNS challenge
 
@@ -221,7 +222,7 @@ If your custom ACME server uses a certificate signed by an untrusted certificate
 
 <details>
   <summary>Selecting the ECDSA Elliptic Curve</summary>
-  
+
   You can choose from the following ECDSA elliptic curves: `secp256r1`, `secp384r1`
 
   ```yaml
@@ -628,16 +629,16 @@ You will need to set up a server with RFC2136 (Dynamic Update) support with a TK
 
 You don't need to publish this; just copy the key data into your named.conf file:
   ```
-  
+
   key "letsencrypt" {
     algorithm hmac-sha512;
     secret "G/adDW8hh7FDlZq5ZDW3JjpU/I7DzzU1PDvp26DvPQWMLg/LfM2apEOejbfdp5BXu78v/ruWbFvSK5dwYY7bIw==";
   };
-  
+
   ```
 And ensure you have an update policy in place in the zone that uses this key to enable update of the correct domain (which must match the domain in your yaml configuration):
   ```
-  
+
      update-policy {
         grant letsencrypt name _acme-challenge.home-assistant.io. txt;
      };
@@ -729,7 +730,7 @@ dns:
 </details>
 <details>
   <summary>ClouDNS</summary>
-In order to use a domain with this challenge, you first need to log into your control panel and create a 
+In order to use a domain with this challenge, you first need to log into your control panel and create a
 new HTTP API user from the "API & Resellers" page on top of your control panel.
 
   ```yaml
@@ -816,7 +817,7 @@ References:
 <details>
   <summary>easyDNS</summary>
 
-easyDNS REST API access must be requested and granted in order to use this module: https://cp.easydns.com/manage/security/api/signup.php after logging into your account. 
+easyDNS REST API access must be requested and granted in order to use this module: https://cp.easydns.com/manage/security/api/signup.php after logging into your account.
 
   ```yaml
   email: your.email@example.com

--- a/nginx_proxy/DOCS.md
+++ b/nginx_proxy/DOCS.md
@@ -43,6 +43,7 @@ customize:
   default: "nginx_proxy_default*.conf"
   servers: "nginx_proxy/*.conf"
 cloudflare: false
+letsencrypt: false
 ```
 
 ### Option: `domain` (required)
@@ -77,6 +78,12 @@ The filename(s) of the NGINX configuration for the additional servers, found in 
 
 If enabled, configure Nginx with a list of IP addresses directly from Cloudflare that will be used for `set_real_ip_from` directive Nginx config.
 This is so the `ip_ban_enabled` feature can be used and work correctly in /config/customize.yaml.
+
+### Option `letsencrypt` (optional)
+
+If enabled, forwards HTTP ACME challenges to the [Letsencrypt addon](https://github.com/home-assistant/addons/blob/master/letsencrypt/DOCS.md). Make sure to install and configure it separately.
+
+Make sure to configure some other port than `80` in the Letsencrypt addon so it doesn't conflict with this addon. Which port you choose doesn't matter, nginx will use the internal docker network to reach the addon which doesn't depend on the port setting in the addon.
 
 ## Known issues and limitations
 

--- a/nginx_proxy/config.yaml
+++ b/nginx_proxy/config.yaml
@@ -22,6 +22,7 @@ options:
   certfile: fullchain.pem
   keyfile: privkey.pem
   cloudflare: false
+  letsencrypt: false
   customize:
     active: false
     default: nginx_proxy_default*.conf
@@ -35,6 +36,7 @@ schema:
   certfile: str
   keyfile: str
   cloudflare: bool
+  letsencrypt: bool
   customize:
     active: bool
     default: str

--- a/nginx_proxy/rootfs/etc/nginx-addon/letsencrypt.conf
+++ b/nginx_proxy/rootfs/etc/nginx-addon/letsencrypt.conf
@@ -1,0 +1,11 @@
+location /.well-known/acme-challenge/ {
+    # this forces nginx to resolve the host on every request
+    # and not on startup since the letsencrypt addon only
+    # runs on-demand, nginx would otherwise not start
+    set $upstream_letsencrypt core-letsencrypt.local.hass.io;
+
+    # Docker DNS
+    resolver 127.0.0.11 valid=30s;
+
+    proxy_pass http://$upstream_letsencrypt;
+}

--- a/nginx_proxy/rootfs/etc/nginx.conf
+++ b/nginx_proxy/rootfs/etc/nginx.conf
@@ -15,14 +15,14 @@ http {
     server_tokens off;
 
     server_names_hash_bucket_size 128;
-	
+
     # intermediate configuration
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
     ssl_prefer_server_ciphers off;
 
     #include /data/cloudflare.conf;
-	
+
     server {
         server_name _;
         listen 80 default_server;
@@ -36,6 +36,9 @@ http {
 
         # These shouldn't need to be changed
         listen 80;
+
+        #include /etc/nginx-addon/letsencrypt.conf;
+
         return 301 https://$host$request_uri;
     }
 
@@ -57,6 +60,8 @@ http {
         proxy_buffering off;
 
         #include /share/nginx_proxy_default*.conf;
+
+        #include /etc/nginx-addon/letsencrypt.conf;
 
         location / {
             proxy_pass http://homeassistant.local.hass.io:%%HA_PORT%%;

--- a/nginx_proxy/rootfs/etc/s6-overlay/s6-rc.d/nginx/run
+++ b/nginx_proxy/rootfs/etc/s6-overlay/s6-rc.d/nginx/run
@@ -47,6 +47,10 @@ if bashio::config.true 'cloudflare'; then
     fi
 fi
 
+if bashio::config.true 'letsencrypt'; then
+    sed -i "s|#include /etc/nginx-addon/letsencrypt.conf;|include /etc/nginx-addon/letsencrypt.conf;|g" /etc/nginx.conf
+fi
+
 # Prepare config file
 sed -i "s#%%FULLCHAIN%%#$CERTFILE#g" /etc/nginx.conf
 sed -i "s#%%PRIVKEY%%#$KEYFILE#g" /etc/nginx.conf


### PR DESCRIPTION
This turns out pretty handy when both addons are used alongside each other.

The only gotcha that people still have to care about is that you need to run the letsencrypt addon on port 80 once to get the initial cert material and then change its port and install nginx, because nginx won't start without a cert. Not sure if that could be documented better.