### PR TITLE
Update to wyoming-faster-whisper 2.0.0

### DIFF
--- a/whisper/CHANGELOG.md
+++ b/whisper/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.0.0
+
+- Add more models for `model` option
+- Add "custom" option for `model` that will use `custom_model` instead
+- Add `custom_model` that can be a path to a model directory or HuggingFace Hub model ID
+- Use faster-whisper PyPI package
+
 ## 1.0.2
 
 - Convert error to warning for CPUs not supporting AVX instructions

--- a/whisper/DOCS.md
+++ b/whisper/DOCS.md
@@ -34,20 +34,36 @@ If you select "auto", the model will run **much** slower but will auto-detect th
 
 ### Option: `model`
 
-Whisper model that will be used for transcription.
+Whisper model that will be used for transcription. Choose `custom` to use the model name in `custom_model`, which may be a HuggingFace model ID like "Systran/faster-distil-whisper-small.en".
 
 The default model is `tiny-int8`, a compressed version of the smallest Whisper model which is able to run on a Raspberry Pi 4.
-Compressed models (`int8`) are slightly less accurate than their counterparts, but smaller and faster.
+Compressed models (`int8`) are slightly less accurate than their counterparts, but smaller and faster. [Distilled](https://github.com/huggingface/distil-whisper) models are not compressed, but are faster and smaller than their non-distilled counterparts.
 
-Available models are sorted from least to most accurate.
+Available models:
 
-- `tiny-int8` (43 MB)
-- `tiny` (152 MB)
-- `base-int8` (80 MB)
-- `base` (291 MB)
-- `small-int8` (255 MB)
-- `small` (968 MB)
-- `medium-int8` (786 MB)
+- `tiny-int8` (compressed)
+- `tiny`
+- `tiny.en` (English only)
+- `base-int8` (compressed)
+- `base`
+- `base.en` (English only)
+- `small-int8` (compressed)
+- `distil-small.en` (distilled, English only)
+- `small`
+- `small.en` (English only)
+- `medium-int8` (compressed)
+- `distil-medium.en` (distilled, English only)
+- `medium`
+- `medium.en` (English only)
+- `large`
+- `large-v1`
+- `distil-large-v2` (distilled, English only)
+- `large-v2`
+- `large-v3`
+
+### Option: `custom_model`
+
+Path to a converted model directory, or a CTranslate2-converted Whisper model ID from the HuggingFace Hub like "Systran/faster-distil-whisper-small.en". 
 
 ### Option: `beam_size`
 

--- a/whisper/Dockerfile
+++ b/whisper/Dockerfile
@@ -3,7 +3,7 @@ FROM ${BUILD_FROM}
 
 # Install Whisper
 WORKDIR /usr/src
-ARG WHISPER_VERSION
+ARG WYOMING_WHISPER_VERSION
 
 RUN \
     apt-get update \
@@ -18,7 +18,7 @@ RUN \
         setuptools \
         wheel \
     && pip3 install --no-cache-dir \
-        "wyoming-faster-whisper==${WHISPER_VERSION}" \
+        "wyoming-faster-whisper @ https://github.com/rhasspy/wyoming-faster-whisper/archive/refs/tags/v${WYOMING_WHISPER_VERSION}.tar.gz" \
     \
     && apt-get purge -y --auto-remove \
         build-essential \

--- a/whisper/build.yaml
+++ b/whisper/build.yaml
@@ -6,4 +6,4 @@ codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
 args:
-  WHISPER_VERSION: 1.0.1
+  WYOMING_WHISPER_VERSION: 2.0.0

--- a/whisper/config.yaml
+++ b/whisper/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 1.0.2
+version: 2.0.0
 slug: whisper
 name: Whisper
 description: Speech-to-text with Whisper
@@ -14,13 +14,18 @@ backup_exclude:
   - "*.bin"
 options:
   model: tiny-int8
+  custom_model: ""
   language: en
   beam_size: 1
+  debug_logging: false
 schema:
-  model: list(tiny-int8|tiny|base|base-int8|small-int8|small|medium-int8)
+  model: |
+    list(tiny-int8|tiny|tiny.en|base-int8|base|base.en|small-int8|distil-small.en|small|small.en|distil-medium.en|medium-int8|medium|medium.en|large|large-v1|distil-large-v2|large-v2|large-v3|custom)
+  custom_model: str
   language: |
-    list(auto|af|am|ar|as|az|ba|be|bg|bn|bo|br|bs|ca|cs|cy|da|de|el|en|es|et|eu|fa|fi|fo|fr|gl|gu|ha|haw|he|hi|hr|ht|hu|hy|id|is|it|ja|jw|ka|kk|km|kn|ko|la|lb|ln|lo|lt|lv|mg|mi|mk|ml|mn|mr|ms|mt|my|ne|nl|nn|no|oc|pa|pl|ps|pt|ro|ru|sa|sd|si|sk|sl|sn|so|sq|sr|su|sv|sw|ta|te|tg|th|tk|tl|tr|tt|uk|ur|uz|vi|yi|yo|zh)
+    list(auto|af|am|ar|as|az|ba|be|bg|bn|bo|br|bs|ca|cs|cy|da|de|el|en|es|et|eu|fa|fi|fo|fr|gl|gu|ha|haw|he|hi|hr|ht|hu|hy|id|is|it|ja|jw|ka|kk|km|kn|ko|la|lb|ln|lo|lt|lv|mg|mi|mk|ml|mn|mr|ms|mt|my|ne|nl|nn|no|oc|pa|pl|ps|pt|ro|ru|sa|sd|si|sk|sl|sn|so|sq|sr|su|sv|sw|ta|te|tg|th|tk|tl|tr|tt|uk|ur|uz|vi|yi|yo|zh|yue)
   beam_size: int
+  debug_logging: bool
 ports:
   "10300/tcp": null
 homeassistant: 2023.8.0.dev20230728

--- a/whisper/rootfs/etc/s6-overlay/s6-rc.d/whisper/run
+++ b/whisper/rootfs/etc/s6-overlay/s6-rc.d/whisper/run
@@ -8,10 +8,20 @@ if [ "$(uname -m)" == "x86_64" ] && ! grep -qw 'avx' /proc/cpuinfo; then
     bashio::log.warning "Your CPU does not support Advanced Vector Extensions (AVX). Whisper will run slower than normal."
 fi
 
+model="$(bashio::config 'model')"
+if [ "${model}" = 'custom' ]; then
+    # Override with custom model
+    model="$(bashio::config 'custom_model')"
+fi
+
+if bashio::config.true 'debug_logging'; then
+    flags+=('--debug')
+fi
+
 exec python3 -m wyoming_faster_whisper \
     --uri 'tcp://0.0.0.0:10300' \
-    --model "$(bashio::config 'model')" \
+    --model "${model}" \
     --beam-size "$(bashio::config 'beam_size')" \
     --language "$(bashio::config 'language')" \
     --data-dir /data \
-    --download-dir /data
+    --download-dir /data ${flags[@]}

--- a/whisper/translations/en.yaml
+++ b/whisper/translations/en.yaml
@@ -20,5 +20,15 @@ configuration:
       Whisper model which is able to run on a Raspberry Pi 4. Compressed models
       (`int8`) are slightly less accurate than their counterparts, but smaller
       and faster.
+  custom_model:
+    name: Custom model
+    description: |
+      Path to a converted model directory, or a CTranslate2-converted Whisper
+      model ID from the HuggingFace Hub like
+      "Systran/faster-distil-whisper-small.en".
+  debug_logging:
+    name: Debug logging
+    description: >-
+      Print DEBUG level messages to the add-on's log.
 network:
   10300/tcp: Whisper Wyoming Protocol


### PR DESCRIPTION
- Add more models for `model` option
- Add "custom" option for `model` that will use `custom_model` instead
- Add `custom_model` that can be a path to a model directory or HuggingFace Hub model ID
- Use faster-whisper PyPI package
