### PR TITLE
Fix Matter SDK logging level when beta flag is set

### DIFF
--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.3.1
+
+- Fix Matter SDK log level when using beta flag
+
 ## 6.3.0
 
 - Bump Python Matter Server to [6.3.0](https://github.com/home-assistant-libs/python-matter-server/releases/tag/6.3.0)

--- a/matter_server/config.yaml
+++ b/matter_server/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 6.3.0
+version: 6.3.1
 slug: matter_server
 name: Matter Server
 description: Matter WebSocket Server for Home Assistant Matter support.

--- a/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
+++ b/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
@@ -8,6 +8,7 @@ declare server_port
 declare log_level
 declare log_level_sdk
 declare primary_interface
+matter_server_args=()
 extra_args=()
 
 if ! bashio::config.exists log_level; then
@@ -57,16 +58,21 @@ bashio::log.info "Using '${primary_interface}' as primary network interface."
 
 cd /root
 
+matter_server_args+=(
+  '--storage-path' "/data"
+  '--port' "${server_port}"
+  '--log-level' "${log_level}"
+  '--log-level-sdk' "${log_level_sdk}"
+  '--primary-interface' "${primary_interface}"
+  '--paa-root-cert-dir' "/data/credentials"
+  '--fabricid' 2
+  '--vendorid' 4939
+  ${extra_args[@]}
+)
+
 if bashio::config.true "beta"; then
     exec /usr/bin/gdb --quiet -ex="set confirm off" -ex run -ex backtrace -ex "quit \$_exitcode" --args /usr/local/bin/python \
-         /usr/local/bin/matter-server --storage-path "/data" --port "${server_port}" \
-                       --log-level "${log_level}" --primary-interface "${primary_interface}" \
-                       --paa-root-cert-dir "/data/credentials" \
-                       --fabricid 2 --vendorid 4939 "${extra_args[@]}"
+         /usr/local/bin/matter-server "${matter_server_args[@]}"
 else
-    exec /usr/local/bin/matter-server --storage-path "/data" --port "${server_port}" \
-                       --log-level "${log_level}" --log-level-sdk "${log_level_sdk}" \
-                       --primary-interface "${primary_interface}" \
-                       --paa-root-cert-dir "/data/credentials" \
-                       --fabricid 2 --vendorid 4939 "${extra_args[@]}"
+    exec /usr/local/bin/matter-server "${matter_server_args[@]}"
 fi


### PR DESCRIPTION
Make sure that the Matter SDK logging level is passed to the Matter Sever when the beta flag is set too.

While at it, extract all server flags into it's own variable to avoid duplicating all flags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected log level handling when the beta flag is used in the Matter SDK.

- **Enhancements**
  - Simplified command execution logic for `matter-server` by dynamically building server configuration arguments.
  - Updated version in the configuration file from 6.3.0 to 6.3.1 for Matter WebSocket Server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->