### PR TITLE
Remove unused vars

### DIFF
--- a/mariadb/rootfs/etc/s6-overlay/s6-rc.d/mariadb-core/finish
+++ b/mariadb/rootfs/etc/s6-overlay/s6-rc.d/mariadb-core/finish
@@ -3,7 +3,6 @@
 # ==============================================================================
 # Take down the S6 supervision tree when daemon fails
 # ==============================================================================
-declare exit_code
 readonly exit_code_container=$(</run/s6-linux-init-container-results/exitcode)
 readonly exit_code_service="${1}"
 readonly exit_code_signal="${2}"

--- a/nginx_proxy/rootfs/etc/s6-overlay/s6-rc.d/crond/finish
+++ b/nginx_proxy/rootfs/etc/s6-overlay/s6-rc.d/crond/finish
@@ -3,7 +3,6 @@
 # ==============================================================================
 # Take down the S6 supervision tree when daemon fails
 # ==============================================================================
-declare exit_code
 readonly exit_code_container=$(</run/s6-linux-init-container-results/exitcode)
 readonly exit_code_service="${1}"
 readonly exit_code_signal="${2}"

--- a/nginx_proxy/rootfs/etc/s6-overlay/s6-rc.d/nginx/finish
+++ b/nginx_proxy/rootfs/etc/s6-overlay/s6-rc.d/nginx/finish
@@ -3,7 +3,6 @@
 # ==============================================================================
 # Take down the S6 supervision tree when daemon fails
 # ==============================================================================
-declare exit_code
 readonly exit_code_container=$(</run/s6-linux-init-container-results/exitcode)
 readonly exit_code_service="${1}"
 readonly exit_code_signal="${2}"

--- a/openwakeword/rootfs/etc/s6-overlay/s6-rc.d/openwakeword/finish
+++ b/openwakeword/rootfs/etc/s6-overlay/s6-rc.d/openwakeword/finish
@@ -4,7 +4,6 @@
 # Take down the S6 supervision tree when service fails
 # s6-overlay docs: https://github.com/just-containers/s6-overlay
 # ==============================================================================
-declare exit_code
 readonly exit_code_container=$(</run/s6-linux-init-container-results/exitcode)
 readonly exit_code_service="${1}"
 readonly exit_code_signal="${2}"

--- a/piper/rootfs/etc/s6-overlay/s6-rc.d/piper/finish
+++ b/piper/rootfs/etc/s6-overlay/s6-rc.d/piper/finish
@@ -4,7 +4,6 @@
 # Take down the S6 supervision tree when service fails
 # s6-overlay docs: https://github.com/just-containers/s6-overlay
 # ==============================================================================
-declare exit_code
 readonly exit_code_container=$(</run/s6-linux-init-container-results/exitcode)
 readonly exit_code_service="${1}"
 readonly exit_code_signal="${2}"

--- a/whisper/rootfs/etc/s6-overlay/s6-rc.d/whisper/finish
+++ b/whisper/rootfs/etc/s6-overlay/s6-rc.d/whisper/finish
@@ -4,7 +4,6 @@
 # Take down the S6 supervision tree when service fails
 # s6-overlay docs: https://github.com/just-containers/s6-overlay
 # ==============================================================================
-declare exit_code
 readonly exit_code_container=$(</run/s6-linux-init-container-results/exitcode)
 readonly exit_code_service="${1}"
 readonly exit_code_signal="${2}"


### PR DESCRIPTION
This is an old copy-paste error. Recreating itself with more copy-paste...

No new releases are necessary, there is no functional change.