### PR TITLE
matter_server: Bump Python Matter server to 6.5.0

### DIFF
--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.5.0
+
+- Bump Python Matter Server to [6.5.0](https://github.com/home-assistant-libs/python-matter-server/releases/tag/6.5.0)
+
 ## 6.4.2
 
 - Add support for custom Matter Server arguments

--- a/matter_server/build.yaml
+++ b/matter_server/build.yaml
@@ -1,7 +1,7 @@
 ---
 build_from:
-  aarch64: ghcr.io/home-assistant-libs/python-matter-server:6.4.0
-  amd64: ghcr.io/home-assistant-libs/python-matter-server:6.4.0
+  aarch64: ghcr.io/home-assistant-libs/python-matter-server:6.5.0
+  amd64: ghcr.io/home-assistant-libs/python-matter-server:6.5.0
 args:
   BASHIO_VERSION: 0.14.3
   TEMPIO_VERSION: 2021.09.0

--- a/matter_server/config.yaml
+++ b/matter_server/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 6.4.2
+version: 6.5.0
 slug: matter_server
 name: Matter Server
 description: Matter WebSocket Server for Home Assistant Matter support.


### PR DESCRIPTION
Update to the lastest Python Matter server. This especially adds some fixes around subscription recovery, making sure subscriptions get setup correctly even if a first attempt fails.

It also includes new custom attributes for Eve Weather.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Upgraded to Python Matter Server version 6.5.0, which may include new features, bug fixes, and performance improvements.
- **Documentation**
	- Updated changelog to reflect the new version entry for 6.5.0.
- **Chores**
	- Updated version numbers in configuration and build files to ensure consistency across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->