### PR TITLE
matter_server: Bump Python Matter server to 6.6.1

### DIFF
--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.6.1
+
+- Bump Python Matter Server to [6.6.1](https://github.com/home-assistant-libs/python-matter-server/releases/tag/6.6.1)
+
 ## 6.6.0
 
 - Bump Python Matter Server to [6.6.0](https://github.com/home-assistant-libs/python-matter-server/releases/tag/6.6.0)

--- a/matter_server/build.yaml
+++ b/matter_server/build.yaml
@@ -1,7 +1,7 @@
 ---
 build_from:
-  aarch64: ghcr.io/home-assistant-libs/python-matter-server:6.6.0
-  amd64: ghcr.io/home-assistant-libs/python-matter-server:6.6.0
+  aarch64: ghcr.io/home-assistant-libs/python-matter-server:6.6.1
+  amd64: ghcr.io/home-assistant-libs/python-matter-server:6.6.1
 args:
   BASHIO_VERSION: 0.14.3
   TEMPIO_VERSION: 2021.09.0

--- a/matter_server/config.yaml
+++ b/matter_server/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 6.6.0
+version: 6.6.1
 slug: matter_server
 name: Matter Server
 description: Matter WebSocket Server for Home Assistant Matter support.


### PR DESCRIPTION
Update to the latest Python Matter server. This release comes with a container based on Debian 12 and Python 3.12. It will be compatible with future Matter Server beta releases.