### PR TITLE
openthread_border_router: Update DOCS.md because nordic-nrf52840-dongle-install page has moved

### DIFF
--- a/openthread_border_router/DOCS.md
+++ b/openthread_border_router/DOCS.md
@@ -87,5 +87,4 @@ In case you've found a bug, please [open an issue on our GitHub][issue].
 [issue]: https://github.com/home-assistant/addons/issues
 [openthread-platforms]: https://openthread.io/platforms
 [nordic-nrf52840-dongle]: https://www.nordicsemi.com/Products/Development-hardware/nrf52840-dongle
-[nordic-nrf52840-dongle-install]: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/matter/openthread_rcp_nrf_dongle.html
-
+[nordic-nrf52840-dongle-install]: https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/protocols/thread/tools.html#configuring_a_radio_co-processor


### PR DESCRIPTION
nordic-nrf52840-dongle-install page has moved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the installation guide URL for the Nordic nRF52840 dongle to direct users to the latest Nordic Connect SDK documentation, ensuring access to current and accurate resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->