### PR TITLE
Bump Z-Wave JS to 13.3.1

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.7.2
+
+### Bug fixes
+
+- Z-Wave JS: Fixed the identification of the primary controller role on some older controllers
+- Z-Wave JS: Fixed an issue where passing a custom log transport to updateOptions would cause a call stack overflow
+- Z-Wave JS: Implement deserialization for more WindowCoveringCC commands to be used in mocks
+
+### Config file changes
+
+- Add Philio Technology Smart Keypad
+- Add LED indication parameter for Inovelli NZW31 dimmer
+
+### Detailed changelogs
+
+- [Z-Wave JS 13.3.1](https://github.com/zwave-js/node-zwave-js/releases/tag/v13.3.1)
+
 ## 0.7.1
 
 ### Bug fixes
@@ -28,7 +45,7 @@
 
 ### Bug fixes
 
-- Fix missing values in endpoint dump
+- Z-Wave JS: Fix missing values in endpoint dump
 - Z-Wave JS: Preserve granted security classes of provisioning entries when switching protocols
 - Z-Wave JS: Version of Humidity Control Mode CC is 1, not 2
 - Z-Wave JS: Abort S2 bootstrapping when KEXSetEcho has reserved bits set

--- a/zwave_js/build.yaml
+++ b/zwave_js/build.yaml
@@ -10,4 +10,4 @@ codenotary:
   base_image: notary@home-assistant.io
 args:
   ZWAVEJS_SERVER_VERSION: 1.38.0
-  ZWAVEJS_VERSION: 13.3.0
+  ZWAVEJS_VERSION: 13.3.1

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.7.1
+version: 0.7.2
 slug: zwave_js
 name: Z-Wave JS
 description: Control a Z-Wave network with Home Assistant Z-Wave JS


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for Philio Technology Smart Keypad.
	- Introduced a new LED indication parameter for Inovelli NZW31 dimmer.
- **Bug Fixes**
	- Corrected primary controller role identification for older controllers.
	- Resolved a critical call stack overflow issue with custom log transport.
	- Enhanced deserialization for additional WindowCoveringCC commands.
- **Version Updates**
	- Updated Z-Wave JS component version to 13.3.1.
	- Incremented configuration file version to 0.7.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

fixes: https://github.com/home-assistant/core/issues/125843