### PR TITLE
nginx: Update to Alpine Linux 3.20 (nginx 1.26.x)

### DIFF
--- a/nginx_proxy/CHANGELOG.md
+++ b/nginx_proxy/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.11.0
+
+- Update Alpine Linux to 3.20 (nginx 1.26.x)
+
 ## 3.10.1
 
 - Make `real_ip_from` optional through an empty default value

--- a/nginx_proxy/build.yaml
+++ b/nginx_proxy/build.yaml
@@ -1,10 +1,10 @@
 ---
 build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-base:3.19
-  amd64: ghcr.io/home-assistant/amd64-base:3.19
-  armhf: ghcr.io/home-assistant/armhf-base:3.19
-  armv7: ghcr.io/home-assistant/armv7-base:3.19
-  i386: ghcr.io/home-assistant/i386-base:3.19
+  aarch64: ghcr.io/home-assistant/aarch64-base:3.20
+  amd64: ghcr.io/home-assistant/amd64-base:3.20
+  armhf: ghcr.io/home-assistant/armhf-base:3.20
+  armv7: ghcr.io/home-assistant/armv7-base:3.20
+  i386: ghcr.io/home-assistant/i386-base:3.20
 codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io

--- a/nginx_proxy/config.yaml
+++ b/nginx_proxy/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 3.10.1
+version: 3.11.0
 hassio_api: true
 slug: nginx_proxy
 name: NGINX Home Assistant SSL proxy


### PR DESCRIPTION
SSIA; updates the nginx proxy add-on to Alpine Linux 3.20 (nginx 1.26.x)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated changelog to include version 3.11.0, detailing enhancements and fixes.
- **Improvements**
	- Upgraded base images to version 3.20 for various architectures, enhancing compatibility and performance.
	- Configuration version updated to 3.11.0, maintaining existing settings for seamless operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->