### PR TITLE
Samba: correct benign idmap errors

### DIFF
--- a/samba/CHANGELOG.md
+++ b/samba/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 12.3.2
+
+- Suppress benign idmap logged error
 
 ## 12.3.1
 

--- a/samba/config.yaml
+++ b/samba/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 12.3.1
+version: 12.3.2
 slug: samba
 name: Samba share
 description: Expose Home Assistant folders with SMB/CIFS

--- a/samba/rootfs/usr/share/tempio/smb.gtpl
+++ b/samba/rootfs/usr/share/tempio/smb.gtpl
@@ -5,6 +5,8 @@
 
    security = user
    ntlm auth = yes
+   idmap config * : backend = tdb
+   idmap config * : range = 1000000-2000000
 
    load printers = no
    disable spoolss = yes


### PR DESCRIPTION
Fixes #3682.  

Adds a default idmap to the smb.conf file.  This corrects the benign error that was being added to the log for every file access via the Samba add-on.

`idmap range not specified for domain '*'`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced ID mapping capabilities with new configuration options for the Samba service.
	- Introduced a specified range for user and group ID mapping to improve management efficiency.

- **Bug Fixes**
	- Suppressed a benign error message related to ID mapping, reducing log clutter and improving user experience.

- **Chores**
	- Updated version number in the configuration file to indicate a minor release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->