### PR TITLE
Bump zwave-js to 12.11.1

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.6.1
+
+### Bug fixes
+
+- Z-Wave JS: When attempting communication with a node that's considered dead, the command is now sent immediately instead of pinging first
+
+### Config file changes
+
+- Remove endpoint workaround for Zooz ZEN30 800LR
+- Encode CCs using target's CC version for TKB Home TZ67
+
+### Detailed changelogs
+
+- [Z-Wave JS 12.11.1](https://github.com/zwave-js/node-zwave-js/releases/tag/v12.11.1)
+
 ## 0.6.0
 
 ### Features
@@ -39,7 +54,7 @@
 
 ### Detailed changelogs
 
-- [Z-Wave JS 12.10.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v12.11.0)
+- [Z-Wave JS 12.11.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v12.11.0)
 - [Z-Wave JS 12.10.1](https://github.com/zwave-js/node-zwave-js/releases/tag/v12.10.1)
 - [Z-Wave JS 12.10.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v12.10.0)
 - [Z-Wave JS 12.9.1](https://github.com/zwave-js/node-zwave-js/releases/tag/v12.9.1)

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 - Z-Wave JS: When attempting communication with a node that's considered dead, the command is now sent immediately instead of pinging first
+- Z-Wave JS: Fixed prioritization of queued transactions once a node wakes up
 
 ### Config file changes
 

--- a/zwave_js/build.yaml
+++ b/zwave_js/build.yaml
@@ -10,4 +10,4 @@ codenotary:
   base_image: notary@home-assistant.io
 args:
   ZWAVEJS_SERVER_VERSION: 1.36.0
-  ZWAVEJS_VERSION: 12.11.0
+  ZWAVEJS_VERSION: 12.11.1

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.6.0
+version: 0.6.1
 slug: zwave_js
 name: Z-Wave JS
 description: Control a Z-Wave network with Home Assistant Z-Wave JS


### PR DESCRIPTION
### Bug fixes

- Z-Wave JS: When attempting communication with a node that's considered dead, the command is now sent immediately instead of pinging first

### Config file changes

- Remove endpoint workaround for Zooz ZEN30 800LR
- Encode CCs using target's CC version for TKB Home TZ67

### Detailed changelogs

- [Z-Wave JS 12.11.1](https://github.com/zwave-js/node-zwave-js/releases/tag/v12.11.1)

@AlCalzone was there any other bug in this release worth mentioning? This one seemed like the only one that HA users would care about

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved communication with nodes considered dead by sending commands immediately.
  - Updated configuration entries for Zooz ZEN30 800LR and TKB Home TZ67 devices for better compatibility.

- **Chores**
  - Updated Z-Wave JS to version `12.11.1`.
  - Updated internal configuration to version `0.6.1`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->