### PR TITLE
matter_server: Add Ingress, custom PAA certificate dir and bump to 5.9.0

### DIFF
--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 5.5.0
+
+- Enable Ingress for the Python Matter Server built-in web interface
+- Store PAA root certificates in /data to avoid download on every startup (downloads once a day)
+
 ## 5.4.1
 
 - Bump Python Matter Server to [5.8.1](https://github.com/home-assistant-libs/python-matter-server/releases/tag/5.8.1)

--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 5.5.0
 
+- Bump Python Matter Server to [5.9.0](https://github.com/home-assistant-libs/python-matter-server/releases/tag/5.9.0)
 - Enable Ingress for the Python Matter Server built-in web interface
 - Store PAA root certificates in /data to avoid download on every startup (downloads once a day)
 

--- a/matter_server/build.yaml
+++ b/matter_server/build.yaml
@@ -1,7 +1,7 @@
 ---
 build_from:
-  aarch64: ghcr.io/home-assistant-libs/python-matter-server:5.8.1
-  amd64: ghcr.io/home-assistant-libs/python-matter-server:5.8.1
+  aarch64: ghcr.io/home-assistant-libs/python-matter-server:5.9.0
+  amd64: ghcr.io/home-assistant-libs/python-matter-server:5.9.0
 args:
   BASHIO_VERSION: 0.14.3
   TEMPIO_VERSION: 2021.09.0

--- a/matter_server/config.yaml
+++ b/matter_server/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 5.4.1
+version: 5.5.0
 slug: matter_server
 name: Matter Server
 description: Matter WebSocket Server for Home Assistant Matter support.
@@ -17,6 +17,8 @@ host_ipc: false
 host_network: true
 host_dbus: true
 image: homeassistant/{arch}-addon-matter-server
+ingress: true
+ingress_port: 5580
 init: false
 options:
   log_level: info

--- a/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
+++ b/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
@@ -53,10 +53,12 @@ if bashio::config.true "beta"; then
     exec /usr/bin/gdb --quiet -ex="set confirm off" -ex run -ex backtrace -ex "quit \$_exitcode" --args /usr/local/bin/python \
          /usr/local/bin/matter-server --storage-path "/data" --port "${server_port}" \
                        --log-level "${log_level}" --primary-interface "${primary_interface}" \
+                       --paa-root-cert-dir "/data/credentials" \
                        --fabricid 2 --vendorid 4939 "${extra_args[@]}"
 else
     exec /usr/local/bin/matter-server --storage-path "/data" --port "${server_port}" \
                        --log-level "${log_level}" --log-level-sdk "${log_level_sdk}" \
                        --primary-interface "${primary_interface}" \
+                       --paa-root-cert-dir "/data/credentials" \
                        --fabricid 2 --vendorid 4939 "${extra_args[@]}"
 fi


### PR DESCRIPTION
Add ingress capabilities to allow easy access for the debug server present in recent Python Matter Server releases.

Also configure to use /data/certificates as location for certificates. This is a persistent directory. With that, the logic which downloads certificates only once a day is actual functional.

Bump Python Matter Server to 5.9.0.