### PR TITLE
matter_server: Bump Python Matter server to 6.1.0

### DIFF
--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 6.1.0
+
+- Bump Python Matter Server to [6.1.0](https://github.com/home-assistant-libs/python-matter-server/releases/tag/6.1.0)
+  - This update is required for Home Assistant Core 2024.6.0
+
 ## 6.0.0
 
 - Bump Python Matter Server to [6.0.0](https://github.com/home-assistant-libs/python-matter-server/releases/tag/6.0.0)

--- a/matter_server/build.yaml
+++ b/matter_server/build.yaml
@@ -1,7 +1,7 @@
 ---
 build_from:
-  aarch64: ghcr.io/home-assistant-libs/python-matter-server:6.0.0
-  amd64: ghcr.io/home-assistant-libs/python-matter-server:6.0.0
+  aarch64: ghcr.io/home-assistant-libs/python-matter-server:6.1.0
+  amd64: ghcr.io/home-assistant-libs/python-matter-server:6.1.0
 args:
   BASHIO_VERSION: 0.14.3
   TEMPIO_VERSION: 2021.09.0

--- a/matter_server/config.yaml
+++ b/matter_server/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 6.0.0
+version: 6.1.0
 slug: matter_server
 name: Matter Server
 description: Matter WebSocket Server for Home Assistant Matter support.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated Python Matter Server to version 6.1.0 for compatibility with Home Assistant Core 2024.6.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->