### PR TITLE
dhcp_server: Remove eth from DOCS.md

### DIFF
--- a/dhcp_server/DOCS.md
+++ b/dhcp_server/DOCS.md
@@ -38,7 +38,7 @@ networks:
     range_end: 192.168.1.200
     broadcast: 192.168.1.255
     gateway: 192.168.1.1
-    interface: eth0
+    interface: end0
 hosts:
   - name: webcam_xy
     mac: aa:bb:ee:cc
@@ -110,7 +110,7 @@ This is usually the IP address of your router.
 
 #### Option: `networks.interface`
 
-The network interface to listen to for this network, e.g., `eth0`.
+The network interface to listen to for this network, e.g., `end0`.
 
 ### Option: `hosts` (optional)
 


### PR DESCRIPTION
Fixes: #3634

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated network interface name from "eth0" to "end0" in the DHCP server configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->