### PR TITLE
Update nginx.conf.gtpl to suppress: 'listen ... http2' directive is deprecated

### DIFF
--- a/nginx_proxy/CHANGELOG.md
+++ b/nginx_proxy/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.11.1
 
-- Uptate to new nginx http2 directive. This also supress a deprecation warning.
+- Update to new nginx http2 directive. This also suppress a deprecation warning.
 
 ## 3.11.0
 

--- a/nginx_proxy/CHANGELOG.md
+++ b/nginx_proxy/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.11.1
+
+- Uptate to new nginx http2 directive. This also supress a deprecation warning.
+
 ## 3.11.0
 
 - Update Alpine Linux to 3.20 (nginx 1.26.x)

--- a/nginx_proxy/config.yaml
+++ b/nginx_proxy/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 3.11.0
+version: 3.11.1
 hassio_api: true
 slug: nginx_proxy
 name: NGINX Home Assistant SSL proxy

--- a/nginx_proxy/rootfs/etc/nginx/nginx.conf.gtpl
+++ b/nginx_proxy/rootfs/etc/nginx/nginx.conf.gtpl
@@ -34,7 +34,8 @@ http {
     server {
         server_name _;
         listen 80 default_server;
-        listen 443 ssl http2 default_server;
+        listen 443 ssl default_server;
+        http2 on;
         ssl_reject_handshake on;
         return 444;
     }
@@ -60,9 +61,11 @@ http {
         ssl_dhparam /data/dhparams.pem;
         
         {{- if not .options.real_ip_from  }}
-        listen 443 ssl http2;
+        listen 443 ssl;
+        http2 on;
         {{- else }}
-        listen 443 ssl http2 proxy_protocol;
+        listen 443 ssl proxy_protocol;
+        http2 on;
         {{- range .options.real_ip_from }}
         set_real_ip_from {{.}};
         {{- end  }}


### PR DESCRIPTION
…eprecated.

This small changed update the code to use the "http2" directive and fixes the issue #3791.
-----
Changed this:
> listen 443 ssl http2;

To this:
> listen 443 ssl;
> http2 on;
-----
Source: https://www.nginx.com/blog/nginx-plus-r30-released/#Important-Changes-in-Behavior-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced SSL connection handling and HTTP/2 settings for improved performance and security.
	- Updated version to 3.11.1, reflecting the new nginx HTTP/2 directive.
- **Bug Fixes**
	- Streamlined configuration to ensure clarity and functionality of SSL and HTTP/2 settings.
	- Suppressed a deprecation warning related to HTTP/2 settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->