### PR TITLE
Fix otbr for USB cc2652 dongles

### DIFF
--- a/openthread_border_router/CHANGELOG.md
+++ b/openthread_border_router/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.11.1
+
+-  Fix issue with USB TI CC2652 based devices
+
 ## 2.11.0
 
 - Bump to OTBR POSIX version ff7227ea9a2 (2024-09-25 14:54:08 -0700)

--- a/openthread_border_router/config.yaml
+++ b/openthread_border_router/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 2.11.0
+version: 2.11.1
 slug: openthread_border_router
 name: OpenThread Border Router
 description: OpenThread Border Router add-on

--- a/openthread_border_router/rootfs/etc/s6-overlay/s6-rc.d/otbr-agent/run
+++ b/openthread_border_router/rootfs/etc/s6-overlay/s6-rc.d/otbr-agent/run
@@ -26,6 +26,8 @@ flow_control=""
 
 if bashio::config.true 'flow_control'; then
     flow_control="&uart-flow-control"
+else
+    flow_control="&uart-init-deassert"
 fi
 
 otbr_log_level=$(bashio::string.lower "$(bashio::config otbr_log_level)")


### PR DESCRIPTION
Upstream put the code to deassert DTR/RTS behind a flag, as it was breaking systems that were incorrectly configured using flow control firmware without configuring flow control settings.

This restores the previous behaviour introduced in `2.9.0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated changelog to reflect version 2.11.1, addressing USB TI CC2652 device issues.
- **Improvements**
	- Enhanced configuration handling for network interfaces and flow control in the OpenThread Border Router script.
	- Improved firewall setup to prevent errors and ensure proper traffic management.
- **Bug Fixes**
	- Resolved issues related to the handling of primary network interfaces and default settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->