### PR TITLE
Update wyoming-whisper to 2.2.0

### DIFF
--- a/whisper/CHANGELOG.md
+++ b/whisper/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.2.0
+
+- Bump `wyoming-whisper` to 2.2.0 (`faster-whisper` to 1.0.3)
+
 ## 2.1.2
 
 - Fix excluding models files from backup

--- a/whisper/build.yaml
+++ b/whisper/build.yaml
@@ -6,4 +6,4 @@ codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
 args:
-  WYOMING_WHISPER_VERSION: 2.1.0
+  WYOMING_WHISPER_VERSION: 2.2.0

--- a/whisper/config.yaml
+++ b/whisper/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 2.1.2
+version: 2.2.0
 slug: whisper
 name: Whisper
 description: Speech-to-text with Whisper


### PR DESCRIPTION
Bumps `wyoming-whisper` to 2.2.0, which internally bumps `faster-whisper` to 1.0.3: https://github.com/SYSTRAN/faster-whisper/compare/v1.0.2...v1.0.3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated Whisper software version to 2.2.0, potentially introducing new capabilities and improvements.
	- Enhanced compatibility with Home Assistant version 2023.8.0.

- **Bug Fixes**
	- No specific bug fixes reported in this release.

- **Documentation**
	- Changelog updated to reflect the new version and dependency updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->