### PR TITLE
Letsencrypt: Add External Account Binding Support

### DIFF
--- a/letsencrypt/CHANGELOG.md
+++ b/letsencrypt/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.1.0
+
+- Add external account binding support
+
 ## 5.0.27
 
 - Add Plesk DNS challenge support

--- a/letsencrypt/DOCS.md
+++ b/letsencrypt/DOCS.md
@@ -248,6 +248,18 @@ If your custom ACME server uses a certificate signed by an untrusted certificate
 
 </details>
 
+<details>
+  <summary>Set up external account binding</summary>
+
+   The ACME protocol (RFC 8555) defines an external account binding (EAB) field that ACME clients can use to access a specific account on the certificate authority (CA). Some CAs may require the client to utilize the EAB protocol to operate. You can add your EAB key ID and HMAC key through the config options `eab_kid` and `eab_hmac_key`.
+
+  ```yaml
+  eab_kid: 'key_id'
+  eab_hmac_key: 'AABBCCDD' #Base64url encoded key
+  ```
+
+</details>
+
 ## Example Configurations
 
 Note: These configuration examples are raw YAML configs. When you use UI edit

--- a/letsencrypt/config.yaml
+++ b/letsencrypt/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 5.0.27
+version: 5.1.0
 slug: letsencrypt
 name: Let's Encrypt
 description: Manage certificate from Let's Encrypt
@@ -35,6 +35,8 @@ schema:
   challenge: list(dns|http)
   acme_root_ca_cert: str?
   acme_server: url?
+  eab_kid: str?
+  eab_hmac_key: str?
   key_type: list(ecdsa|rsa)?
   elliptic_curve: list(secp256r1|secp384r1)?
   dns:

--- a/letsencrypt/rootfs/etc/services.d/lets-encrypt/run
+++ b/letsencrypt/rootfs/etc/services.d/lets-encrypt/run
@@ -7,6 +7,7 @@ WORK_DIR=/data/workdir
 PROVIDER_ARGUMENTS=()
 ACME_CUSTOM_SERVER_ARGUMENTS=()
 KEY_ARGUMENTS=()
+EAB_ARGUMENTS=()
 
 EMAIL=$(bashio::config 'email')
 DOMAINS=$(bashio::config 'domains')
@@ -16,6 +17,8 @@ CHALLENGE=$(bashio::config 'challenge')
 DNS_PROVIDER=$(bashio::config 'dns.provider')
 ACME_SERVER=$(bashio::config 'acme_server')
 ACME_ROOT_CA=$(bashio::config 'acme_root_ca_cert')
+EAB_KID=$(bashio::config 'eab_kid')
+EAB_HMAC_KEY=$(bashio::config 'eab_hmac_key')
 
 if [ "${CHALLENGE}" == "dns" ]; then
     bashio::log.info "Selected DNS Provider: ${DNS_PROVIDER}"
@@ -294,6 +297,12 @@ else
     done
 fi
 
+# Set External Account Binding
+if bashio::config.has_value 'eab_kid' ; then
+    bashio::config.require 'eab_hmac_key'
+    EAB_ARGUMENTS+=("--eab-kid" "${EAB_KID}" "--eab-hmac-key" "${EAB_HMAC_KEY}")
+fi
+
 # Generate a new certificate if necessary or expand a previous certificate if domains has changed
 if [ "$CHALLENGE" == "dns" ]; then
     certbot certonly --non-interactive --keep-until-expiring --expand \
@@ -302,7 +311,8 @@ if [ "$CHALLENGE" == "dns" ]; then
         --cert-name "${DOMAIN_ARR[1]}" "${DOMAIN_ARR[@]}" \
         --config-dir "$CERT_DIR" --work-dir "$WORK_DIR" \
         --preferred-challenges "$CHALLENGE" "${PROVIDER_ARGUMENTS[@]}" \
-        --preferred-chain "ISRG Root X1"
+        --preferred-chain "ISRG Root X1" \
+        "${EAB_ARGUMENTS[@]}"
 else
     certbot certonly --non-interactive --keep-until-expiring --expand \
         --email "$EMAIL" --agree-tos \
@@ -310,7 +320,8 @@ else
         --cert-name "${DOMAIN_ARR[1]}" "${DOMAIN_ARR[@]}" \
         --config-dir "$CERT_DIR" --work-dir "$WORK_DIR" \
         --preferred-challenges "$CHALLENGE" "${ACME_CUSTOM_SERVER_ARGUMENTS[@]}" --standalone \
-        --preferred-chain "ISRG Root X1"
+        --preferred-chain "ISRG Root X1" \
+        "${EAB_ARGUMENTS[@]}"
 fi
 
 # Get the last modified cert directory and copy the cert and private key to store


### PR DESCRIPTION
Add ACME external account binding (EAB) support.

Certbot supports EAB natively through arguments `--eab-kid` and `--eab-hmac-key`. This PR adds support for EAB by creating config options `eab_kid` and `eab_hmac_key` and integrating them while calling certbot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced support for external account binding (EAB) to enhance account management capabilities.
	- Added new configuration options for external account binding in the ACME protocol.

- **Documentation**
	- Updated documentation to include setup instructions for external account binding, enhancing user guidance.

- **Chores**
	- Incremented version number to 5.1.0 in configuration files to reflect new features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->