### PR TITLE
OTBR: Abort firmware flasher if network device is selected.

### DIFF
--- a/openthread_border_router/CHANGELOG.md
+++ b/openthread_border_router/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.9.1
+
+- Abort firmware flasher if network device is selected
+
 ## 2.9.0
 
 - Avoid triggering reset/boot loader on TI CC2652 based devices

--- a/openthread_border_router/config.yaml
+++ b/openthread_border_router/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 2.9.0
+version: 2.9.1
 slug: openthread_border_router
 name: OpenThread Border Router
 description: OpenThread Border Router add-on

--- a/openthread_border_router/rootfs/etc/s6-overlay/scripts/universal-silabs-flasher-up
+++ b/openthread_border_router/rootfs/etc/s6-overlay/scripts/universal-silabs-flasher-up
@@ -24,6 +24,11 @@ if bashio::config.false 'autoflash_firmware'; then
     exit 0
 fi
 
+if bashio::config.has_value 'network_device'; then
+    bashio::log.info "Network device is selected, skipping firmware flashing"
+    exit 0
+fi
+
 # Assume to run on Yellow if UART4 is mapped to ttyAMA1
 if [ -d /sys/devices/platform/soc/fe201800.serial/tty/ttyAMA1 ] && [ "${device}" == "/dev/ttyAMA1" ]; then
     bashio::log.info "Detected Home Assistant Yellow"


### PR DESCRIPTION
This is a bit of a corner case, as it would require a supported device connected and it also be selected in the otbr addon (but of course it has happened!)

If network device is selected, then we shouldn't run the flasher against that USB device. The `device` setting should be ignored if `network device` is set.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a safeguard in the firmware flashing process that aborts the operation if a network device is selected, enhancing user safety.
	
- **Version Update**
	- Version incremented from 2.9.0 to 2.9.1, reflecting a minor release with improvements and updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->