### PR TITLE
whisper: add prompt option

### DIFF
--- a/whisper/DOCS.md
+++ b/whisper/DOCS.md
@@ -55,6 +55,16 @@ Number of candidates to consider simultaneously during transcription (see [beam 
 
 Increasing the beam size will increase accuracy at the cost of performance.
 
+### Option: prompt
+
+If you have uncommon names for your users or devices, it may help to include them in a prompt, passed to whisper.
+
+An example of this may be:
+
+```
+"The following command is about things and places in the possession of the person named <Name>."
+```
+
 ## Backups
 
 Whisper model files can be quite large, so they are automatically excluded from backups. The models will be re-downloaded when the backup is restored.

--- a/whisper/config.yaml
+++ b/whisper/config.yaml
@@ -16,11 +16,13 @@ options:
   model: tiny-int8
   language: en
   beam_size: 1
+  prompt: ""
 schema:
   model: list(tiny-int8|tiny|base|base-int8|small-int8|small|medium-int8)
   language: |
     list(auto|af|am|ar|as|az|ba|be|bg|bn|bo|br|bs|ca|cs|cy|da|de|el|en|es|et|eu|fa|fi|fo|fr|gl|gu|ha|haw|he|hi|hr|ht|hu|hy|id|is|it|ja|jw|ka|kk|km|kn|ko|la|lb|ln|lo|lt|lv|mg|mi|mk|ml|mn|mr|ms|mt|my|ne|nl|nn|no|oc|pa|pl|ps|pt|ro|ru|sa|sd|si|sk|sl|sn|so|sq|sr|su|sv|sw|ta|te|tg|th|tk|tl|tr|tt|uk|ur|uz|vi|yi|yo|zh)
   beam_size: int
+  prompt: str
 ports:
   "10300/tcp": null
 homeassistant: 2023.8.0.dev20230728

--- a/whisper/rootfs/etc/s6-overlay/s6-rc.d/whisper/run
+++ b/whisper/rootfs/etc/s6-overlay/s6-rc.d/whisper/run
@@ -15,3 +15,4 @@ exec python3 -m wyoming_faster_whisper \
     --language "$(bashio::config 'language')" \
     --data-dir /data \
     --download-dir /data
+    --initial_prompt "$(bashio::config 'prompt')"

--- a/whisper/translations/en.yaml
+++ b/whisper/translations/en.yaml
@@ -20,5 +20,11 @@ configuration:
       Whisper model which is able to run on a Raspberry Pi 4. Compressed models
       (`int8`) are slightly less accurate than their counterparts, but smaller
       and faster.
+  prompt:
+    name: Prompt
+    description: >-
+      This will define a prompt passed to whisper before parsing your voice.
+      Including things that may appear in your commands, like uncommon names,
+      may help their recognition.
 network:
   10300/tcp: Whisper Wyoming Protocol


### PR DESCRIPTION
I have a quite uncommon name, that whisper currently struggles to make any sense of. Adding a prompt, as suggested [here](https://github.com/openai/whisper/discussions/963) and [here](https://github.com/openai/whisper/discussions/328), made whisper actually capable of recognizing it. 

Unfortunately for me still only with the medium model, which doesn't really run well on my raspi 4, however I thought it is still worth sharing.