### PR TITLE
silabs-flasher: Bump universal-silabs-flasher to 0.0.19

### DIFF
--- a/silabs_flasher/CHANGELOG.md
+++ b/silabs_flasher/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.2.2
+- Update universal-silabs-flasher to v0.0.19
+
 ## 0.2.1
 - Support flashing the Connect ZBT-1.
 

--- a/silabs_flasher/build.yaml
+++ b/silabs_flasher/build.yaml
@@ -6,4 +6,4 @@ build_from:
   armv7: ghcr.io/home-assistant/armv7-base-python:3.11-alpine3.17
   i386: ghcr.io/home-assistant/i386-base-python:3.11-alpine3.17
 args:
-  UNIVERSAL_SILABS_FLASHER: 0.0.13
+  UNIVERSAL_SILABS_FLASHER: 0.0.19

--- a/silabs_flasher/config.yaml
+++ b/silabs_flasher/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.2.1
+version: 0.2.2
 slug: silabs_flasher
 name: Silicon Labs Flasher
 description: Silicon Labs firmware flasher add-on

--- a/silabs_flasher/rootfs/etc/s6-overlay/scripts/universal-silabs-flasher-up
+++ b/silabs_flasher/rootfs/etc/s6-overlay/scripts/universal-silabs-flasher-up
@@ -35,7 +35,7 @@ bootloader_baudrate=$(bashio::config 'bootloader_baudrate')
 
 if [ -d /sys/devices/platform/soc/fe201800.serial/tty/ttyAMA1 ] && [ "${device}" == "/dev/ttyAMA1" ]; then
     bashio::log.info "Detected Home Assistant Yellow"
-    gpio_reset_flag="--yellow-gpio-reset"
+    gpio_reset_flag="--bootloader-reset yellow"
 else
     gpio_reset_flag=""
 fi
@@ -86,8 +86,11 @@ if bashio::config.true 'verbose'; then
 fi
 
 bashio::log.info "Starting universal-silabs-flasher with ${device} (bootloader baudrate ${bootloader_baudrate})"
-universal-silabs-flasher ${verbose} --device ${device} \
-     --bootloader-baudrate "${bootloader_baudrate}" \
-     flash ${gpio_reset_flag} --force --firmware "/root/${firmware}"
+universal-silabs-flasher \
+    ${verbose} \
+    --device ${device} \
+    --bootloader-baudrate "${bootloader_baudrate}" \
+    ${gpio_reset_flag} \
+    flash --force --firmware "/root/${firmware}"
 
 


### PR DESCRIPTION
The flasher version in this addon (0.0.13) did not properly pin dependencies so it could not be re-installed when the addon was rebuilt.

I've also adjusted the bootloader reset command line argument to use the new syntax.

Built and tested locally.