### PR TITLE
matter_server: Add optional settings for development and testing

### DIFF
--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 6.4.2
 
 - Add support for custom Matter Server arguments
+- Add support to install custom Matter Server and Matter SDK (CHIP) versions
 
 ## 6.4.1
 

--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.4.2
+
+- Add support for custom Matter Server arguments
+
 ## 6.4.1
 
 - Bump Python Matter Server to [6.4.0](https://github.com/home-assistant-libs/python-matter-server/releases/tag/6.4.0)

--- a/matter_server/config.yaml
+++ b/matter_server/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 6.4.1
+version: 6.4.2
 slug: matter_server
 name: Matter Server
 description: Matter WebSocket Server for Home Assistant Matter support.
@@ -34,6 +34,8 @@ schema:
   beta: bool?
   enable_test_net_dcl: bool?
   bluetooth_adapter_id: int?
+  matter_server_args:
+    - str?
 ports:
   5580/tcp: null
 stage: stable

--- a/matter_server/config.yaml
+++ b/matter_server/config.yaml
@@ -36,6 +36,8 @@ schema:
   bluetooth_adapter_id: int?
   matter_server_args:
     - str?
+  matter_server_version: str?
+  matter_sdk_wheels_version: str?
 ports:
   5580/tcp: null
 stage: stable

--- a/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
+++ b/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
@@ -51,6 +51,10 @@ if bashio::config.has_value "bluetooth_adapter_id"; then
   extra_args+=('--bluetooth-adapter' $(bashio::config 'bluetooth_adapter_id'))
 fi
 
+if bashio::config.has_value "matter_server_args"; then
+  extra_args+=($(bashio::config 'matter_server_args'))
+fi
+
 bashio::log.info "Using '${primary_interface}' as primary network interface."
 
 # Send out discovery information to Home Assistant

--- a/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
+++ b/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
@@ -8,6 +8,8 @@ declare server_port
 declare log_level
 declare log_level_sdk
 declare primary_interface
+declare matter_server_version
+declare chip_version
 matter_server_args=()
 extra_args=()
 
@@ -19,9 +21,21 @@ log_level=$(bashio::string.lower "$(bashio::config log_level info)")
 # Make Matter SDK log level currently default to error
 log_level_sdk=$(bashio::string.lower "$(bashio::config log_level_sdk error)")
 
-if bashio::config.true "beta"; then
-    bashio::log.info 'Upgrading Python Matter Server to latest pre-release'
-    pip3 install --upgrade --pre python-matter-server[server]
+if bashio::config.has_value "matter_server_version"; then
+  matter_server_version=$(bashio::config 'matter_server_version')
+  bashio::log.info "Installing Python Matter Server ${matter_server_version}"
+  pip3 install --pre python-matter-server[server]=="${matter_server_version}"
+elif bashio::config.true "beta"; then
+  bashio::log.info 'Upgrading Python Matter Server to latest pre-release'
+  pip3 install --upgrade --pre python-matter-server[server]
+fi
+
+if bashio::config.has_value "matter_sdk_wheels_version"; then
+  chip_version=$(bashio::config 'matter_sdk_wheels_version')
+  bashio::log.info "Installing Matter SDK ${chip_version}"
+  pip3 install --pre --no-dependencies \
+    home-assistant-chip-clusters=="${chip_version}" \
+    home-assistant-chip-core=="${chip_version}"
 fi
 
 # Bind to internal hassio network only unless user requests to expose

--- a/matter_server/translations/en.yaml
+++ b/matter_server/translations/en.yaml
@@ -24,5 +24,12 @@ configuration:
       Home Assistant Companion app commissioning method is recommended as it is
       better tested and allows to commission directly in proximity of the device
       itself.
+  matter_server_args:
+    name: Extra Matter Server arguments
+    description: >-
+      This allows to pass additional command line arguments to the Python Matter
+      Server. Use `--help` to get a list of possible arguments. Note that
+      arguments are also added by the startup script controlled by other add-on
+      options.
 network:
   5580/tcp: Matter Server WebSocket server port.

--- a/matter_server/translations/en.yaml
+++ b/matter_server/translations/en.yaml
@@ -31,5 +31,16 @@ configuration:
       Server. Use `--help` to get a list of possible arguments. Note that
       arguments are also added by the startup script controlled by other add-on
       options.
+  matter_server_version:
+    name: Matter Server version
+    description: >-
+      Install custom Matter Server version. WARNING: An older version might have
+      an incompatible storage format! Use this feature with cauption! Make sure
+      you have a recent backup of the add-on!
+  matter_sdk_wheels_version:
+    name: Matter SDK wheels version
+    description: >-
+      Install custom Matter SDK wheels version. NOTE: The API might not be
+      compatible with the Python Matter server.
 network:
   5580/tcp: Matter Server WebSocket server port.

--- a/matter_server/translations/en.yaml
+++ b/matter_server/translations/en.yaml
@@ -35,7 +35,7 @@ configuration:
     name: Matter Server version
     description: >-
       Install custom Matter Server version. WARNING: An older version might have
-      an incompatible storage format! Use this feature with cauption! Make sure
+      an incompatible storage format! Use this feature with caution! Make sure
       you have a recent backup of the add-on!
   matter_sdk_wheels_version:
     name: Matter SDK wheels version


### PR DESCRIPTION
This adds three new options:

- An optional configuration to pass additional command line arguments to the Matter Server. This is useful for not commonly used settings (e.g. for testing and debugging) which we don't want to expose as actual add-on configuration.
- Add an option to install a custom Matter Server. This is an extension to the existing beta flag, but instead of simply allowing the latest version, a version can be specified.
- Add an option to install a custom Matter SDK (CHIP wheels) version




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced support for custom Matter Server arguments.
	- Added capability to install custom versions of the Matter Server and the Matter SDK.
	- Enhanced configuration options for specifying server and SDK versions.

- **Documentation**
	- Updated translations to include descriptions for new configuration options: `matter_server_args`, `matter_server_version`, and `matter_sdk_wheels_version`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->