### PR TITLE
Bump letsencrypt version to reflect latest changes

### DIFF
--- a/letsencrypt/config.yaml
+++ b/letsencrypt/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 5.2.5
+version: 5.2.6
 slug: letsencrypt
 name: Let's Encrypt
 description: Manage certificate from Let's Encrypt


### PR DESCRIPTION
Here we go again. The version was never bumped to reflect the fixes in #3838.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the version of the configuration for Let's Encrypt from 5.2.5 to 5.2.6, ensuring continued compatibility and security without altering existing settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->