### PR TITLE
matter_server: Bump Python Matter server to 6.6.0

### DIFF
--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.6.0
+
+- Bump Python Matter Server to [6.6.0](https://github.com/home-assistant-libs/python-matter-server/releases/tag/6.6.0)
+
 ## 6.5.1
 
 - Bump Python Matter Server to [6.5.1](https://github.com/home-assistant-libs/python-matter-server/releases/tag/6.5.1)

--- a/matter_server/build.yaml
+++ b/matter_server/build.yaml
@@ -1,7 +1,7 @@
 ---
 build_from:
-  aarch64: ghcr.io/home-assistant-libs/python-matter-server:6.5.1
-  amd64: ghcr.io/home-assistant-libs/python-matter-server:6.5.1
+  aarch64: ghcr.io/home-assistant-libs/python-matter-server:6.6.0
+  amd64: ghcr.io/home-assistant-libs/python-matter-server:6.6.0
 args:
   BASHIO_VERSION: 0.14.3
   TEMPIO_VERSION: 2021.09.0

--- a/matter_server/config.yaml
+++ b/matter_server/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 6.5.1
+version: 6.6.0
 slug: matter_server
 name: Matter Server
 description: Matter WebSocket Server for Home Assistant Matter support.


### PR DESCRIPTION
Update to the lastest Python Matter server. This adds a new feature which sets the fabric labels and aborts the update process when the node goes offline during update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated to Python Matter Server version 6.6.0, enhancing performance and stability.
  
- **Documentation**
	- Changelog updated to reflect the new version entry and link to release notes.

- **Chores**
	- Version numbers updated in configuration files to ensure consistency across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->