### PR TITLE
matter_server: Fix bashio::log.warn

### DIFF
--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.5.1
+
+- Fix logging in case fallback method for determining the primary network interface is used
+
 ## 5.5.0
 
 - Bump Python Matter Server to [5.9.0](https://github.com/home-assistant-libs/python-matter-server/releases/tag/5.9.0)

--- a/matter_server/config.yaml
+++ b/matter_server/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 5.5.0
+version: 5.5.1
 slug: matter_server
 name: Matter Server
 description: Matter WebSocket Server for Home Assistant Matter support.

--- a/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
+++ b/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
@@ -34,7 +34,7 @@ primary_interface="$(bashio::api.supervisor 'GET' '/network/info' '' 'first(.int
 
 # Try fallback method (e.g. in case NetworkManager is not available)
 if [ -z ${primary_interface} ]; then
-  bashio::log.warn 'Trying fallback method to determine primary interface'
+  bashio::log.warning 'Trying fallback method to determine primary interface'
   primary_interface="$(ip --json route show default | jq --raw-output '.[0].dev')"
 fi
 


### PR DESCRIPTION
Fixes bashio::log.warn
I have to admit I didn't test it after the review, not sure why I used log.*warn* instead of log.*warning*.