### PR TITLE
samba: Handle passwords with backslash correctly

### DIFF
--- a/samba/CHANGELOG.md
+++ b/samba/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 12.3.1
+
+- Handle passwords with backslash correctly
+
 ## 12.3.0
 
 - Upgrade Alpine Linux to 3.19

--- a/samba/config.yaml
+++ b/samba/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 12.3.0
+version: 12.3.1
 slug: samba
 name: Samba share
 description: Expose Home Assistant folders with SMB/CIFS

--- a/samba/rootfs/etc/s6-overlay/s6-rc.d/init-smbd/run
+++ b/samba/rootfs/etc/s6-overlay/s6-rc.d/init-smbd/run
@@ -40,6 +40,6 @@ username=$(bashio::config 'username')
 password=$(bashio::config 'password')
 addgroup "${username}"
 adduser -D -H -G "${username}" -s /bin/false "${username}"
-# shellcheck disable=SC1117
-echo -e "${password}\n${password}" \
+
+(echo "$password"; echo "$password") \
     | smbpasswd -a -s -c "/etc/samba/smb.conf" "${username}"


### PR DESCRIPTION
Make sure backslash in a password is not interpreted as an escape sequence.