### PR TITLE
Add config to silabs multiprotocol for infra interface

### DIFF
--- a/silabs-multiprotocol/config.yaml
+++ b/silabs-multiprotocol/config.yaml
@@ -50,5 +50,6 @@ schema:
   otbr_enable: bool
   otbr_log_level: list(debug|info|notice|warning|error|critical|alert|emergency)
   otbr_firewall: bool
+  backbone_if: str?
 stage: experimental
 startup: services

--- a/silabs-multiprotocol/rootfs/etc/s6-overlay/s6-rc.d/otbr-agent/run
+++ b/silabs-multiprotocol/rootfs/etc/s6-overlay/s6-rc.d/otbr-agent/run
@@ -14,7 +14,17 @@ declare otbr_log_level_int
 declare otbr_rest_listen
 declare otbr_rest_listen_port
 
-backbone_if="$(bashio::api.supervisor 'GET' '/network/info' '' 'first(.interfaces[] | select (.primary == true)) .interface')"
+if ! bashio::config.exists backbone_if || [ -z $(bashio::config backbone_if) ]; then
+  bashio::log.info 'No backbone_if set in config, fallback to using supervisor primary interface'
+  backbone_if="$(bashio::api.supervisor 'GET' '/network/info' '' 'first(.interfaces[] | select (.primary == true)) .interface')"
+else
+  backbone_if=$(bashio::string.lower "$(bashio::config backbone_if)")
+  bashio::log.info "primary_interface set in config to ${backbone_if}"
+  if ! ip ad ls dev ${backbone_if} > /dev/null ; then
+    bashio::log.warning 'Specified interface does not exist. Falling back to supervisor primary interface'
+    backbone_if="$(bashio::api.supervisor 'GET' '/network/info' '' 'first(.interfaces[] | select (.primary == true)) .interface')"
+  fi
+fi
 
 otbr_log_level=$(bashio::string.lower "$(bashio::config otbr_log_level)")
 case "${otbr_log_level}" in

--- a/silabs-multiprotocol/translations/en.yaml
+++ b/silabs-multiprotocol/translations/en.yaml
@@ -34,6 +34,11 @@ configuration:
     name: OTBR firewall
     description: >-
       Use OpenThread Border Router firewall to block unnecessary traffic.
+  backbone_if:
+    name: Backbone Interface
+    description: >-
+      Used to override the ethernet interface where WiFi Matter traffic runs.
+      (optional)
 network:
   9999/tcp: EmberZNet EZSP/ASH port
   8080/tcp: OpenThread Web port


### PR DESCRIPTION
This configuration option allows the user to specify a different interface where the matter ethernet is running. This is useful in cases where you have matter WiFi running on a different vlan (e.g., end0.9).

I've tested this with a corresponding change in python matter server. By switching the python matter server to end0.9 and this change to end0.9, matter devices are able to join a guest WiFi network (on vlan 9) and thread devices are able to communicate correctly onto the same VLAN through this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new optional `backbone_if` field in the configuration schema for specifying the Backbone Interface.

- **Improvements**
  - Enhanced configuration handling to validate and set the `backbone_if` interface, with fallback to the primary interface if not specified or invalid.
  
- **Documentation**
  - Updated English translations to include descriptions for the new `backbone_if` configuration and modified existing descriptions for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->