### PR TITLE
nginx_proxy: Define default for real_ip_from to make it optional

### DIFF
--- a/nginx_proxy/CHANGELOG.md
+++ b/nginx_proxy/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.10.1
+
+- Make `real_ip_from` optional through an empty default value
+
 ## 3.10.0
 
 - Supporting TCP Proxy Protocol

--- a/nginx_proxy/DOCS.md
+++ b/nginx_proxy/DOCS.md
@@ -43,7 +43,7 @@ customize:
   default: "nginx_proxy_default*.conf"
   servers: "nginx_proxy/*.conf"
 cloudflare: false
-real_ip_from:
+real_ip_from: []
 ```
 
 ### Option: `domain` (required)

--- a/nginx_proxy/config.yaml
+++ b/nginx_proxy/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 3.10.0
+version: 3.10.1
 hassio_api: true
 slug: nginx_proxy
 name: NGINX Home Assistant SSL proxy
@@ -26,6 +26,7 @@ options:
     active: false
     default: nginx_proxy_default*.conf
     servers: nginx_proxy/*.conf
+  real_ip_from: []
 ports:
   443/tcp: 443
   80/tcp: null


### PR DESCRIPTION
Unfortunately we can't make the setting truly optional, but since it is a list, we treat an empty list as not set. Set the empty list as default to avoid users requiring to create and delete a dummy real_ip_from value.

Fixes: #3726

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- The `real_ip_from` configuration directive is now optional, enhancing setup flexibility for users.
	- Introduced a new configuration option for `real_ip_from`, allowing for future IP address configurations.

- **Documentation**
	- Updated documentation to reflect the new flexible handling of the `real_ip_from` option, which can now accept multiple entries.

- **Version Update**
	- Updated to version 3.10.1, reflecting the latest enhancements and features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->