### PR TITLE
whisper: Exclude Whisper model files from backups

### DIFF
--- a/whisper/CHANGELOG.md
+++ b/whisper/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.1.1
+
+- Exclude `data/models*` files from backup
+
 ## 2.1.0
 
 - Add distil-large-v3 `model` option

--- a/whisper/config.yaml
+++ b/whisper/config.yaml
@@ -11,7 +11,6 @@ init: false
 discovery:
   - wyoming
 backup_exclude:
-  - "*.bin"
   - "data/models*"
 options:
   model: tiny-int8

--- a/whisper/config.yaml
+++ b/whisper/config.yaml
@@ -12,6 +12,7 @@ discovery:
   - wyoming
 backup_exclude:
   - "*.bin"
+  - "data/models*"
 options:
   model: tiny-int8
   language: en

--- a/whisper/config.yaml
+++ b/whisper/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 2.1.0
+version: 2.1.1
 slug: whisper
 name: Whisper
 description: Speech-to-text with Whisper


### PR DESCRIPTION
Exclude large Whisper model files from backups. I'm using the faster-whisper-tiny-int8 which is ~42MB or ~34MB compressed.

This is what I see inside the add on:

```
root@core-whisper:/# ls -Rla data/models*
data/models--rhasspy--faster-whisper-tiny-int8:
total 20
drwxr-xr-x 5 root root 4096 Apr  7 05:37 .
drwxr-xr-x 4 root root 4096 May 24 13:06 ..
drwxr-xr-x 2 root root 4096 Apr  7 05:37 blobs
drwxr-xr-x 2 root root 4096 Apr  7 05:37 refs
drwxr-xr-x 3 root root 4096 Apr  7 05:37 snapshots

data/models--rhasspy--faster-whisper-tiny-int8/blobs:
total 41600
drwxr-xr-x 2 root root     4096 Apr  7 05:37 .
drwxr-xr-x 5 root root     4096 Apr  7 05:37 ..
-rw-r--r-- 1 root root 42120343 Apr  7 05:37 6fdeb89775be8b3455197e4685fec5d59ce47874de4fb8fb7724a43ea205a7b0
-rw-r--r-- 1 root root   459861 Apr  7 05:37 c9074644d9d1205686f16d411564729461324b75
-rw-r--r-- 1 root root     2020 Apr  7 05:37 e86f0ed3287af742920a8ef37577c347a1a8153b

data/models--rhasspy--faster-whisper-tiny-int8/refs:
total 12
drwxr-xr-x 2 root root 4096 Apr  7 05:37 .
drwxr-xr-x 5 root root 4096 Apr  7 05:37 ..
-rw-r--r-- 1 root root   40 May 24 13:07 main

data/models--rhasspy--faster-whisper-tiny-int8/snapshots:
total 12
drwxr-xr-x 3 root root 4096 Apr  7 05:37 .
drwxr-xr-x 5 root root 4096 Apr  7 05:37 ..
drwxr-xr-x 2 root root 4096 Apr  7 05:37 5b6382e0f4ac867ce9ff24aaa249400a7c6c73d9

data/models--rhasspy--faster-whisper-tiny-int8/snapshots/5b6382e0f4ac867ce9ff24aaa249400a7c6c73d9:
total 12
drwxr-xr-x 2 root root 4096 Apr  7 05:37 .
drwxr-xr-x 3 root root 4096 Apr  7 05:37 ..
lrwxrwxrwx 1 root root   52 Apr  7 05:37 config.json -> ../../blobs/e86f0ed3287af742920a8ef37577c347a1a8153b
lrwxrwxrwx 1 root root   76 Apr  7 05:37 model.bin -> ../../blobs/6fdeb89775be8b3455197e4685fec5d59ce47874de4fb8fb7724a43ea205a7b0
lrwxrwxrwx 1 root root   52 Apr  7 05:37 vocabulary.txt -> ../../blobs/c9074644d9d1205686f16d411564729461324b75
```

And this is what I see in the backup:


![image](https://github.com/home-assistant/addons/assets/9987465/6498515b-0d98-41da-9415-1abf314f7911)

![image](https://github.com/home-assistant/addons/assets/9987465/439d1444-de46-4440-aaec-e825862b79b3)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved the backup process by excluding certain files ("data/models*") from backups.
- **Updates**
  - Updated configuration to version 2.1.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->