### PR TITLE
matter_server: Bump Python Matter server to 6.5.1

### DIFF
--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.5.1
+
+- Bump Python Matter Server to [6.5.1](https://github.com/home-assistant-libs/python-matter-server/releases/tag/6.5.1)
+
 ## 6.5.0
 
 - Bump Python Matter Server to [6.5.0](https://github.com/home-assistant-libs/python-matter-server/releases/tag/6.5.0)

--- a/matter_server/build.yaml
+++ b/matter_server/build.yaml
@@ -1,7 +1,7 @@
 ---
 build_from:
-  aarch64: ghcr.io/home-assistant-libs/python-matter-server:6.5.0
-  amd64: ghcr.io/home-assistant-libs/python-matter-server:6.5.0
+  aarch64: ghcr.io/home-assistant-libs/python-matter-server:6.5.1
+  amd64: ghcr.io/home-assistant-libs/python-matter-server:6.5.1
 args:
   BASHIO_VERSION: 0.14.3
   TEMPIO_VERSION: 2021.09.0

--- a/matter_server/config.yaml
+++ b/matter_server/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 6.5.0
+version: 6.5.1
 slug: matter_server
 name: Matter Server
 description: Matter WebSocket Server for Home Assistant Matter support.


### PR DESCRIPTION
Update to the lastest Python Matter server. This mainly cleans up some older work arounds for discovery issues we had in place, which should no longer be required.

There are also some bugfixes and improvements for Matter device updates in this release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated to Python Matter Server version 6.5.1, which may include bug fixes, performance improvements, and minor enhancements.

- **Documentation**
	- Changelog updated to reflect the new version entry for 6.5.1, including a link to the release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->