### PR TITLE
whisper: Actually exclude Whisper model files from backups

### DIFF
--- a/whisper/CHANGELOG.md
+++ b/whisper/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.1.2
+
+- Fix excluding models files from backup
+
 ## 2.1.1
 
 - Exclude `data/models*` files from backup

--- a/whisper/config.yaml
+++ b/whisper/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 2.1.1
+version: 2.1.2
 slug: whisper
 name: Whisper
 description: Speech-to-text with Whisper
@@ -11,7 +11,7 @@ init: false
 discovery:
   - wyoming
 backup_exclude:
-  - "data/models*"
+  - "models*"
 options:
   model: tiny-int8
   language: en


### PR DESCRIPTION
Previous attempt at https://github.com/home-assistant/addons/pull/3658 didn't work
This time I verified this works via a local addon using this config.yaml but with the 2.1.1 version so that I can pull the existing docker image.

Fixes https://github.com/home-assistant/addons/issues/3598

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the exclusion pattern for model files in the backup configuration. Model files will now be properly excluded from backups, ensuring more efficient backup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->