### PR TITLE
SSH: Enable ha command completion for non-login shell (e.g. the web terminal)

### DIFF
--- a/ssh/CHANGELOG.md
+++ b/ssh/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 9.13.0
+
+- Enable ha command completion for non-login shell (e.g. the web terminal)
+
 ## 9.12.0
 
 - Install completions for ha commands

--- a/ssh/config.yaml
+++ b/ssh/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 9.12.0
+version: 9.13.0
 slug: ssh
 name: Terminal & SSH
 description: Allow logging in remotely to Home Assistant using SSH

--- a/ssh/rootfs/root/.bashrc
+++ b/ssh/rootfs/root/.bashrc
@@ -1,3 +1,0 @@
-#!/usr/bin/with-contenv bash
-# shellcheck disable=SC1090
-source <(ha completion bash)

--- a/ssh/rootfs/usr/share/tempio/homeassistant.profile
+++ b/ssh/rootfs/usr/share/tempio/homeassistant.profile
@@ -3,3 +3,5 @@ export PS1="\[\e[0;32m\][\h \W]\$ \[\e[m\]"
 export SUPERVISOR_TOKEN={{ .supervisor_token }}
 
 ha banner
+# shellcheck disable=SC1090
+source <(ha completion bash)


### PR DESCRIPTION
This is fix/improvement of #3557. The terminal that is spawned when the add-on is opened on the web has the -l (--login) flag, and in that case Bash doesn't read .bashrc [1]. Move it to /etc/profile.d/homeassistant.sh to enable completion also in that case.

[1] https://www.gnu.org/software/bash/manual/html_node/Bash-Startup-Files.html