### PR TITLE
openthread_border_router: Deassert DTR/RTS lines for USB devices using these for BSL

### DIFF
--- a/openthread_border_router/0004-Deassert-DTR-and-RTS-if-flow-control-is-disabled.patch
+++ b/openthread_border_router/0004-Deassert-DTR-and-RTS-if-flow-control-is-disabled.patch
@@ -1,0 +1,40 @@
+From b5adc7fb59939a5054e2e2d301b26b5132254262 Mon Sep 17 00:00:00 2001
+From: Tim Lunn <tl@smlight.tech>
+Date: Mon, 1 Jul 2024 14:27:40 +1000
+Subject: [PATCH] Deassert DTR and RTS if flow control is disabled
+
+Many USB radio devices (particularly those based on TI CC2652) have
+reset and bootloader activation directly connected to DTR/RTS lines.
+These devices will fail to start, in the default state where both
+DTR/RTS are asserted on connection.
+
+This patch ensures flow control is disabled and both DTR and RTS are
+deasserted on startup while configuring the terminal.
+---
+ src/posix/platform/hdlc_interface.cpp | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/src/posix/platform/hdlc_interface.cpp b/src/posix/platform/hdlc_interface.cpp
+index 12726fc72..056224786 100644
+--- a/src/posix/platform/hdlc_interface.cpp
++++ b/src/posix/platform/hdlc_interface.cpp
+@@ -600,6 +600,16 @@ int HdlcInterface::OpenFile(const Url::Url &aRadioUrl)
+         {
+             tios.c_cflag |= CRTSCTS;
+         }
++        else
++        {
++            tios.c_cflag &= ~(CRTSCTS);
++
++            // Deassert DTR and RTS
++            int flags;
++            VerifyOrExit((ioctl(fd, TIOCMGET, &flags)) != -1, perror("tiocmget"));
++            flags &= ~(TIOCM_DTR | TIOCM_RTS);
++            VerifyOrExit((ioctl(fd, TIOCMSET, &flags)) != -1, perror("tiocmset"));
++        }
+ 
+         VerifyOrExit((rval = cfsetspeed(&tios, static_cast<speed_t>(speed))) == 0, perror("cfsetspeed"));
+         rval = tcsetattr(fd, TCSANOW, &tios);
+-- 
+2.43.0
+

--- a/openthread_border_router/CHANGELOG.md
+++ b/openthread_border_router/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.9.0
+
+- Deassert DTR/RTS lines for USB devices using these for BSL
+
 ## 2.8.0
 
 - Bump to OTBR POSIX version 41474ce29a (2024-06-21 08:41:31 -0700)
@@ -15,6 +19,7 @@
 - Add support for network sockets using socat
 
 ## 2.5.1
+
 - Support Home Assistant Connect ZBT-1.
 
 ## 2.5.0

--- a/openthread_border_router/CHANGELOG.md
+++ b/openthread_border_router/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.9.0
 
-- Deassert DTR/RTS lines for USB devices using these for BSL
+- Avoid triggering reset/boot loader on TI CC2652 based devices
 
 ## 2.8.0
 

--- a/openthread_border_router/Dockerfile
+++ b/openthread_border_router/Dockerfile
@@ -20,7 +20,7 @@ COPY 0002-rest-support-deleting-the-dataset.patch /usr/src
 COPY 0003-openthread-set-netif-route-metric-lower.patch /usr/src
 COPY 0001-channel-monitor-disable-by-default.patch /usr/src
 COPY 0002-posix-fix-build-with-custom-netif-prefix-route-set.patch /usr/src
-
+COPY 0004-Deassert-DTR-and-RTS-if-flow-control-is-disabled.patch /usr/src
 # Required and installed (script/bootstrap) can be removed after build
 ENV OTBR_BUILD_DEPS build-essential ninja-build cmake wget ca-certificates \
   libreadline-dev libncurses-dev libcpputest-dev libdbus-1-dev libavahi-common-dev \
@@ -61,6 +61,7 @@ RUN \
         cd third_party/openthread/repo \
         && patch -p1 < /usr/src/0001-channel-monitor-disable-by-default.patch \
         && patch -p1 < /usr/src/0002-posix-fix-build-with-custom-netif-prefix-route-set.patch \
+        && patch -p1 < /usr/src/0004-Deassert-DTR-and-RTS-if-flow-control-is-disabled.patch \
        ) \
     # Mimic rt_tables_install \
     && echo "88 openthread" >> /etc/iproute2/rt_tables \

--- a/openthread_border_router/config.yaml
+++ b/openthread_border_router/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 2.8.0
+version: 2.9.0
 slug: openthread_border_router
 name: OpenThread Border Router
 description: OpenThread Border Router add-on


### PR DESCRIPTION
It seems most USB devices based on TI CC2652 (except for ZBDongle-P which is not affected) have `DTR` and `RTS` lines directly connected to the `reset` and `bootloader activation` pins.  For these devices if these lines are asserted at startup then these devices fail to startup as they are in a stuck state.

This patch ensures both DTR and RTS are deasserted on startup for devices where hw flow control has been disabled. Over in Zigbee land, both zigpy and zigbee-herdsmen must be doing the same, as the dongles work without issues in both ZHA and Zigbee2MQTT.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved startup reliability for USB radio devices by ensuring DTR and RTS lines are deasserted when flow control is disabled.
- **Version Update**
	- Updated the version number to 2.9.0.
- **Documentation**
	- Added details of the new patch and its impact in the changelog.
- **Configuration**
	- Incorporated the new patch file into the Dockerfile.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->