### PR TITLE
Update file-structure.sh

### DIFF
--- a/letsencrypt/rootfs/etc/cont-init.d/file-structure.sh
+++ b/letsencrypt/rootfs/etc/cont-init.d/file-structure.sh
@@ -49,7 +49,6 @@ echo -e "dns_desec_token = $(bashio::config 'dns.desec_token')\n" \
       "aws_secret_access_key = $(bashio::config 'dns.aws_secret_access_key')\n" \
       "dns_sakuracloud_api_token = $(bashio::config 'dns.sakuracloud_api_token')\n" \
       "dns_sakuracloud_api_secret = $(bashio::config 'dns.sakuracloud_api_secret')\n" \
-      "dns_gandi_api_key = $(bashio::config 'dns.gandi_api_key')\n" \
       "dns_transip_username = $(bashio::config 'dns.transip_username')\n" \
       "dns_transip_key_file = /data/transip-rsa.key\n" \
       "dns_inwx_url = https://api.domrobot.com/xmlrpc/\n" \


### PR DESCRIPTION
Do not add dns_gandi_api_key to /data/dnsapikey, as this is added by /etc/services.d/lets-encrypt/run too. Adding it twice makes certbot fail with
Error parsing credentials configuration '/data/dnsapikey': Duplicate keyword name at line 60.