### PR TITLE
Fix dnsmasq config

### DIFF
--- a/dnsmasq/CHANGELOG.md
+++ b/dnsmasq/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.8.1
+
+- Fix config bug of cache_size option
+
 ## 1.8.0
 
 - Add cache_size option

--- a/dnsmasq/config.yaml
+++ b/dnsmasq/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 1.8.0
+version: 1.8.1
 slug: dnsmasq
 name: Dnsmasq
 description: A simple DNS server

--- a/dnsmasq/rootfs/usr/share/tempio/dnsmasq.config
+++ b/dnsmasq/rootfs/usr/share/tempio/dnsmasq.config
@@ -9,7 +9,7 @@ log-queries
 log-facility=-
 no-poll
 user=root
-cache={{ .cache_size}}
+cache-size={{ .cache_size}}
 
 # Default forward servers
 {{ range .defaults }}


### PR DESCRIPTION
The new cache feature seems to use the wrong value name in its config so we fix it.

fixes #3609

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
  - Updated `dnsmasq` configuration to use `cache-size` directive for improved caching functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->