### PR TITLE
letsencrypt: Fix config.yaml

### DIFF
--- a/letsencrypt/CHANGELOG.md
+++ b/letsencrypt/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.0.21
+
+- Fix configuration to make list of provider parsable again
+
 ## 5.0.20
 
 - Fix file-structure.sh script

--- a/letsencrypt/config.yaml
+++ b/letsencrypt/config.yaml
@@ -92,8 +92,7 @@ schema:
       dns-hetzner|dns-infomaniak|dns-linode|dns-luadns|dns-njalla|dns-nsone|\
       dns-porkbun|dns-ovh|dns-rfc2136|dns-route53|dns-sakuracloud|\
       dns-namecheap|dns-netcup|dns-gandi|dns-transip|dns-inwx|dns-dreamhost|\
-      dns-he|dns-easydns|dns-domainoffensive)?\
-      dns-he|dns-easydns|dns-websupport)?"
+      dns-he|dns-easydns|dns-domainoffensive|dns-websupport)?"
     rfc2136_algorithm: str?
     rfc2136_name: str?
     rfc2136_port: str?

--- a/letsencrypt/config.yaml
+++ b/letsencrypt/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 5.0.20
+version: 5.0.21
 slug: letsencrypt
 name: Let's Encrypt
 description: Manage certificate from Let's Encrypt


### PR DESCRIPTION
Fixed typo in provider list that made dns-domainoffensive unusable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Addressed parsing issue in configuration to ensure the list of providers is correctly interpreted.

- **Chores**
  - Updated configuration file to version 5.0.21.
  - Consolidated DNS provider options for easier management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->