### PR TITLE
silabs-multiprotocol: Support the Home Assistant Connect ZBT-1

### DIFF
--- a/silabs-multiprotocol/CHANGELOG.md
+++ b/silabs-multiprotocol/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.4.5
+- Support Home Assistant Connect ZBT-1.
+
 ## 2.4.4
 - Revert back to Silicon Labs Gecko SDK 4.3.1 while 4.4.0 instability is investigated.
 - Backport firmware modifications for improved stability.

--- a/silabs-multiprotocol/DOCS.md
+++ b/silabs-multiprotocol/DOCS.md
@@ -1,6 +1,6 @@
 # Home Assistant Add-on: Silicon Labs Multiprotocol
 
-**NOTE**: This add-on has the option to automatically install the right firmware for Home Assistant Yellow and Home Assistant SkyConnect. Follow [this guide](https://github.com/NabuCasa/silabs-firmware/wiki/Flash-Silicon-Labs-radio-firmware-manually) to change back to a firmware that is compatible with other Zigbee software.
+**NOTE**: This add-on has the option to automatically install the right firmware for Home Assistant Yellow, SkyConnect, and Connect ZBT-1. Follow [this guide](https://github.com/NabuCasa/silabs-firmware/wiki/Flash-Silicon-Labs-radio-firmware-manually) to change back to a firmware that is compatible with other Zigbee software.
 
 ## Installation
 
@@ -60,8 +60,8 @@ and 8081 in the OpenThread REST API port field).
 ### Automatic firmware upgrade
 
 If the `autoflash_firmware` configuration is set, the add-on will automatically
-install or update to the RCP Multi-PAN firmware if a Home Assistant SkyConnect
-or Home Assistant Yellow is detected.
+install or update to the RCP Multi-PAN firmware if a Home Assistant Connect ZBT-1/
+SkyConnect or Home Assistant Yellow is detected.
 
 **NOTE:** Switching back to a Zigbee only (EmberZNet) firmware requires manual
 steps currently. You can find a guide on the Nabu Casa Silicon Labs firmware
@@ -77,7 +77,7 @@ Add-on configuration:
 | device (mandatory) | Serial service where the Silicon Labs radio is attached |
 | baudrate           | Serial port baudrate (depends on firmware)   |
 | flow_control       | If hardware flow control should be enabled (depends on firmware) |
-| autoflash_firmware | Automatically install/update firmware (Home Assistant SkyConnect/Yellow) |
+| autoflash_firmware | Automatically install/update firmware (Home Assistant Connect ZBT-1/SkyConnect/Yellow) |
 | network_device     | Host and port where CPC daemon can find the Silicon Labs radio (takes precedence over device) |
 | cpcd_trace         | Co-Processor Communication tracing (trace in log)      |
 | otbr_enable        | Enable OpenThread BorderRouter                         |

--- a/silabs-multiprotocol/README.md
+++ b/silabs-multiprotocol/README.md
@@ -1,7 +1,7 @@
 # Home Assistant Add-on: SiliconLabs Zigbee/OpenThread Multiprotocol Add-on
 
 Zigbee/OpenThread Multiprotocol container for Silicon Labs based radios such as
-Home Assistant Yellow or Home Assistant SkyConnect.
+Home Assistant Yellow, Home Assistant SkyConnect, and Home Assistant Connect ZBT-1.
 
 **NOTE:** Use System -> Hardware -> Configure to enable Multiprotocol support
 seamlessly.

--- a/silabs-multiprotocol/config.yaml
+++ b/silabs-multiprotocol/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 2.4.4
+version: 2.4.5
 slug: silabs_multiprotocol
 name: Silicon Labs Multiprotocol
 description: Zigbee and OpenThread multiprotocol add-on

--- a/silabs-multiprotocol/rootfs/etc/s6-overlay/scripts/universal-silabs-flasher-up
+++ b/silabs-multiprotocol/rootfs/etc/s6-overlay/scripts/universal-silabs-flasher-up
@@ -47,6 +47,8 @@ else
     bashio::log.info "Checking ${device} identifying ${usb_product} from ${usb_manufacturer}."
     if [[ "${usb_manufacturer}" == "Nabu Casa" && "${usb_product}" == "SkyConnect"* ]]; then
         firmware="NabuCasa_SkyConnect_RCP_v4.3.1_rcp-uart-hw-802154_460800.gbl"
+    elif [[ "${usb_manufacturer}" == "Nabu Casa" && "${usb_product}" == "Home Assistant Connect ZBT-1"* ]]; then
+        firmware="NabuCasa_SkyConnect_RCP_v4.3.1_rcp-uart-hw-802154_460800.gbl"
     else
         exit_no_firmware
     fi


### PR DESCRIPTION
Matches the Home Assistant Connect ZBT-1 and automatically flashes SkyConnect multi-PAN firmware.

Core PR required for full support via discovery.