### PR TITLE
openthread_border_router: OTBR bump and Debian Bookworm update

### DIFF
--- a/openthread_border_router/CHANGELOG.md
+++ b/openthread_border_router/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.5.0
+
+- Bump to OTBR POSIX version 2279c02f3c (2024-02-28 22:36:55 -0800)
+- Bump base image to Debian bookworm
+
 ## 2.4.7
 
 - Better fix for container shutdown in case of OTBR agent failures

--- a/openthread_border_router/Dockerfile
+++ b/openthread_border_router/Dockerfile
@@ -90,7 +90,8 @@ RUN \
         && cd build/otbr/ \
         && ninja \
         && ninja install) \
-    && pip install universal-silabs-flasher==${UNIVERSAL_SILABS_FLASHER} \
+    && pip install --break-system-packages \
+       universal-silabs-flasher==${UNIVERSAL_SILABS_FLASHER} \
     && apt-get purge -y --auto-remove \
        git \
        nodejs \

--- a/openthread_border_router/build.yaml
+++ b/openthread_border_router/build.yaml
@@ -1,7 +1,7 @@
 ---
 build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-base-debian:bullseye
-  amd64: ghcr.io/home-assistant/amd64-base-debian:bullseye
+  aarch64: ghcr.io/home-assistant/aarch64-base-debian:bookworm
+  amd64: ghcr.io/home-assistant/amd64-base-debian:bookworm
 args:
-  OTBR_VERSION: 9bdaa9101663c2ce9016fb5e2b5010442b17ca26
+  OTBR_VERSION: 2279c02f3c3373f074899fc8d993b8ddb72910a2
   UNIVERSAL_SILABS_FLASHER: 0.0.18


### PR DESCRIPTION
This updates the OTBR to the latest upstream git version. In particular, this should address issue #3491.

Also update the base image to Debian Bookworm.

Fixes: #3491