### PR TITLE
matter_server: Bump Python Matter server to 6.4.0

### DIFF
--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 6.4.0
+
+- Bump Python Matter Server to [6.4.0](https://github.com/home-assistant-libs/python-matter-server/releases/tag/6.4.0)
+- Use add-on config directory as update directory
+
 ## 6.3.1
 
 - Fix Matter SDK log level when using beta flag

--- a/matter_server/config.yaml
+++ b/matter_server/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 6.3.1
+version: 6.4.0
 slug: matter_server
 name: Matter Server
 description: Matter WebSocket Server for Home Assistant Matter support.

--- a/matter_server/config.yaml
+++ b/matter_server/config.yaml
@@ -23,8 +23,6 @@ init: false
 map:
   - type: addon_config
     read_only: false
-  - type: data
-    read_only: false
 options:
   log_level: info
   log_level_sdk: error

--- a/matter_server/config.yaml
+++ b/matter_server/config.yaml
@@ -20,6 +20,11 @@ image: homeassistant/{arch}-addon-matter-server
 ingress: true
 ingress_port: 5580
 init: false
+map:
+  - type: addon_config
+    read_only: false
+  - type: data
+    read_only: false
 options:
   log_level: info
   log_level_sdk: error

--- a/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
+++ b/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
@@ -65,6 +65,7 @@ matter_server_args+=(
   '--log-level-sdk' "${log_level_sdk}"
   '--primary-interface' "${primary_interface}"
   '--paa-root-cert-dir' "/data/credentials"
+  '--ota-provider-dir' "/config/updates"
   '--fabricid' 2
   '--vendorid' 4939
   ${extra_args[@]}


### PR DESCRIPTION
Bump the Python Matter server to the latest release. Also use the add-on config directory as location for the OTA provider. This allows to see logs and provide local update files for testing and development.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Upgraded to Python Matter Server version 6.4.0, enhancing versioning and configuration management.
  - Introduced new configuration options allowing for better data type management and accessibility in server settings.
  - Added support for specifying a directory for over-the-air (OTA) updates to improve update management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->