### PR TITLE
ssh: Add port to "TCP port forwarding"

### DIFF
--- a/ssh/DOCS.md
+++ b/ssh/DOCS.md
@@ -85,7 +85,7 @@ Some SSH server options.
 
 #### Option `tcp_forwarding`
 
-Specifies whether TCP forwarding is permitted or not.
+Specifies whether TCP port forwarding (-L -R etc.) is permitted or not.
 
 **Note**: _Enabling this option lowers the security of your SSH server! Nevertheless, this warning is debatable._
 


### PR DESCRIPTION
Give more of a hint what forwarding specifically "tcp_forwarding" would enable or not.  I was confused and I've forwarded many things over ssh.

I'm new to Home Assistant, not ssh, and when I read the description of
tcp_forwarding I was confused as to what specifically it was talking
about.  There are a number of things ssh can forward, X11 connections, authentication agent, jump hosts are listed as "TCP forwarding", it took some digging to find a reference.  I know it as port forwarding.  I also didn't know if it would somehow be related to the Home Assistant Cloud making ssh available behind a firewall, because ssh itself uses TCP.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified the purpose of the `tcp_forwarding` option in the SSH server options documentation, specifying it controls TCP port forwarding (-L -R etc) permissions with a note on security implications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->