### PR TITLE
matter_server: Bump Python Matter server to 5.7.0

### DIFF
--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 5.3.0
+
+- Bump Python Matter Server to [5.7.0](https://github.com/home-assistant-libs/python-matter-server/releases/tag/5.6.0)
+- Add Matter SDK log options
+
 ## 5.2.0
 
 - Bump Python Matter Server to [5.6.0](https://github.com/home-assistant-libs/python-matter-server/releases/tag/5.6.0)

--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 5.3.0
 
-- Bump Python Matter Server to [5.7.0](https://github.com/home-assistant-libs/python-matter-server/releases/tag/5.6.0)
+- Bump Python Matter Server to [5.7.0](https://github.com/home-assistant-libs/python-matter-server/releases/tag/5.7.0)
 - Add Matter SDK log options
 
 ## 5.2.0

--- a/matter_server/build.yaml
+++ b/matter_server/build.yaml
@@ -1,7 +1,7 @@
 ---
 build_from:
-  aarch64: ghcr.io/home-assistant-libs/python-matter-server:5.6.0
-  amd64: ghcr.io/home-assistant-libs/python-matter-server:5.6.0
+  aarch64: ghcr.io/home-assistant-libs/python-matter-server:5.7.0
+  amd64: ghcr.io/home-assistant-libs/python-matter-server:5.7.0
 args:
   BASHIO_VERSION: 0.14.3
   TEMPIO_VERSION: 2021.09.0

--- a/matter_server/config.yaml
+++ b/matter_server/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 5.2.0
+version: 5.3.0
 slug: matter_server
 name: Matter Server
 description: Matter WebSocket Server for Home Assistant Matter support.
@@ -20,9 +20,11 @@ image: homeassistant/{arch}-addon-matter-server
 init: false
 options:
   log_level: info
+  log_level_sdk: error
   beta: false
 schema:
   log_level: list(debug|info|warning|error|critical)
+  log_level_sdk: list(automation|detail|progress|error|none)?
   beta: bool?
 ports:
   5580/tcp: null

--- a/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
+++ b/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
@@ -6,14 +6,17 @@ bashio::log.info "Starting Matter Server..."
 
 declare server_port
 declare log_level
+declare log_level_sdk
 declare primary_interface
 extra_args=()
 
-log_level=$(bashio::string.lower "$(bashio::config log_level invalid)")
-if [ "$log_level" = "invalid" ]; then
-  bashio::log.magenta 'Received invalid log_level from config, fallback to info'
-  log_level="info"
+if ! bashio::config.exists log_level; then
+  bashio::log.magenta 'No log_level set in config, fallback to info'
 fi
+log_level=$(bashio::string.lower "$(bashio::config log_level info)")
+
+# Make Matter SDK log level currently default to error
+log_level_sdk=$(bashio::string.lower "$(bashio::config log_level_sdk error)")
 
 if bashio::config.true "beta"; then
     bashio::log.info 'Upgrading Python Matter Server to latest pre-release'
@@ -45,6 +48,7 @@ if bashio::config.true "beta"; then
                        --fabricid 2 --vendorid 4939 "${extra_args[@]}"
 else
     exec /usr/local/bin/matter-server --storage-path "/data" --port "${server_port}" \
-                       --log-level "${log_level}" --primary-interface "${primary_interface}" \
+                       --log-level "${log_level}" --log-level-sdk "${log_level_sdk}" \
+                       --primary-interface "${primary_interface}" \
                        --fabricid 2 --vendorid 4939 "${extra_args[@]}"
 fi


### PR DESCRIPTION
Bump the Python Matter server to 5.7.0. Also add Matter SDK log level as separate (optional) configuration. This allows to select the Matter SDK log level separately from the server logging level.