### PR TITLE
matter_server: Bump Python Matter server to 6.1.1

### DIFF
--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.1.1
+
+- Bump Python Matter Server to [6.1.1](https://github.com/home-assistant-libs/python-matter-server/releases/tag/6.1.1)
+
 ## 6.1.0
 
 - Bump Python Matter Server to [6.1.0](https://github.com/home-assistant-libs/python-matter-server/releases/tag/6.1.0)

--- a/matter_server/config.yaml
+++ b/matter_server/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 6.1.0
+version: 6.1.1
 slug: matter_server
 name: Matter Server
 description: Matter WebSocket Server for Home Assistant Matter support.
@@ -11,7 +11,7 @@ arch:
 discovery:
   - matter
 hassio_api: true
-homeassistant: 2023.12.0
+homeassistant: 2024.6.0
 # IPC is only used within the Add-on
 host_ipc: false
 host_network: true


### PR DESCRIPTION
Correctly mark the Python Matter server to require Home Assistant Core 2024.6.0 at least. This is since a breaking change has been introduced which makes the Server incompatible with older Core versions.