### PR TITLE
silabs-flasher: Support Yellow with CM5

### DIFF
--- a/silabs_flasher/CHANGELOG.md
+++ b/silabs_flasher/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.2
+
+- Update flasher script to work with Home Assistant Yellow with CM5
+
 ## 0.3.1
 - Update firmwares to EmberZNet 7.4.4
 - Update universal-silabs-flasher to v0.0.25

--- a/silabs_flasher/config.yaml
+++ b/silabs_flasher/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.3.1
+version: 0.3.2
 slug: silabs_flasher
 name: Silicon Labs Flasher
 description: Silicon Labs firmware flasher add-on

--- a/silabs_flasher/rootfs/etc/s6-overlay/scripts/universal-silabs-flasher-up
+++ b/silabs_flasher/rootfs/etc/s6-overlay/scripts/universal-silabs-flasher-up
@@ -30,10 +30,30 @@ function exit_no_firmware {
     exit 0
 }
 
+# Function to check if the device is Home Assistant Yellow
+function is_home_assistant_yellow {
+    # First, ensure the device is /dev/ttyAMA1
+    if [ "${device}" != "/dev/ttyAMA1" ]; then
+        return 1
+    fi
+
+    # Check the known paths for Home Assistant Yellow
+    local paths=(
+        "/sys/devices/platform/soc/fe201800.serial/tty/ttyAMA1"
+        "/sys/devices/platform/axi/1000120000.pcie/1f0003c000.serial/tty/ttyAMA1"
+    )
+    for path in "${paths[@]}"; do
+        if [ -d "${path}" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
 device=$(bashio::config 'device')
 bootloader_baudrate=$(bashio::config 'bootloader_baudrate')
 
-if [ -d /sys/devices/platform/soc/fe201800.serial/tty/ttyAMA1 ] && [ "${device}" == "/dev/ttyAMA1" ]; then
+if is_home_assistant_yellow; then
     bashio::log.info "Detected Home Assistant Yellow"
     gpio_reset_flag="--bootloader-reset yellow"
 else
@@ -50,7 +70,7 @@ if bashio::config.has_value 'firmware_url'; then
     firmware="firmware.gbl"
 else
     # Assume to run on Yellow if UART4 is mapped to ttyAMA1
-    if [ -d /sys/devices/platform/soc/fe201800.serial/tty/ttyAMA1 ] && [ "${device}" == "/dev/ttyAMA1" ]; then
+    if is_home_assistant_yellow; then
         firmware="yellow_zigbee_ncp_7.4.4.0.gbl"
     else
         # Check device manufacturer/product information


### PR DESCRIPTION
Support flashing the internal radio on Home Assistant Yellow with CM5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated flasher script for compatibility with Home Assistant Yellow using the CM5 module.
	- Introduced a new function to simplify device checks for Home Assistant Yellow.

- **Bug Fixes**
	- Enhanced error handling and logging in the flasher script.

- **Documentation**
	- Updated changelog to reflect the new version (0.3.2) and changes made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->