### PR TITLE
openthread_border_router: Support Yellow with CM5

### DIFF
--- a/openthread_border_router/CHANGELOG.md
+++ b/openthread_border_router/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.12.2
+
+- Update flasher script to work with Home Assistant Yellow with CM5
+
 ## 2.12.1
 - Fix possible race condition between otbr-agent-configure and otbr-agent-rest-discovery
   services causing failed startup ([#3826](https://github.com/home-assistant/addons/issues/3826))

--- a/openthread_border_router/config.yaml
+++ b/openthread_border_router/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 2.12.1
+version: 2.12.2
 slug: openthread_border_router
 name: OpenThread Border Router
 description: OpenThread Border Router add-on

--- a/openthread_border_router/rootfs/etc/s6-overlay/scripts/universal-silabs-flasher-up
+++ b/openthread_border_router/rootfs/etc/s6-overlay/scripts/universal-silabs-flasher-up
@@ -16,6 +16,26 @@ function exit_no_firmware {
     exit 0
 }
 
+# Function to check if the device is Home Assistant Yellow
+function is_home_assistant_yellow {
+    # First, ensure the device is /dev/ttyAMA1
+    if [ "${device}" != "/dev/ttyAMA1" ]; then
+        return 1
+    fi
+
+    # Check the known paths for Home Assistant Yellow
+    local paths=(
+        "/sys/devices/platform/soc/fe201800.serial/tty/ttyAMA1"
+        "/sys/devices/platform/axi/1000120000.pcie/1f0003c000.serial/tty/ttyAMA1"
+    )
+    for path in "${paths[@]}"; do
+        if [ -d "${path}" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
 device=$(bashio::config 'device')
 gpio_reset_flag=""
 
@@ -29,8 +49,7 @@ if bashio::config.has_value 'network_device'; then
     exit 0
 fi
 
-# Assume to run on Yellow if UART4 is mapped to ttyAMA1
-if [ -d /sys/devices/platform/soc/fe201800.serial/tty/ttyAMA1 ] && [ "${device}" == "/dev/ttyAMA1" ]; then
+if is_home_assistant_yellow; then
     bashio::log.info "Detected Home Assistant Yellow"
     firmware="yellow_openthread_rcp_2.4.4.0_GitHub-7074a43e4_gsdk_4.4.4.gbl"
     gpio_reset_flag="--bootloader-reset yellow"


### PR DESCRIPTION
Support flashing the internal radio on Home Assistant Yellow with CM5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated flasher script for enhanced compatibility with Home Assistant Yellow using the CM5 module.
	- Introduced a new function for improved device identification in the flasher script.

- **Bug Fixes**
	- Addressed a race condition issue that could lead to startup failures in previous versions.

- **Documentation**
	- Updated changelog to reflect changes in version 2.12.2 and previous updates. 

- **Chores**
	- Incremented version number in configuration file from 2.12.1 to 2.12.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->