### PR TITLE
Add note that anonymous logins are not supported to mosquitto/DOCS.md

### DIFF
--- a/mosquitto/DOCS.md
+++ b/mosquitto/DOCS.md
@@ -68,6 +68,8 @@ logins:
     password_pre_hashed: true
 ```
 
+**Note:** This add-on does not support anonymous logins; all connections must use a username/password to connect. `allow_anonymous true` nor any anonymous ACLs will not work with this add-on. 
+
 #### Option: `customize.active`
 
 If set to `true` additional configuration files will be read, see the next option.


### PR DESCRIPTION
Fix documentation to inform users that this HA add-on version of Mosquitto does not support anonymous logins or ACLs. Lost a couple hours of my time wondering why this add-on was silently ignoring configuration options, and thought I'd help others not do the same.

Reference: #2623

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated documentation to clarify that the add-on does not support anonymous logins; all connections must use a username and password.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->