### PR TITLE
Bump zwavejs to 13.10.3

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -30,7 +30,7 @@
 
 ### Detailed changelogs
 
-- [Z-Wave JS Server 1.39.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v1.39.0)
+[Z-Wave JS Server 1.39.0](https://github.com/zwave-js/zwave-js-server/releases/tag/1.39.0)
 - [Z-Wave JS 13.10.3](https://github.com/zwave-js/node-zwave-js/releases/tag/v13.10.3)
 - [Z-Wave JS 13.10.2](https://github.com/zwave-js/node-zwave-js/releases/tag/v13.10.2)
 - [Z-Wave JS 13.10.1](https://github.com/zwave-js/node-zwave-js/releases/tag/v13.10.1)

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## 0.9.0
+
+### Features
+
+- Z-Wave JS: mock-server now supports putting the simulated controller into add and remove mode
+- Z-Wave JS Server: Support get_raw_config_parameter_value
+- Z-Wave JS Server: Support all signatures of node.manuallyIdleNotificationValue
+
+### Bug fixes
+
+- Z-Wave JS: Fixed an issue where preferred scales were not being found when set as a string
+- Z-Wave JS: Correct unit of Meter CC values
+- Z-Wave JS: Bootloader mode is now detected even when short chunks of data are received
+- Z-Wave JS: Corrected the wording of idle/busy queue logging
+
+### Config file changes
+
+- Add Heatit Z-TEMP3
+- Add new parameters 17 and 18 for HeatIt TF016_TF021 FW 1.92
+- Disable Supervision for Heatit TF021
+- Add ZVIDAR WB04V Smartwings Day Night Shades
+- Add ZVIDAR WM25L Smartwings Smart Motor
+- Add ZVIDAR ZW881 Multi-Protocol Gateway
+- Add include, exclude, and wakeup instructions for VCZ1
+- Add new Product ID to Namron 16A Switch
+- Add Minoston MP24Z 800LR Outdoor Smart Plug - 2 Outlet
+- Disable Supervision for Everspring SE813
+
+### Detailed changelogs
+
+- [Z-Wave JS 13.9.1](https://github.com/zwave-js/node-zwave-js/releases/tag/v13.9.1)
+- [Z-Wave JS 13.10.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v13.10.0)
+- [Z-Wave JS 13.10.1](https://github.com/zwave-js/node-zwave-js/releases/tag/v13.10.1)
+- [Z-Wave JS 13.10.2](https://github.com/zwave-js/node-zwave-js/releases/tag/v13.10.2)
+- [Z-Wave JS 13.10.3](https://github.com/zwave-js/node-zwave-js/releases/tag/v13.10.3)
+
 ## 0.8.1
 
 Rename Z-Wave watchdog option to avoid confusion with add-on watchdog.

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -30,7 +30,7 @@
 
 ### Detailed changelogs
 
-[Z-Wave JS Server 1.39.0](https://github.com/zwave-js/zwave-js-server/releases/tag/1.39.0)
+- [Z-Wave JS Server 1.39.0](https://github.com/zwave-js/zwave-js-server/releases/tag/1.39.0)
 - [Z-Wave JS 13.10.3](https://github.com/zwave-js/node-zwave-js/releases/tag/v13.10.3)
 - [Z-Wave JS 13.10.2](https://github.com/zwave-js/node-zwave-js/releases/tag/v13.10.2)
 - [Z-Wave JS 13.10.1](https://github.com/zwave-js/node-zwave-js/releases/tag/v13.10.1)

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -30,11 +30,12 @@
 
 ### Detailed changelogs
 
-- [Z-Wave JS 13.9.1](https://github.com/zwave-js/node-zwave-js/releases/tag/v13.9.1)
-- [Z-Wave JS 13.10.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v13.10.0)
-- [Z-Wave JS 13.10.1](https://github.com/zwave-js/node-zwave-js/releases/tag/v13.10.1)
-- [Z-Wave JS 13.10.2](https://github.com/zwave-js/node-zwave-js/releases/tag/v13.10.2)
+- [Z-Wave JS Server 1.39.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v1.39.0)
 - [Z-Wave JS 13.10.3](https://github.com/zwave-js/node-zwave-js/releases/tag/v13.10.3)
+- [Z-Wave JS 13.10.2](https://github.com/zwave-js/node-zwave-js/releases/tag/v13.10.2)
+- [Z-Wave JS 13.10.1](https://github.com/zwave-js/node-zwave-js/releases/tag/v13.10.1)
+- [Z-Wave JS 13.10.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v13.10.0)
+- [Z-Wave JS 13.9.1](https://github.com/zwave-js/node-zwave-js/releases/tag/v13.9.1)
 
 ## 0.8.1
 

--- a/zwave_js/build.yaml
+++ b/zwave_js/build.yaml
@@ -9,5 +9,5 @@ codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
 args:
-  ZWAVEJS_SERVER_VERSION: 1.38.0
-  ZWAVEJS_VERSION: 13.9.0
+  ZWAVEJS_SERVER_VERSION: 1.39.0
+  ZWAVEJS_VERSION: 13.10.3

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.8.1
+version: 0.9.0
 slug: zwave_js
 name: Z-Wave JS
 description: Control a Z-Wave network with Home Assistant Z-Wave JS


### PR DESCRIPTION
And zwavejs server to 1.39.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated version to `0.9.0` in the configuration, enhancing compatibility.
	- Introduced new options for configuration: `network_key`, `emulate_hardware`, and `disable_controller_recovery` for improved flexibility.
	- Mock-server now allows the simulated controller to enter add and remove modes.
	- Support for new devices, including Heatit Z-TEMP3 and various ZVIDAR products.

- **Improvements**
	- Updated `ZWAVEJS_SERVER_VERSION` to `1.39.0` and `ZWAVEJS_VERSION` to `13.10.3`, ensuring users have the latest features and fixes.
	- Enhanced logging for idle/busy queue states for better clarity.

- **Bug Fixes**
	- Corrected identification of preferred scales set as strings and improved bootloader mode detection.
	- Fixed unit of Meter CC values for accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->