### PR TITLE
Bump zwave-js to 12.11.2

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.6.2
+
+### Bug fixes
+
+- Z-Wave JS: Fixed a regression causing commands to sleeping nodes to block communication with other nodes
+
+### Detailed changelogs
+
+- [Z-Wave JS 12.11.2](https://github.com/zwave-js/node-zwave-js/releases/tag/v12.11.2)
+
 ## 0.6.1
 
 ### Bug fixes
@@ -335,7 +345,6 @@ Almost 1000 device configuration files have been reworked to be more consistent,
 
 - Z-Wave JS: Fixes or works around multiple issues with 500 series controllers that could trigger the unresponsive controller detection in Z-Wave JS 12 in situations where it was not necessary, causing restart loops.
 
-
 ### Bug fixes
 
 - [Z-Wave JS 12.0.3](https://github.com/zwave-js/node-zwave-js/releases/tag/v12.0.3)
@@ -353,6 +362,7 @@ Almost 1000 device configuration files have been reworked to be more consistent,
 - Z-Wave JS: Ignore when a node reports Security S0/S2 CC to have version 0 (unsupported) although it is using that CC
 
 ### Config file changes
+
 - Add Shelly to manufacturers
 - Add Shelly Wave 1, Wave 2PM, update Wave 1PM association labels
 - Add Sunricher SR-ZV2833PAC
@@ -457,7 +467,7 @@ Almost 1000 device configuration files have been reworked to be more consistent,
 
 - Z-Wave JS: Fixed a regression from v11.10.1 where the controller's firmware version was not fully queried
 - Z-Wave JS: Change order of commands so the startup does not fail when a controller is already set to use 16-bit node IDs and soft-reset is disabled
-- Z-Wave JS: Soft-reset is now always enabled on 700+ series controllers 
+- Z-Wave JS: Soft-reset is now always enabled on 700+ series controllers
 - Z-Wave JS: Queried user codes and their status are now preserved during re-interview when they won't be re-queried automatically
 - Z-Wave JS: Fixed an issue where nodes were being marked as dead because the controller couldn't transmit.
 - Z-Wave JS: Fixed an issue where 700 series controllers were not soft-reset after NVM backup when soft-reset was disabled via config
@@ -475,6 +485,7 @@ Almost 1000 device configuration files have been reworked to be more consistent,
 - Correct reporting frequency parameter values for Sensative AB Strips Comfort / Drips Multisensor
 
 ### Detailed changelogs
+
 - [Bump Z-Wave JS Server to 1.31.0](https://github.com/zwave-js/zwave-js-server/releases/tag/1.31.0)
 - [Bump Z-Wave JS to 11.11.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v11.11.0)
 - [Bump Z-Wave JS to 11.12.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v11.12.0)
@@ -487,9 +498,8 @@ Almost 1000 device configuration files have been reworked to be more consistent,
 
 - Z-Wave JS: Fixed a bug where firmware links that redirected to another URL were not supported
 - Z-Wave JS: Change order of commands so the startup does not fail when a controller is already set to use 16-bit node IDs and soft-reset is disabled
-- Z-Wave JS: Soft-reset is now always enabled on 700+ series controllers 
+- Z-Wave JS: Soft-reset is now always enabled on 700+ series controllers
 - Z-Wave JS: Queried user codes and their status are now preserved during re-interview when they won't be re-queried automatically
-
 
 ### Config file changes
 
@@ -517,7 +527,6 @@ Almost 1000 device configuration files have been reworked to be more consistent,
 - Z-Wave JS: Improve heuristic to refresh values from legacy nodes when receiving a node information frame
 - Z-Wave JS: Fixed an issue where no control values were exposed for devices that do not support/advertise Version CC
 - Z-Wave JS: Fixed a regression introduced in 11.9.1 that would sometimes cause the startup process to hang
-
 
 ### Config file changes
 
@@ -555,7 +564,6 @@ Almost 1000 device configuration files have been reworked to be more consistent,
 - Z-Wave JS: Improved the automatic removal of factory-reset devices that are slow to leave the network
 - Z-Wave JS: Devices that failed to join using SmartStart are now automatically removed
 - Z-Wave JS: Fix an issue where Z-Wave JS could get stuck when removing a node from the network failed
-
 
 ### Config file changes
 

--- a/zwave_js/build.yaml
+++ b/zwave_js/build.yaml
@@ -10,4 +10,4 @@ codenotary:
   base_image: notary@home-assistant.io
 args:
   ZWAVEJS_SERVER_VERSION: 1.36.0
-  ZWAVEJS_VERSION: 12.11.1
+  ZWAVEJS_VERSION: 12.11.2

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.6.1
+version: 0.6.2
 slug: zwave_js
 name: Z-Wave JS
 description: Control a Z-Wave network with Home Assistant Z-Wave JS


### PR DESCRIPTION
This is a hotfix

### Bug fixes

- Z-Wave JS: Fixed a regression causing commands to sleeping nodes to block communication with other nodes

### Detailed changelogs

- [Z-Wave JS 12.11.2](https://github.com/zwave-js/node-zwave-js/releases/tag/v12.11.2)