### PR TITLE
Increase mqtt max_queued_messages to 8192

### DIFF
--- a/mosquitto/CHANGELOG.md
+++ b/mosquitto/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.4.1
+
+- Increase default max_queued_messages to 8192 to fix dropped messages during Home Assistant startup
+
 ## 6.4.0
 
 - Update mosquitto to 2.0.18

--- a/mosquitto/config.yaml
+++ b/mosquitto/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 6.4.0
+version: 6.4.1
 slug: mosquitto
 name: Mosquitto broker
 description: An Open Source MQTT broker

--- a/mosquitto/rootfs/usr/share/tempio/mosquitto.gtpl
+++ b/mosquitto/rootfs/usr/share/tempio/mosquitto.gtpl
@@ -13,6 +13,12 @@ log_timestamp_format %Y-%m-%d %H:%M:%S
 persistence true
 persistence_location /data/
 
+# Limits
+# max_queued_messages is effectively the upper limit of
+# the number of entities on Home Assistant is startup
+# is busy and cannot ready messages fast enough
+max_queued_messages 8192
+
 # Authentication plugin
 auth_plugin /usr/share/mosquitto/go-auth.so
 auth_opt_backends files,http


### PR DESCRIPTION
The default of 1000 was not sufficent when the user has more than 1000 entities and startup is so busy that is cannot read the buffer before it fills up and the broker starts dropping messages.

```
2024-05-26 21:33:43: New client connected from 172.30.32.1:49641 as 6RPEl0PbDg8Z5fNLHymeL4 (p2, c1, k60, u'homeassistant').
2024-05-26 21:33:43: Outgoing messages are being dropped for client 6RPEl0PbDg8Z5fNLHymeL4.
```

While we have increased the mqtt receive buffer in core, this only solves the problem on fast systems.

This value can still be overridden with a config file in `/share/mosquitto` if a higher value (or lower) is desired.

I didn't change it to 0 (unlimited) to handle the case where they expose the MQTT server to the public internet (this is unwise but someone will).  

I also didn't make it configurable since having the value match close to what Home Assistant can support made the most sense. Making it easier to configure would likely lead to more issues in the future since it would be hard to increase the default again without having to adjust any configuration that had been overridden manually.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new configuration parameter `max_queued_messages` to manage the upper limit of queued messages during busy startup periods.

- **Updates**
  - Updated Mosquitto version from `6.4.0` to `6.4.1`.
  - Increased default value of `max_queued_messages` to 8192.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->