### PR TITLE
Bump zwave-js to 13.9.0 and add watchdog configuration option

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Features
 
-- Add-On: Add `disable_watchdog` configuration option. When enabled, the driver will not enable the hardware watchdog of the Z-Wave controller. This is an advanced configuration option that should not be adjusted in most cases and is therefore hidden from the default view.
+- Add-on: Add `disable_watchdog` configuration option. When enabled, the driver will not enable the hardware watchdog of the Z-Wave controller. This is an advanced configuration option that should not be adjusted in most cases and is therefore hidden from the default view.
+
 
 ### Config file changes
 

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -5,16 +5,31 @@
 ### Features
 
 - Add-on: Add `disable_watchdog` configuration option. When enabled, the driver will not enable the hardware watchdog of the Z-Wave controller. This is an advanced configuration option that should not be adjusted in most cases and is therefore hidden from the default view.
+- Z-Wave JS: Multiple parallel firmware updates are now supported
 
+### Bug fixes
+
+- Z-Wave JS: Fixed an issue where open/close for some covers was inverted
 
 ### Config file changes
 
 - Update Z-Wave SDK warnings to mention recommended versions
 - Update Zooz device labels
+- Add fingerprint to Aeotec ZWA024
+- Correct max. value of SKU parameters for Kwikset locks
+- Add fingerprint to Remotec ZXT-800
+- Add incompatibility warning to UZB1
+- Override Central Scene CC version for Springs Window Fashions VCZ1
+- Add manual and reset metadata for Danfoss LC-13
 
 ### Detailed changelogs
 
 - [Z-Wave JS 13.4.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v13.4.0)
+- [Z-Wave JS 13.5.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v13.5.0)
+- [Z-Wave JS 13.6.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v13.6.0)
+- [Z-Wave JS 13.7.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v13.7.0)
+- [Z-Wave JS 13.8.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v13.8.0)
+- [Z-Wave JS 13.9.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v13.9.0)
 
 ## 0.7.2
 

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.8.0
+
+### Features
+
+- Add-On: Add `disable_watchdog` configuration option. When enabled, the driver will not enable the hardware watchdog of the Z-Wave controller. This is an advanced configuration option that should not be adjusted in most cases and is therefore hidden from the default view.
+
+### Config file changes
+
+- Update Z-Wave SDK warnings to mention recommended versions
+- Update Zooz device labels
+
+### Detailed changelogs
+
+- [Z-Wave JS 13.4.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v13.4.0)
+
 ## 0.7.2
 
 ### Bug fixes

--- a/zwave_js/DOCS.md
+++ b/zwave_js/DOCS.md
@@ -175,7 +175,7 @@ This setting tells the add-on how to handle soft-resets for 500 series controlle
 If you don't have a USB stick, you can use a fake stick for testing purposes.
 It will not be able to control any real devices.
 
-### Optional `disable_controller_recovery` (optional):
+### Option `disable_controller_recovery` (optional):
 
 This setting will disable Z-Wave JS's automatic recovery process when the
 controller appears to be unresponsive and will instead let the controller
@@ -185,6 +185,13 @@ marked as dead. If a controller is not able to recover on its own, you
 will need to restart the add-on to attempt recovery. In most cases, users
 will never need to use this feature, so only change this setting if you
 know what you are doing and/or you are asked to.
+
+### Option `disable_watchdog` (optional):
+
+This setting will prevent Z-Wave JS from enabling the hardware watchdog
+on supporting controllers. In most cases, users will never need to use this
+feature, so only change this setting if you know what you are doing and/or
+you are asked to.
 
 ### Option `safe_mode` (optional)
 

--- a/zwave_js/build.yaml
+++ b/zwave_js/build.yaml
@@ -10,4 +10,4 @@ codenotary:
   base_image: notary@home-assistant.io
 args:
   ZWAVEJS_SERVER_VERSION: 1.38.0
-  ZWAVEJS_VERSION: 13.3.1
+  ZWAVEJS_VERSION: 13.4.0

--- a/zwave_js/build.yaml
+++ b/zwave_js/build.yaml
@@ -10,4 +10,4 @@ codenotary:
   base_image: notary@home-assistant.io
 args:
   ZWAVEJS_SERVER_VERSION: 1.38.0
-  ZWAVEJS_VERSION: 13.4.0
+  ZWAVEJS_VERSION: 13.9.0

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.7.2
+version: 0.8.0
 slug: zwave_js
 name: Z-Wave JS
 description: Control a Z-Wave network with Home Assistant Z-Wave JS
@@ -48,6 +48,7 @@ schema:
   network_key: match(|[0-9a-fA-F]{32,32})?
   emulate_hardware: bool?
   disable_controller_recovery: bool?
+  disable_watchdog: bool?
   safe_mode: bool?
 stage: stable
 startup: services

--- a/zwave_js/rootfs/etc/cont-init.d/config.sh
+++ b/zwave_js/rootfs/etc/cont-init.d/config.sh
@@ -142,6 +142,12 @@ if bashio::config.true 'disable_controller_recovery'; then
     presets_array+=("NO_CONTROLLER_RECOVERY")
 fi
 
+if bashio::config.true 'disable_watchdog'; then
+    bashio::log.info "Hardware watchdog disabled"
+    # Add NO_WATCHDOG to presets array
+    presets_array+=("NO_WATCHDOG")
+fi
+
 # Convert presets array to JSON string and add to config
 if [[ ${#presets_array[@]} -eq 0 ]]; then
     presets="[]"

--- a/zwave_js/translations/en.yaml
+++ b/zwave_js/translations/en.yaml
@@ -81,9 +81,9 @@ configuration:
     name: Disable watchdog
     description: >-
       This setting will prevent Z-Wave JS from enabling the hardware watchdog
-      on supporting controllers. In most cases, users will never need to use this
-      feature, so only change this setting if you know what you are doing and/or
-      you are asked to.
+      on supporting controllers. In most cases, users will never need to use
+      this feature, so only change this setting if you know what you are doing
+      and/or you are asked to.
   safe_mode:
     name: Enable safe mode
     description: >-

--- a/zwave_js/translations/en.yaml
+++ b/zwave_js/translations/en.yaml
@@ -77,6 +77,13 @@ configuration:
       will need to restart the add-on to attempt recovery. In most cases, users
       will never need to use this feature, so only change this setting if you
       know what you are doing and/or you are asked to.
+  disable_watchdog:
+    name: Disable watchdog
+    description: >-
+      This setting will prevent Z-Wave JS from enabling the hardware watchdog
+      on supporting controllers. In most cases, users will never need to use this
+      feature, so only change this setting if you know what you are doing and/or
+      you are asked to.
   safe_mode:
     name: Enable safe mode
     description: >-


### PR DESCRIPTION
Similar to https://github.com/home-assistant/addons/pull/3295, this PR adds support for disabling the watchdog that causes perpetual controller restarts in some rare cases.

Z-Wave JS changelogs:
- [Z-Wave JS 13.4.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v13.4.0)
- [Z-Wave JS 13.5.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v13.5.0)
- [Z-Wave JS 13.6.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v13.6.0)
- [Z-Wave JS 13.7.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v13.7.0)
- [Z-Wave JS 13.8.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v13.8.0)
- [Z-Wave JS 13.9.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v13.9.0)

I've now verified the watchdog change and it is working as intended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `disable_watchdog` configuration option for the Z-Wave Add-On, allowing advanced users to disable the hardware watchdog.
	- Enhanced support for multiple parallel firmware updates for devices.
	- Updated configuration file with improved warnings and new labels for Zooz devices, along with added fingerprints for Aeotec ZWA024 and Remotec ZXT-800.

- **Bug Fixes**
	- Resolved an issue with inverted open/close states for certain covers, improving device reliability.

- **Documentation**
	- Clarified documentation regarding configuration options, including the new `disable_watchdog` setting.

- **Chores**
	- Updated Z-Wave JS server version to 13.9.0, ensuring users benefit from the latest features and improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->