### PR TITLE
matter_server: Bump Python Matter server to 6.4.0 correctly

### DIFF
--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Changelog
 
-## 6.4.0
+## 6.4.1
 
 - Bump Python Matter Server to [6.4.0](https://github.com/home-assistant-libs/python-matter-server/releases/tag/6.4.0)
+
+## 6.4.0
+
 - Use add-on config directory as update directory
 
 ## 6.3.1

--- a/matter_server/build.yaml
+++ b/matter_server/build.yaml
@@ -1,7 +1,7 @@
 ---
 build_from:
-  aarch64: ghcr.io/home-assistant-libs/python-matter-server:6.3.0
-  amd64: ghcr.io/home-assistant-libs/python-matter-server:6.3.0
+  aarch64: ghcr.io/home-assistant-libs/python-matter-server:6.4.0
+  amd64: ghcr.io/home-assistant-libs/python-matter-server:6.4.0
 args:
   BASHIO_VERSION: 0.14.3
   TEMPIO_VERSION: 2021.09.0

--- a/matter_server/config.yaml
+++ b/matter_server/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 6.4.0
+version: 6.4.1
 slug: matter_server
 name: Matter Server
 description: Matter WebSocket Server for Home Assistant Matter support.


### PR DESCRIPTION
Addresses https://github.com/home-assistant/addons/pull/3706#pullrequestreview-2219693861.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated configuration directory for enhanced organization during updates.

- **Bug Fixes**
	- Incremented version from 6.4.0 to 6.4.1, likely addressing minor bugs and improving functionality.

- **Chores**
	- Updated version numbers for the `python-matter-server` images to reflect enhancements and potential new capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->