### PR TITLE
silabs-flasher: Support flashing the Connect ZBT-1

### DIFF
--- a/silabs_flasher/CHANGELOG.md
+++ b/silabs_flasher/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.2.1
+- Support flashing the Connect ZBT-1.
+
 ## 0.2.0
 
 - Update universal-silabs-flasher to v0.0.13

--- a/silabs_flasher/DOCS.md
+++ b/silabs_flasher/DOCS.md
@@ -12,7 +12,7 @@ Follow these steps to get the add-on installed on your system:
 
 The add-on needs a Silicon Labs based wireless module accessible through a
 serial port (like the module on Home Assistant Yellow, Home Assistant
-SkyConnect or other USB based wireless adapters).
+SkyConnect/ZBT-1 or other USB based wireless adapters).
 
 1. Select the correct `device` in the add-on configuration tab and press `Save`.
 2. Start the add-on.

--- a/silabs_flasher/README.md
+++ b/silabs_flasher/README.md
@@ -18,7 +18,7 @@ Multiprotocol add-on.
 ## About
 
 This add-on allows you to flash firmwares using the Gecko Bootloader file format
-(gbl). By default it comes with firmware for Home Assistant SkyConnect and
+(gbl). By default it comes with firmware for Home Assistant SkyConnect/ZBT-1 and
 Home Assistant Yellow to flash Zigbee.
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg

--- a/silabs_flasher/config.yaml
+++ b/silabs_flasher/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.2.0
+version: 0.2.1
 slug: silabs_flasher
 name: Silicon Labs Flasher
 description: Silicon Labs firmware flasher add-on

--- a/silabs_flasher/rootfs/etc/s6-overlay/scripts/universal-silabs-flasher-up
+++ b/silabs_flasher/rootfs/etc/s6-overlay/scripts/universal-silabs-flasher-up
@@ -71,6 +71,8 @@ else
         bashio::log.info "Checking ${device} identifying ${usb_product} from ${usb_manufacturer}."
         if [[ "${usb_manufacturer}" == "Nabu Casa" && "${usb_product}" == "SkyConnect"* ]]; then
             firmware="NabuCasa_SkyConnect_EZSP_v7.3.1.0_ncp-uart-hw_115200.gbl"
+        elif [[ "${usb_manufacturer}" == "Nabu Casa" && "${usb_product}" == "Home Assistant Connect ZBT-1"* ]]; then
+            firmware="NabuCasa_SkyConnect_EZSP_v7.3.1.0_ncp-uart-hw_115200.gbl"
         else
             exit_no_firmware
         fi


### PR DESCRIPTION
Matches the Home Assistant Connect ZBT-1 and automatically flashes SkyConnect firmware.