### PR TITLE
mariadb: Enable auto-upgrade

### DIFF
--- a/mariadb/CHANGELOG.md
+++ b/mariadb/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.7.1
+
+- Enable MariaDB auto-upgrade
+
 ## 2.7.0
 
 - Update to Alpine 3.19

--- a/mariadb/Dockerfile
+++ b/mariadb/Dockerfile
@@ -10,7 +10,8 @@ RUN apk add --no-cache \
 
 ENV \
     LD_PRELOAD="/usr/local/lib/libjemalloc.so.2" \
-    S6_SERVICES_GRACETIME=18000
+    S6_SERVICES_GRACETIME=18000 \
+    MARIADB_AUTO_UPGRADE=1
 
 # Copy data
 COPY rootfs /

--- a/mariadb/config.yaml
+++ b/mariadb/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 2.7.0
+version: 2.7.1
 slug: mariadb
 name: MariaDB
 description: A SQL database server


### PR DESCRIPTION
After a major update, the mariadb-upgrade tool should be run (see https://mariadb.com/kb/en/mariadb-upgrade/). However, we don't have a specific post-upgrade script we can run.

Luckily, MariaDB has a feature to run the upgrade on it's own when needed. Enable the feature using the MARIADB_AUTO_UPGRADE environment variable.