### PR TITLE
Adding configurability for primary_interface for python matter-server

### DIFF
--- a/matter_server/DOCS.md
+++ b/matter_server/DOCS.md
@@ -31,6 +31,7 @@ Add-on configuration:
 | Configuration      | Description                                                 |
 |--------------------|-------------------------------------------------------------|
 | log_level          | Logging level of the Matter Server component.               |
+| primary_interface  | Override auto detected primary interface (optional)         |
 
 ## Support
 

--- a/matter_server/config.yaml
+++ b/matter_server/config.yaml
@@ -24,10 +24,12 @@ options:
   log_level: info
   log_level_sdk: error
   beta: false
+  primary_interface: ""
 schema:
   log_level: list(verbose|debug|info|warning|error|critical)
   log_level_sdk: list(automation|detail|progress|error|none)?
   beta: bool?
+  primary_interface: str?
 ports:
   5580/tcp: null
 stage: stable

--- a/matter_server/config.yaml
+++ b/matter_server/config.yaml
@@ -24,7 +24,6 @@ options:
   log_level: info
   log_level_sdk: error
   beta: false
-  primary_interface: ""
 schema:
   log_level: list(verbose|debug|info|warning|error|critical)
   log_level_sdk: list(automation|detail|progress|error|none)?

--- a/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
+++ b/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
@@ -30,7 +30,13 @@ if ! bashio::var.has_value "${server_port}"; then
     extra_args+=('--listen-address' "$(bashio::addon.ip_address)")
 fi
 
-primary_interface="$(bashio::api.supervisor 'GET' '/network/info' '' 'first(.interfaces[] | select (.primary == true)) .interface')"
+if ! bashio::config.exists primary_interface; then
+  bashio::log.magenta 'No primary_interface set in config, fallback to using supervisor primary interface'
+  primary_interface="$(bashio::api.supervisor 'GET' '/network/info' '' 'first(.interfaces[] | select (.primary == true)) .interface')"
+else
+  primary_interface=$(bashio::string.lower "$(bashio::config primary_interface)")
+  bashio::log.magenta "primary_interface set in config to ${primary_interface}"
+fi
 
 # Try fallback method (e.g. in case NetworkManager is not available)
 if [ -z ${primary_interface} ]; then

--- a/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
+++ b/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
@@ -30,12 +30,12 @@ if ! bashio::var.has_value "${server_port}"; then
     extra_args+=('--listen-address' "$(bashio::addon.ip_address)")
 fi
 
-if ! bashio::config.exists primary_interface; then
-  bashio::log.magenta 'No primary_interface set in config, fallback to using supervisor primary interface'
+if ! bashio::config.exists primary_interface || [ -z $(bashio::config primary_interface) ]; then
+  bashio::log.info 'No primary_interface set in config, fallback to using supervisor primary interface'
   primary_interface="$(bashio::api.supervisor 'GET' '/network/info' '' 'first(.interfaces[] | select (.primary == true)) .interface')"
 else
   primary_interface=$(bashio::string.lower "$(bashio::config primary_interface)")
-  bashio::log.magenta "primary_interface set in config to ${primary_interface}"
+  bashio::log.info "primary_interface set in config to ${primary_interface}"
 fi
 
 # Try fallback method (e.g. in case NetworkManager is not available)

--- a/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
+++ b/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
@@ -36,6 +36,10 @@ if ! bashio::config.exists primary_interface || [ -z $(bashio::config primary_in
 else
   primary_interface=$(bashio::string.lower "$(bashio::config primary_interface)")
   bashio::log.info "primary_interface set in config to ${primary_interface}"
+  if ! ip ad ls dev ${primary_interface} > /dev/null ; then
+    bashio::log.warning 'Specified interface does not exist. Falling back to supervisor primary interface'
+    primary_interface="$(bashio::api.supervisor 'GET' '/network/info' '' 'first(.interfaces[] | select (.primary == true)) .interface')"
+  fi
 fi
 
 # Try fallback method (e.g. in case NetworkManager is not available)

--- a/matter_server/translations/en.yaml
+++ b/matter_server/translations/en.yaml
@@ -11,5 +11,8 @@ configuration:
     description: >-
       Installs the latest beta of the Python Matter Server. It is recommended
       to create a backup before starting the add-on with this flag enabled!
+  primary_interface:
+    name: Primary network interface
+    description: Override for the name of the network interface to use
 network:
   5580/tcp: Matter Server WebSocket server port.


### PR DESCRIPTION
I have tested this in my own environment where I have an end0.9 VLAN interface. I've tested that I can now pair matter devices on this VLAN (which is connected to my guest WiFi network) through the home assistant android app and subsequently control these matter devices.

Fixes: #3619

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `primary_interface` configuration option to allow users to specify the primary network interface, enhancing network settings customization.

- **Improvements**
  - Introduced conditional logic to set `primary_interface` based on user configuration, with fallback to supervisor's primary interface.
  - Added log messages for better visibility into interface configuration and fallback processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->