### PR TITLE
Update Assist Microphone to wyoming-satellite 1.2.0

### DIFF
--- a/assist_microphone/CHANGELOG.md
+++ b/assist_microphone/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.2.0
+
+- Update to wyoming-satellite 1.2.0
+
 ## 1.0.0
 
 - Initial release

--- a/assist_microphone/Dockerfile
+++ b/assist_microphone/Dockerfile
@@ -21,7 +21,7 @@ RUN \
         setuptools \
         wheel \
     && pip3 install --no-cache-dir \
-        "wyoming_satellite[webrtc]==${WYOMING_SATELLITE_VERSION}" \
+        "wyoming-satellite[webrtc] @ https://github.com/rhasspy/wyoming-satellite/archive/refs/tags/v${WYOMING_SATELLITE_VERSION}.tar.gz" \
     \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/assist_microphone/build.yaml
+++ b/assist_microphone/build.yaml
@@ -6,4 +6,4 @@ codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
 args:
-  WYOMING_SATELLITE_VERSION: v1.0.0
+  WYOMING_SATELLITE_VERSION: 1.2.0

--- a/assist_microphone/config.yaml
+++ b/assist_microphone/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 1.0.0
+version: 1.2.0
 slug: assist_microphone
 name: Assist Microphone
 description: Use Assist with local microphone


### PR DESCRIPTION
- Updates the Assist Microphone add-on to use Wyoming Satellite 1.2.0.
- Fixes https://github.com/home-assistant/addons/issues/3464