### PR TITLE
openthread-border-router: Support Home Assistant Connect ZBT-1

### DIFF
--- a/openthread_border_router/CHANGELOG.md
+++ b/openthread_border_router/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.5.1
+- Support Home Assistant Connect ZBT-1.
+
 ## 2.5.0
 
 - Bump to OTBR POSIX version 2279c02f3c (2024-02-28 22:36:55 -0800)

--- a/openthread_border_router/DOCS.md
+++ b/openthread_border_router/DOCS.md
@@ -13,8 +13,8 @@ Follow these steps to get the add-on installed on your system:
 ## How to use
 
 You will need a 802.15.4 capable radio supported by OpenThread. Home Assistant
-Yellow as well as Home Assistant SkyConnect are both capable to run OpenThread.
-This add-on automatically installs the necessary firmware on these systems.
+Yellow as well as Home Assistant SkyConnect/Connect ZBT-1 are both capable to run
+OpenThread. This add-on automatically installs the necessary firmware on these systems.
 
 If you are using Home Assistant Yellow, choose `/dev/ttyAMA1` as device.
 

--- a/openthread_border_router/config.yaml
+++ b/openthread_border_router/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 2.5.0
+version: 2.5.1
 slug: openthread_border_router
 name: OpenThread Border Router
 description: OpenThread Border Router add-on

--- a/openthread_border_router/rootfs/etc/s6-overlay/scripts/universal-silabs-flasher-up
+++ b/openthread_border_router/rootfs/etc/s6-overlay/scripts/universal-silabs-flasher-up
@@ -47,6 +47,8 @@ else
     bashio::log.info "Checking ${device} identifying ${usb_product} from ${usb_manufacturer}."
     if [[ "${usb_manufacturer}" == "Nabu Casa" && "${usb_product}" == "SkyConnect"* ]]; then
         firmware="NabuCasa_SkyConnect_OpenThread_RCP_v2.4.0.0_ot-rcp_hw_460800.gbl"
+    elif [[ "${usb_manufacturer}" == "Nabu Casa" && "${usb_product}" == "Home Assistant Connect ZBT-1"* ]]; then
+        firmware="NabuCasa_SkyConnect_OpenThread_RCP_v2.4.0.0_ot-rcp_hw_460800.gbl"
     else
         exit_no_firmware
     fi

--- a/openthread_border_router/translations/en.yaml
+++ b/openthread_border_router/translations/en.yaml
@@ -14,7 +14,7 @@ configuration:
     name: Automatically flash firmware
     description: >-
       Automatically flash OpenThread RCP firmware on Home Assistant Yellow and
-      SkyConnect.
+      SkyConnect/Connect ZBT-1.
   otbr_log_level:
     name: OpenThread Border Router agent log level
     description: >-


### PR DESCRIPTION
Adds support for the Home Assistant Connect ZBT-1. This change allows SkyConnect firmware to be flashed to it.

Linked Core PR to enable discovery: `insert here`