### PR TITLE
ssh: Bump CLI to v4.36.0

### DIFF
--- a/ssh/CHANGELOG.md
+++ b/ssh/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 9.15.0
+
+- Upgrade Home Assistant CLI to 4.36.0
+
 ## 9.14.0
 
 - Upgrade Home Assistant CLI to 4.34.0

--- a/ssh/build.yaml
+++ b/ssh/build.yaml
@@ -9,6 +9,6 @@ codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
 args:
-  CLI_VERSION: 4.34.0
+  CLI_VERSION: 4.36.0
   LIBWEBSOCKETS_VERSION: 4.3.3
   TTYD_VERSION: 1.7.4

--- a/ssh/config.yaml
+++ b/ssh/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 9.14.0
+version: 9.15.0
 slug: ssh
 name: Terminal & SSH
 description: Allow logging in remotely to Home Assistant using SSH


### PR DESCRIPTION
Changes:
* https://github.com/home-assistant/cli/releases/tag/4.35.0
* https://github.com/home-assistant/cli/releases/tag/4.36.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the Home Assistant CLI to version 4.36.0, enhancing command-line functionality.
  
- **Documentation**
	- Changelog updated to reflect the new version entry for 9.15.0. 

- **Chores**
	- Configuration files updated to reflect the new CLI version and overall version increment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->