### PR TITLE
[configurator] Expose log level env variable 

### DIFF
--- a/configurator/CHANGELOG.md
+++ b/configurator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.8.1
+
+- Expose configurable log level
+
 ## 5.8.0
 
 - Update base image to Alpine 3.19

--- a/configurator/DOCS.md
+++ b/configurator/DOCS.md
@@ -54,6 +54,10 @@ By default, it hides the `__pycache__` folders.
 
 A list of filenames containing SSH private keys. These can be used to allow for access to remote git repositories.
 
+### Option: `loglevel` (optional)
+
+The loglevel to pass to hass-configurator (default 'info').
+
 ## Known issues and limitations
 
 - This add-on can only be used via Ingress and has no direct access.

--- a/configurator/config.yaml
+++ b/configurator/config.yaml
@@ -33,6 +33,7 @@ options:
     - .storage
     - deps
   ssh_keys: []
+  loglevel: info
 panel_icon: mdi:wrench
 schema:
   dirsfirst: bool
@@ -42,3 +43,4 @@ schema:
     - str
   ssh_keys:
     - str
+  loglevel: list(debug|info|warning|error|critical)

--- a/configurator/config.yaml
+++ b/configurator/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 5.8.0
+version: 5.8.1
 slug: configurator
 name: File editor
 description: Simple browser-based file editor for Home Assistant

--- a/configurator/rootfs/etc/s6-overlay/s6-rc.d/configurator/run
+++ b/configurator/rootfs/etc/s6-overlay/s6-rc.d/configurator/run
@@ -7,6 +7,7 @@ export HC_ENFORCE_BASEPATH
 export HC_GIT
 export HC_HASS_API_PASSWORD
 export HC_IGNORE_PATTERN
+export HC_LOGLEVEL
 
 # If any SSH key files are defined in the configuration options, add them for use by git
 if bashio::config.has_value "ssh_keys"; then
@@ -31,5 +32,6 @@ HC_ENFORCE_BASEPATH=$(bashio::config 'enforce_basepath')
 HC_GIT=$(bashio::config 'git')
 HC_HASS_API_PASSWORD="${SUPERVISOR_TOKEN}"
 HC_IGNORE_PATTERN="$(bashio::config 'ignore_pattern | join(",")')"
+HC_LOGLEVEL=$(bashio::config 'loglevel')
 
 exec hass-configurator /etc/configurator.conf

--- a/configurator/rootfs/etc/s6-overlay/s6-rc.d/configurator/run
+++ b/configurator/rootfs/etc/s6-overlay/s6-rc.d/configurator/run
@@ -32,6 +32,7 @@ HC_ENFORCE_BASEPATH=$(bashio::config 'enforce_basepath')
 HC_GIT=$(bashio::config 'git')
 HC_HASS_API_PASSWORD="${SUPERVISOR_TOKEN}"
 HC_IGNORE_PATTERN="$(bashio::config 'ignore_pattern | join(",")')"
-HC_LOGLEVEL=$(bashio::config 'loglevel')
+bashio::config.has_value 'loglevel' \
+    && HC_LOGLEVEL="$(bashio::config 'loglevel')" || HC_LOGLEVEL=info
 
 exec hass-configurator /etc/configurator.conf

--- a/configurator/translations/en.yaml
+++ b/configurator/translations/en.yaml
@@ -25,3 +25,7 @@ configuration:
     description: >-
       A list of filenames containing SSH private keys. These can be used to
       allow for access to remote git repositories.
+  loglevel:
+    name: Log level
+    description: >-
+      The log level to use (default `info`).


### PR DESCRIPTION
It would be nice to reduce unnecessary logspam, e.g. that *every single* HTTP request gets logged in the default 'info' loglevel of `hass-configurator`, with no easy way to fix this. And it does indeed have a loglevel flag ( https://github.com/danielperna84/hass-configurator/blob/397bda2f9131d2c1c979bf01391745699852b049/hass_configurator/configurator.py#L105 ) that is however not exposed in the Home Assistant addon configuration.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a configurable log level, allowing users to adjust logging verbosity.
	- Added a new optional configuration option `loglevel` for the "File editor" add-on.

- **Documentation**
	- Updated changelog to reflect the new version 5.8.1 and the addition of the `loglevel` feature.
	- Enhanced documentation for the "File editor" add-on to include the new `loglevel` option.

- **Configuration Updates**
	- Updated configuration file to include the new `loglevel` option with a default value of 'info'.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->