### PR TITLE
letsencrypt: Add digitalocean

### DIFF
--- a/letsencrypt/CHANGELOG.md
+++ b/letsencrypt/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.0.25
+
+- Add DigitalOcean propagation-seconds support
+
 ## 5.0.24
 
 - Fix Gandi DNS support using API key

--- a/letsencrypt/config.yaml
+++ b/letsencrypt/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 5.0.24
+version: 5.0.25
 slug: letsencrypt
 name: Let's Encrypt
 description: Manage certificate from Let's Encrypt

--- a/letsencrypt/rootfs/etc/services.d/lets-encrypt/run
+++ b/letsencrypt/rootfs/etc/services.d/lets-encrypt/run
@@ -92,6 +92,11 @@ elif [ "${DNS_PROVIDER}" == "dns-cloudflare" ]; then
 
     PROVIDER_ARGUMENTS+=("--${DNS_PROVIDER}" "--${DNS_PROVIDER}-credentials" "/data/dnsapikey" "--dns-cloudflare-propagation-seconds" "${PROPAGATION_SECONDS}")
 
+# DigitalOcean
+elif [ "${CHALLENGE}" == "dns" ] && [ "${DNS_PROVIDER}" == "dns-digitalocean" ]; then
+    bashio::config.require 'dns.digitalocean_token'
+    PROVIDER_ARGUMENTS+=("--authenticator" "${DNS_PROVIDER}" "--${DNS_PROVIDER}-credentials" "/data/dnsapikey" "--${DNS_PROVIDER}-propagation-seconds" "${PROPAGATION_SECONDS}")
+
 # DirectAdmin
 elif [ "${CHALLENGE}" == "dns" ] && [ "${DNS_PROVIDER}" == "dns-directadmin" ]; then
     bashio::config.require 'dns.directadmin_url'


### PR DESCRIPTION
adding digitalocean for propagation-seconds support as 'all others' logic doesn't 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced support for DigitalOcean DNS challenge authentication for Let's Encrypt.
	- Added the ability to specify propagation delays when using DigitalOcean's DNS services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->