### PR TITLE
matter_server: Bump Python Matter server to 6.3.0

### DIFF
--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.3.0
+
+- Bump Python Matter Server to [6.3.0](https://github.com/home-assistant-libs/python-matter-server/releases/tag/6.3.0)
+
 ## 6.2.1
 
 - Bump Python Matter Server to [6.2.1](https://github.com/home-assistant-libs/python-matter-server/releases/tag/6.2.1)

--- a/matter_server/DOCS.md
+++ b/matter_server/DOCS.md
@@ -34,6 +34,7 @@ Add-on configuration:
 | log_level_sdk       | Logging level for Matter SDK logs.                          |
 | beta                | Whether to install the latest beta version on startup       |
 | enable_test_net_dcl | Enable test-net DCL for PAA root certificates and other device information. |
+| bluetooth_adapter_id | Set BlueZ Bluetooth Controller ID (for local commissioning) |
 
 ## Support
 

--- a/matter_server/build.yaml
+++ b/matter_server/build.yaml
@@ -1,7 +1,7 @@
 ---
 build_from:
-  aarch64: ghcr.io/home-assistant-libs/python-matter-server:6.2.1
-  amd64: ghcr.io/home-assistant-libs/python-matter-server:6.2.1
+  aarch64: ghcr.io/home-assistant-libs/python-matter-server:6.3.0
+  amd64: ghcr.io/home-assistant-libs/python-matter-server:6.3.0
 args:
   BASHIO_VERSION: 0.14.3
   TEMPIO_VERSION: 2021.09.0

--- a/matter_server/config.yaml
+++ b/matter_server/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 6.2.1
+version: 6.3.0
 slug: matter_server
 name: Matter Server
 description: Matter WebSocket Server for Home Assistant Matter support.
@@ -30,6 +30,7 @@ schema:
   log_level_sdk: list(automation|detail|progress|error|none)?
   beta: bool?
   enable_test_net_dcl: bool?
+  bluetooth_adapter_id: int?
 ports:
   5580/tcp: null
 stage: stable

--- a/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
+++ b/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
@@ -46,6 +46,10 @@ if [ -z ${primary_interface} ] || [ ${primary_interface} == "null" ]; then
     bashio::exit.nok "No primary network interface found!"
 fi
 
+if bashio::config.has_value "bluetooth_adapter_id"; then
+  extra_args+=('--bluetooth-adapter' $(bashio::config 'bluetooth_adapter_id'))
+fi
+
 bashio::log.info "Using '${primary_interface}' as primary network interface."
 
 # Send out discovery information to Home Assistant

--- a/matter_server/translations/en.yaml
+++ b/matter_server/translations/en.yaml
@@ -16,5 +16,13 @@ configuration:
     description: >-
       Enable PAA root certificates and other device information from test-net
       DCL. This is meant for development and testing purposes.
+  bluetooth_adapter_id:
+    name: Bluetooth Adapter ID
+    description: >-
+      BlueZ Bluetooth Adapter Controller ID used by the Matter Server. This is
+      required if local commissioning via Bluetooth is used. Note: Using the
+      Home Assistant Companion app commissioning method is recommended as it is
+      better tested and allows to commission directly in proximity of the device
+      itself.
 network:
   5580/tcp: Matter Server WebSocket server port.


### PR DESCRIPTION
Update to the lastest Python Matter server. This makes sure that the OTA Provider update binary is already part of the add-on so that updates can be tested in the upcomming beta phase.

This also adds an option to set the Bluetooth adapter, which is useful to test local commissioning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new configuration option `bluetooth_adapter_id` for setting the BlueZ Bluetooth Controller ID.
  
- **Documentation**
  - Updated changelog to include version `6.3.0` with links to the release on GitHub.
  - Added documentation for the new `bluetooth_adapter_id` configuration option.

- **Bug Fixes**
  - Enhanced script functionality to check for Bluetooth adapter ID and log primary network interface usage.

- **Version Updates**
  - Updated Python Matter Server to version `6.3.0` in various files and configurations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->