### PR TITLE
Update config.yaml add port 39108

### DIFF
--- a/repository.yaml
+++ b/repository.yaml
@@ -1,0 +1,3 @@
+name: gitaday fork of addons
+url: https://github.com/gitaday/addons/
+maintainer: HomeAssistant Team <info@home-assistant.io>

--- a/ssh/config.yaml
+++ b/ssh/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 9.14.2
+version: 9.14.0
 slug: ssh
 name: Terminal & SSH
 description: Allow logging in remotely to Home Assistant using SSH

--- a/ssh/config.yaml
+++ b/ssh/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 9.14.0
+version: 9.14.2
 slug: ssh
 name: Terminal & SSH
 description: Allow logging in remotely to Home Assistant using SSH

--- a/ssh/config.yaml
+++ b/ssh/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 9.14.0
+version: 9.14.1
 slug: ssh
 name: Terminal & SSH
 description: Allow logging in remotely to Home Assistant using SSH

--- a/ssh/config.yaml
+++ b/ssh/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 9.14.1
+version: 9.14.0
 slug: ssh
 name: Terminal & SSH
 description: Allow logging in remotely to Home Assistant using SSH

--- a/ssh/config.yaml
+++ b/ssh/config.yaml
@@ -37,6 +37,7 @@ panel_icon: mdi:console
 panel_title: Terminal
 ports:
   22/tcp: null
+  39108/tcp: null
 schema:
   authorized_keys:
     - str

--- a/ssh/config.yaml
+++ b/ssh/config.yaml
@@ -37,7 +37,7 @@ panel_icon: mdi:console
 panel_title: Terminal
 ports:
   22/tcp: null
-  39108/tcp: null
+  39108/tcp: 39108
 schema:
   authorized_keys:
     - str


### PR DESCRIPTION
In my understanding exposing this port would enhance the add-on capabilities, for instance:
You could start zigbee2mqtt pointing to the new exposed port on localhost. The core_ssh docker having already a reverse ssh listing on the corresponding internal port will forward data to a remote server with a ZigBee adapter and ser2net installed. As consequence you will have only one installation of home-assistant with a set of local ZigBee devices managed by ZHA and a set of remote ZigBee devices managed with zigbee2mqtt. Cheers 🥂

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new TCP port configuration for SSH connections, allowing flexibility with an additional port option (39108/tcp).
	- Added a new metadata configuration for a forked repository, improving organization and access to addons.
- **Bug Fixes**
	- Updated the version number for the SSH configuration to reflect the latest changes (from 9.14.0 to 9.14.2).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->