### PR TITLE
letsencrypt: Improved Logging

### DIFF
--- a/letsencrypt/config.yaml
+++ b/letsencrypt/config.yaml
@@ -24,6 +24,7 @@ options:
   certfile: fullchain.pem
   challenge: http
   dns: {}
+  max_logs_backup: 100
 ports:
   80/tcp: 80
 schema:
@@ -39,6 +40,7 @@ schema:
   eab_hmac_key: str?
   key_type: list(ecdsa|rsa)?
   elliptic_curve: list(secp256r1|secp384r1)?
+  max_logs_backup: int
   dns:
     aws_access_key_id: str?
     aws_secret_access_key: str?

--- a/letsencrypt/rootfs/etc/cont-init.d/file-structure.sh
+++ b/letsencrypt/rootfs/etc/cont-init.d/file-structure.sh
@@ -4,6 +4,7 @@
 # ==============================================================================
 mkdir -p /data/workdir
 mkdir -p /data/letsencrypt
+mkdir -p /ssl/letsencrypt-logs
 
 # Setup Let's encrypt config
 echo -e "dns_desec_token = $(bashio::config 'dns.desec_token')\n" \

--- a/letsencrypt/rootfs/etc/services.d/lets-encrypt/run
+++ b/letsencrypt/rootfs/etc/services.d/lets-encrypt/run
@@ -4,6 +4,7 @@
 # ==============================================================================
 CERT_DIR=/data/letsencrypt
 WORK_DIR=/data/workdir
+LOGS_DIR=/ssl/letsencrypt-logs
 PROVIDER_ARGUMENTS=()
 ACME_CUSTOM_SERVER_ARGUMENTS=()
 KEY_ARGUMENTS=()
@@ -19,6 +20,7 @@ ACME_SERVER=$(bashio::config 'acme_server')
 ACME_ROOT_CA=$(bashio::config 'acme_root_ca_cert')
 EAB_KID=$(bashio::config 'eab_kid')
 EAB_HMAC_KEY=$(bashio::config 'eab_hmac_key')
+MAX_LOGS_BACKUP=$(bashio::config 'max_logs_backup')
 
 if [ "${CHALLENGE}" == "dns" ]; then
     bashio::log.info "Selected DNS Provider: ${DNS_PROVIDER}"
@@ -302,7 +304,7 @@ if bashio::config.exists 'key_type'; then
     fi
 else
     bashio::log.info "Detecting existing certificate type for ${DOMAIN_ARR[1]}"
-    readarray -t CBCERTS < <(certbot certificates --non-interactive --cert-name "${DOMAIN_ARR[1]}" --config-dir "$CERT_DIR" --work-dir "$WORK_DIR") 
+    readarray -t CBCERTS < <(certbot certificates --non-interactive --cert-name "${DOMAIN_ARR[1]}" --config-dir "$CERT_DIR" --work-dir "$WORK_DIR" --logs-dir "$LOGS_DIR" --max-log-backups "$MAX_LOGS_BACKUP" )
     for output in "${CBCERTS[@]}"; do
         if [[ $output =~ "No certificates found." ]]; then
             bashio::log.info "No certificate found - using 'ecdsa' key type."
@@ -335,6 +337,7 @@ if [ "$CHALLENGE" == "dns" ]; then
         "${KEY_ARGUMENTS[@]}" \
         --cert-name "${DOMAIN_ARR[1]}" "${DOMAIN_ARR[@]}" \
         --config-dir "$CERT_DIR" --work-dir "$WORK_DIR" \
+        --logs-dir "$LOGS_DIR" --max-log-backups "$MAX_LOGS_BACKUP" \
         --preferred-challenges "$CHALLENGE" "${PROVIDER_ARGUMENTS[@]}" \
         --preferred-chain "ISRG Root X1" \
         "${EAB_ARGUMENTS[@]}"
@@ -344,6 +347,7 @@ else
         "${KEY_ARGUMENTS[@]}" \
         --cert-name "${DOMAIN_ARR[1]}" "${DOMAIN_ARR[@]}" \
         --config-dir "$CERT_DIR" --work-dir "$WORK_DIR" \
+        --logs-dir "$LOGS_DIR" --max-log-backups "$MAX_LOGS_BACKUP" \
         --preferred-challenges "$CHALLENGE" "${ACME_CUSTOM_SERVER_ARGUMENTS[@]}" --standalone \
         --preferred-chain "ISRG Root X1" \
         "${EAB_ARGUMENTS[@]}"

--- a/letsencrypt/translations/en.yaml
+++ b/letsencrypt/translations/en.yaml
@@ -42,5 +42,12 @@ configuration:
     description: >-
       Elliptic curve for ECDSA keys. This option must be used with Key Type
       set to ECDSA. If unset the Certbot default will be used.
+  max_logs_backup:
+    name: Max Logs Backup
+    description: >-
+      Specifies the maximum number of backup logs that
+      should be kept by Certbot's built in log rotation.
+      Setting this flag to 0 disables log rotation entirely,
+      causing Certbot to always append to the same log file.
 network:
   80/tcp: Only needed for http challenge


### PR DESCRIPTION
I had struggles to get access to the certbot Logs, the only way i found was with an Backup and there in the Data dir of the addon.
So I changed the Log Directory to /ssl/letsencrypt-logs to make it easier for the users to get access.

I also added max_logs_backup as a configurable option with a default of 100 Log Files.
If it is not specified certbot creates 1000 Files.