### PR TITLE
matter_server: Bump Python Matter server to 6.2.1

### DIFF
--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.2.0
+
+- Bump Python Matter Server to [6.2.0](https://github.com/home-assistant-libs/python-matter-server/releases/tag/6.2.0)
+
 ## 6.1.2
 
 - Bump Python Matter Server to [6.1.2](https://github.com/home-assistant-libs/python-matter-server/releases/tag/6.1.2)

--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## 6.2.0
+## 6.2.1
 
-- Bump Python Matter Server to [6.2.0](https://github.com/home-assistant-libs/python-matter-server/releases/tag/6.2.0)
+- Bump Python Matter Server to [6.2.1](https://github.com/home-assistant-libs/python-matter-server/releases/tag/6.2.1)
 
 ## 6.1.2
 

--- a/matter_server/DOCS.md
+++ b/matter_server/DOCS.md
@@ -28,9 +28,12 @@ Matter Server WebSocket server port field.
 
 Add-on configuration:
 
-| Configuration      | Description                                                 |
-|--------------------|-------------------------------------------------------------|
-| log_level          | Logging level of the Matter Server component.               |
+| Configuration       | Description                                                 |
+|---------------------|-------------------------------------------------------------|
+| log_level           | Logging level of the Matter Server component.               |
+| log_level_sdk       | Logging level for Matter SDK logs.                          |
+| beta                | Whether to install the latest beta version on startup       |
+| enable_test_net_dcl | Enable test-net DCL for PAA root certificates and other device information. |
 
 ## Support
 

--- a/matter_server/build.yaml
+++ b/matter_server/build.yaml
@@ -1,7 +1,7 @@
 ---
 build_from:
-  aarch64: ghcr.io/home-assistant-libs/python-matter-server:6.1.2
-  amd64: ghcr.io/home-assistant-libs/python-matter-server:6.1.2
+  aarch64: ghcr.io/home-assistant-libs/python-matter-server:6.2.0
+  amd64: ghcr.io/home-assistant-libs/python-matter-server:6.2.0
 args:
   BASHIO_VERSION: 0.14.3
   TEMPIO_VERSION: 2021.09.0

--- a/matter_server/build.yaml
+++ b/matter_server/build.yaml
@@ -1,7 +1,7 @@
 ---
 build_from:
-  aarch64: ghcr.io/home-assistant-libs/python-matter-server:6.2.0
-  amd64: ghcr.io/home-assistant-libs/python-matter-server:6.2.0
+  aarch64: ghcr.io/home-assistant-libs/python-matter-server:6.2.1
+  amd64: ghcr.io/home-assistant-libs/python-matter-server:6.2.1
 args:
   BASHIO_VERSION: 0.14.3
   TEMPIO_VERSION: 2021.09.0

--- a/matter_server/config.yaml
+++ b/matter_server/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 6.1.2
+version: 6.2.0
 slug: matter_server
 name: Matter Server
 description: Matter WebSocket Server for Home Assistant Matter support.
@@ -24,10 +24,12 @@ options:
   log_level: info
   log_level_sdk: error
   beta: false
+  enable_test_net_dcl: false
 schema:
   log_level: list(verbose|debug|info|warning|error|critical)
   log_level_sdk: list(automation|detail|progress|error|none)?
   beta: bool?
+  enable_test_net_dcl: bool?
 ports:
   5580/tcp: null
 stage: stable

--- a/matter_server/config.yaml
+++ b/matter_server/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 6.2.0
+version: 6.2.1
 slug: matter_server
 name: Matter Server
 description: Matter WebSocket Server for Home Assistant Matter support.

--- a/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
+++ b/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
@@ -30,6 +30,10 @@ if ! bashio::var.has_value "${server_port}"; then
     extra_args+=('--listen-address' "$(bashio::addon.ip_address)")
 fi
 
+if bashio::config.true "enable_test_net_dcl"; then
+    extra_args+=('--enable-test-net-dcl')
+fi
+
 primary_interface="$(bashio::api.supervisor 'GET' '/network/info' '' 'first(.interfaces[] | select (.primary == true)) .interface')"
 
 # Try fallback method (e.g. in case NetworkManager is not available)

--- a/matter_server/translations/en.yaml
+++ b/matter_server/translations/en.yaml
@@ -11,5 +11,10 @@ configuration:
     description: >-
       Installs the latest beta of the Python Matter Server. It is recommended
       to create a backup before starting the add-on with this flag enabled!
+  enable_test_net_dcl:
+    name: Enable test-net DCL usage.
+    description: >-
+      Enable PAA root certificates and other device information from test-net
+      DCL. This is meant for development and testing purposes.
 network:
   5580/tcp: Matter Server WebSocket server port.


### PR DESCRIPTION
Bump Python Matter Server to [6.2.1](https://github.com/home-assistant-libs/python-matter-server/releases/tag/6.2.1)

This adds a new configuration option enable_test_net_dcl which enables PAA root certificates and other device information from test-net DCL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded logging capabilities with new `log_level_sdk` option.
  - Introduced `beta` option to install the latest beta version on startup.
  - Added `enable_test_net_dcl` option to use test-net DCL for development and testing.

- **Chores**
  - Bumped version of Python Matter Server to `6.2.1`.
  - Updated image versions for `aarch64` and `amd64` architectures in build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->