### PR TITLE
RPC Shutdown: Upgrade to Alpine 3.19

### DIFF
--- a/rpc_shutdown/CHANGELOG.md
+++ b/rpc_shutdown/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.5
+
+- Update to Alpine 3.19
+
 ## 2.4
 
 - Update to Alpine 3.17

--- a/rpc_shutdown/build.yaml
+++ b/rpc_shutdown/build.yaml
@@ -1,10 +1,10 @@
 ---
 build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-base:3.17
-  amd64: ghcr.io/home-assistant/amd64-base:3.17
-  armhf: ghcr.io/home-assistant/armhf-base:3.17
-  armv7: ghcr.io/home-assistant/armv7-base:3.17
-  i386: ghcr.io/home-assistant/i386-base:3.17
+  aarch64: ghcr.io/home-assistant/aarch64-base:3.19
+  amd64: ghcr.io/home-assistant/amd64-base:3.19
+  armhf: ghcr.io/home-assistant/armhf-base:3.19
+  armv7: ghcr.io/home-assistant/armv7-base:3.19
+  i386: ghcr.io/home-assistant/i386-base:3.19
 codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io

--- a/rpc_shutdown/config.yaml
+++ b/rpc_shutdown/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: "2.4"
+version: "2.5"
 slug: rpc_shutdown
 name: RPC Shutdown
 description: Shutdown Windows machines remotely


### PR DESCRIPTION
Upgrade RPC Shutdown addon to Alpine 3.19