### PR TITLE
Update mosquitto image to latest versions

### DIFF
--- a/mosquitto/CHANGELOG.md
+++ b/mosquitto/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 6.5.0
+
+- Update base image to Debian 12 (bookworm)
+- Update mosquitto to version 2.0.20
+- Update mosquitto-go-auth to version 2.1.0
+- Update libwebsockets to version 4.3.3
+
 ## 6.4.1
 
 - Increase default max_queued_messages to 8192 to fix dropped messages during Home Assistant startup

--- a/mosquitto/Dockerfile
+++ b/mosquitto/Dockerfile
@@ -24,13 +24,16 @@ RUN apt-get update \
         golang-go \
     \
     # Compile and install libwebsocket
+    #
+    # DLWS_WITHOUT_TESTAPPS is just a workaround, see
+    # https://github.com/warmcat/libwebsockets/issues/2790 for more
     && git clone --depth 1 -b "${LIBWEBSOCKET_VERSION}" \
        https://libwebsockets.org/repo/libwebsockets \
     \
     && cd libwebsockets \
     && mkdir build \
     && cd build \
-    && cmake -DLWS_WITH_EXTERNAL_POLL=ON .. \
+    && cmake -DLWS_WITH_EXTERNAL_POLL=ON -DLWS_WITHOUT_TESTAPPS=ON .. \
     && make install \
     && ldconfig \
     && cd ../.. \

--- a/mosquitto/Dockerfile
+++ b/mosquitto/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update \
     #
     # DLWS_WITHOUT_TESTAPPS is just a workaround, see
     # https://github.com/warmcat/libwebsockets/issues/2790 for more
-    && git clone --depth 1 -b "${LIBWEBSOCKET_VERSION}" \
+    && git clone --depth 1 -b "v${LIBWEBSOCKET_VERSION}" \
        https://libwebsockets.org/repo/libwebsockets \
     \
     && cd libwebsockets \
@@ -38,7 +38,7 @@ RUN apt-get update \
     && ldconfig \
     && cd ../.. \
     # Compile and install mosquitto
-    && git clone --depth 1 -b "${MOSQUITTO_VERSION}" \
+    && git clone --depth 1 -b "v${MOSQUITTO_VERSION}" \
        https://github.com/eclipse/mosquitto \
     \
     && cd mosquitto \

--- a/mosquitto/build.yaml
+++ b/mosquitto/build.yaml
@@ -1,10 +1,10 @@
 ---
 build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-base-debian:bullseye
-  amd64: ghcr.io/home-assistant/amd64-base-debian:bullseye
-  armhf: ghcr.io/home-assistant/armhf-base-debian:bullseye
-  armv7: ghcr.io/home-assistant/armv7-base-debian:bullseye
-  i386: ghcr.io/home-assistant/i386-base-debian:bullseye
+  aarch64: ghcr.io/home-assistant/aarch64-base-debian:bookworm
+  amd64: ghcr.io/home-assistant/amd64-base-debian:bookworm
+  armhf: ghcr.io/home-assistant/armhf-base-debian:bookworm
+  armv7: ghcr.io/home-assistant/armv7-base-debian:bookworm
+  i386: ghcr.io/home-assistant/i386-base-debian:bookworm
 codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io

--- a/mosquitto/build.yaml
+++ b/mosquitto/build.yaml
@@ -9,6 +9,6 @@ codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
 args:
-  LIBWEBSOCKET_VERSION: v4.3.3
-  MOSQUITTO_VERSION: v2.0.20
+  LIBWEBSOCKET_VERSION: 4.3.3
+  MOSQUITTO_VERSION: 2.0.20
   MOSQUITTO_AUTH_VERSION: 2.1.0

--- a/mosquitto/build.yaml
+++ b/mosquitto/build.yaml
@@ -9,6 +9,6 @@ codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
 args:
-  LIBWEBSOCKET_VERSION: v4.3.2
-  MOSQUITTO_VERSION: v2.0.18
-  MOSQUITTO_AUTH_VERSION: 1.8.2
+  LIBWEBSOCKET_VERSION: v4.3.3
+  MOSQUITTO_VERSION: v2.0.20
+  MOSQUITTO_AUTH_VERSION: 2.1.0

--- a/mosquitto/config.yaml
+++ b/mosquitto/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 6.4.1
+version: 6.5.0
 slug: mosquitto
 name: Mosquitto broker
 description: An Open Source MQTT broker


### PR DESCRIPTION
The mosquitto image is quite outdated. This PR changes this by updating the following components:

- Use latest Debian Bookworm as base image
- Update mosquitto from v2.0.18 to v2.0.20 (which includes [a few security fixes from version 2.0.19](https://mosquitto.org/blog/2024/10/version-2-0-19-released/))
- Update mosquitto-go-auth to v2.1.0
- Update libwebsocket to v4.3.3

To achive this, it was necessary to include the `DLWS_WITHOUT_TESTAPPS` switch when building the libwebsocket library. This [is being discussed here](https://github.com/warmcat/libwebsockets/issues/2790) and will be fixed in the next version of libwebsocket. I've added a little comment in the Dockerfile to make it clear it can be removed in the future.

Additionally, I've normalized the version strings in the build.yaml by moving the prefix into the the Dockerfile (like it's being handled in i.e. the ssh addon).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes for Mosquitto Version 6.5.0

- **New Features**
	- Updated to Mosquitto version 2.0.20 and included enhancements from mosquitto-go-auth version 2.1.0.
	- Base image updated to Debian 12 (bookworm) for improved compatibility and security.

- **Bug Fixes**
	- Adjusted build configuration to resolve issues related to libwebsockets, enhancing stability.

- **Documentation**
	- Changelog updated to reflect new version entry and detailed changes for version 6.5.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->