### PR TITLE
Add abilty to config cache size for dnsmasq addon

### DIFF
--- a/dnsmasq/CHANGELOG.md
+++ b/dnsmasq/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.8.0
+
+- Add cache_size option
+
 ## 1.7.0
 
 - Update to Alpine 3.19

--- a/dnsmasq/DOCS.md
+++ b/dnsmasq/DOCS.md
@@ -123,6 +123,10 @@ The target name. Note that this only works for targets which are names from DHCP
 
 Log all DNS requests. Defaults to `false`.
 
+### Option: `cache_size`
+
+Sets the size of the Dnsmasq cache. The default setting is 150. If this is set to 0 this disable caching. Note that huge cache sizes can create performance problems.
+
 ## Support
 
 Got questions?

--- a/dnsmasq/DOCS.md
+++ b/dnsmasq/DOCS.md
@@ -125,7 +125,7 @@ Log all DNS requests. Defaults to `false`.
 
 ### Option: `cache_size`
 
-Sets the size of the Dnsmasq cache. The default setting is 150. If this is set to 0 this disable caching. Note that huge cache sizes can create performance problems.
+Sets the size of the Dnsmasq cache. The default setting is 150. If this is set to 0 this disables caching. Note that huge cache sizes can create performance problems.
 
 ## Support
 

--- a/dnsmasq/config.yaml
+++ b/dnsmasq/config.yaml
@@ -22,6 +22,7 @@ options:
   services: []
   cnames: []
   log_queries: false
+  cache_size: 150
 ports:
   53/tcp: 53
   53/udp: 53
@@ -44,4 +45,5 @@ schema:
     - name: str
       target: str
   log_queries: bool
+  cache_size: int
 startup: system

--- a/dnsmasq/config.yaml
+++ b/dnsmasq/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 1.7.0
+version: 1.8.0
 slug: dnsmasq
 name: Dnsmasq
 description: A simple DNS server

--- a/dnsmasq/rootfs/usr/share/tempio/dnsmasq.config
+++ b/dnsmasq/rootfs/usr/share/tempio/dnsmasq.config
@@ -9,6 +9,7 @@ log-queries
 log-facility=-
 no-poll
 user=root
+cache={{ .cache_size}}
 
 # Default forward servers
 {{ range .defaults }}


### PR DESCRIPTION
This adds the ability to set the cache size for the Dnsmasq addon.

The default cache size is 150, which can be too small when one has a lot of local servers and devices constantly calling out to cloud services.   Here is a user request for adjusting the cache size https://community.home-assistant.io/t/dnsmasq-increase-cache-size/382020


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new option `cache_size` allowing users to set the size of the Dnsmasq cache, enhancing caching performance.

- **Updates**
  - Upgraded the underlying system to Alpine 3.19 for improved stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->