### PR TITLE
git_pull: sanitize git_pull add-on to avoid deleting /config, fix some nits

### DIFF
--- a/git_pull/CHANGELOG.md
+++ b/git_pull/CHANGELOG.md
@@ -1,4 +1,10 @@
-# Changelog
+# Changelogs
+
+## 7.14.2
+- Point $HOME to /root, not ~
+- Immediately exit the script if an error occurs to avoid losing data
+- Deployment key should be passed base64-encoded to avoid newline concatenation problems
+- Clone the repository in a fresh folder, copy the contents and then delete the old config contents
 
 ## 7.14.1
 - Fix error where $HOME is not defined

--- a/git_pull/config.yaml
+++ b/git_pull/config.yaml
@@ -12,9 +12,8 @@ arch:
   - amd64
   - i386
 boot: manual
-hassio_api: true
+homeassistant_api: true
 hassio_role: homeassistant
-image: homeassistant/{arch}-addon-git_pull
 init: false
 map:
   - config:rw

--- a/git_pull/config.yaml
+++ b/git_pull/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 7.14.1
+version: 7.14.2
 slug: git_pull
 name: Git pull
 description: Simple git pull to update the local configuration

--- a/git_pull/config.yaml
+++ b/git_pull/config.yaml
@@ -28,7 +28,7 @@ options:
     - .gitignore
   git_command: pull
   git_prune: false
-  deployment_key: []
+  deployment_key_base64_encoded: ""
   deployment_user: ""
   deployment_password: ""
   deployment_key_protocol: rsa
@@ -44,8 +44,7 @@ schema:
     - str
   git_command: list(pull|reset)
   git_prune: bool
-  deployment_key:
-    - str
+  deployment_key_base64_encoded: str
   deployment_user: str
   deployment_password: password
   deployment_key_protocol: match(rsa|dsa|ecdsa|ed25519|rsa)


### PR DESCRIPTION
"The risk of complete loss is possible." is a real thing with git_pull! I wiped out my `/config` folder and found that [I am not alone](https://github.com/home-assistant/addons/issues?q=is%3Aissue+git_pull). I did a backup just before putting my hands on `git_pull`, so it was innocuous for my HA install.

I added some error handling using `set e` so the script would stop running if an error occurred (like a misconfiguration or a connectivity problem). I also found using `~` a bit misleading when trying to set `$HOME`; for example, `git` couldn't find the ssh key when using `~` as `$HOME`.

Also, I decided to pass the SSH deployment key base64 encoded; otherwise, parsing the single-line SSH key would be a lot of struggle.

Last, the repo is cloned to a fresh folder called `/new_config` before destroying the working `/config` one.