### PR TITLE
OTBR: fix start order of services calling ot-ctl

### DIFF
--- a/openthread_border_router/CHANGELOG.md
+++ b/openthread_border_router/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.12.1
+- Fix otbr-configure bug affecting startup on some systems
+
 ## 2.12.0
 - Bump universal-silabs-flasher to 0.0.23
 - Bump OTBR firmwares to latest versions

--- a/openthread_border_router/config.yaml
+++ b/openthread_border_router/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 2.12.0
+version: 2.12.1
 slug: openthread_border_router
 name: OpenThread Border Router
 description: OpenThread Border Router add-on


### PR DESCRIPTION
See https://github.com/home-assistant/addons/issues/3826#issuecomment-2489736650

I can't reproduce here so far, however seems like there may be a race between `otbr-agent-configure` and `otbr-agent-rest-discovery`. As they both are calling `ot-ctl` at about the same time. First fails and latter succeeds. This was introduced with the discover change in 2.12.0.