### PR TITLE
Fix zwave_js soft reset option

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.7.1
+
+### Bug fixes
+
+- - Add-On: Fix the soft reset driver option that was moved in driver v.13.
+
 ## 0.7.0
 
 ### Features

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-- - Add-On: Fix the soft reset driver option that was moved in driver v.13.
+- Add-on: Fix the soft reset driver option that was moved in driver v.13.
 
 ## 0.7.0
 

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.7.0
+version: 0.7.1
 slug: zwave_js
 name: Z-Wave JS
 description: Control a Z-Wave network with Home Assistant Z-Wave JS

--- a/zwave_js/rootfs/usr/share/tempio/zwave_config.conf
+++ b/zwave_js/rootfs/usr/share/tempio/zwave_config.conf
@@ -21,6 +21,9 @@
         "S2_AccessControl": "{{ .lr_s2_access_control }}",
         "S2_Authenticated": "{{ .lr_s2_authenticated }}"
     },
-    "enableSoftReset": {{ .soft_reset }},
+    "features": {
+        "softReset": {{ .soft_reset }}
+    },
     "presets": {{ .presets }}
 }
+§

--- a/zwave_js/rootfs/usr/share/tempio/zwave_config.conf
+++ b/zwave_js/rootfs/usr/share/tempio/zwave_config.conf
@@ -26,4 +26,3 @@
     },
     "presets": {{ .presets }}
 }
-§


### PR DESCRIPTION
- In 0.7.0 we missed that the soft reset driver option was moved in driver v.13. Fix that.
- https://zwave-js.github.io/node-zwave-js/#/getting-started/migrating/v13?id=removed-deprecated-things