### PR TITLE
Correct CHANGELOG.md

### DIFF
--- a/letsencrypt/CHANGELOG.md
+++ b/letsencrypt/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 5.1.1
 
-- Add Simply DNS support
+- Add Simply.com DNS support
 
 ## 5.1.0
 


### PR DESCRIPTION
Brand is "Simply.com", not "Simply"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated changelog to clarify branding for the DNS support feature by changing "Simply DNS" to "Simply.com DNS." This enhances accuracy without affecting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->