### PR TITLE
Bump tellstick addon to alpine 3.15 and deprecate it

### DIFF
--- a/tellstick/CHANGELOG.md
+++ b/tellstick/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.2.0
+
+- Use Alpine 3.15
+
 ## 2.1.0
 
 - Update hardware configuration for Supervisor 2021.02.5

--- a/tellstick/CHANGELOG.md
+++ b/tellstick/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 2.2.0
 
+**Deprecation notice**
+This will be the final update for this addon. The library it depends on is abandoned.
+It's last activity was 5 years ago it it cannot be built on alpine >3.15. Users
+can continue to use it but no issues or PRs will be accepted for it going forward.
+
 - Use Alpine 3.15
 
 ## 2.1.0

--- a/tellstick/build.yaml
+++ b/tellstick/build.yaml
@@ -1,10 +1,10 @@
 ---
 build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-base:3.13
-  amd64: ghcr.io/home-assistant/amd64-base:3.13
-  armhf: ghcr.io/home-assistant/armhf-base:3.13
-  armv7: ghcr.io/home-assistant/armv7-base:3.13
-  i386: ghcr.io/home-assistant/i386-base:3.13
+  aarch64: ghcr.io/home-assistant/aarch64-base:3.15
+  amd64: ghcr.io/home-assistant/amd64-base:3.15
+  armhf: ghcr.io/home-assistant/armhf-base:3.15
+  armv7: ghcr.io/home-assistant/armv7-base:3.15
+  i386: ghcr.io/home-assistant/i386-base:3.15
 codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io

--- a/tellstick/config.yaml
+++ b/tellstick/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 2.1.0
+version: 2.2.0
 slug: tellstick
 name: TellStick
 description: TellStick and TellStick Duo service

--- a/tellstick/config.yaml
+++ b/tellstick/config.yaml
@@ -42,3 +42,4 @@ startup: system
 stdin: true
 usb: true
 init: false
+stage: deprecated


### PR DESCRIPTION
This is the latest version of Alpine this addon builds on currently. The make file fails on every version of alpine >3.15 .

There is a PR with alpine 3.17 fixes (https://github.com/telldus/telldus/pull/21) but the project appears abandoned. Not clear how to handle this addon going forward.

**Decision:** This addon is deprecated. This will be the final update for the addon.