### PR TITLE
nginx_proxy: Add map_hash_bucket_size

### DIFF
--- a/nginx_proxy/CHANGELOG.md
+++ b/nginx_proxy/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.9.0
+
+- Add `map_hash_bucket_size` to add support for longer matches in `map`
+
 ## 3.8.0
 
 - Update Alpine Linux to 3.19

--- a/nginx_proxy/config.yaml
+++ b/nginx_proxy/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 3.8.0
+version: 3.9.0
 hassio_api: true
 slug: nginx_proxy
 name: NGINX Home Assistant SSL proxy

--- a/nginx_proxy/rootfs/etc/nginx.conf
+++ b/nginx_proxy/rootfs/etc/nginx.conf
@@ -7,6 +7,8 @@ events {
 }
 
 http {
+    map_hash_bucket_size 128;
+
     map $http_upgrade $connection_upgrade {
         default upgrade;
         ''      close;


### PR DESCRIPTION
The `map_hash_bucket_size` option must be specified before the first `map`. Since the first `map` comes before the user `include` in `nginx.conf`, it is not possible for the user to set this value. A larger bucket is required when matching long strings (such as user agents) in a `map`.