### PR TITLE
Move Turbo closer to Large to avoid confusing it with Tiny

### DIFF
--- a/whisper/CHANGELOG.md
+++ b/whisper/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.3.1
+
+- Move `turbo` down the list closer to `large` to avoid confusion
+
 ## 2.3.0
 
 - Bump `wyoming-whisper` to 2.3.0 (`faster-whisper` to 1.1.0)

--- a/whisper/DOCS.md
+++ b/whisper/DOCS.md
@@ -41,7 +41,6 @@ Compressed models (`int8`) are slightly less accurate than their counterparts, b
 
 Available models:
 
-- `turbo` (faster than `large-v3`)
 - `tiny-int8` (compressed)
 - `tiny`
 - `tiny.en` (English only)
@@ -62,6 +61,7 @@ Available models:
 - `large-v2`
 - `distil-large-v3` (distilled, English only)
 - `large-v3`
+- `turbo` (faster than `large-v3`)
 
 ### Option: `custom_model`
 

--- a/whisper/config.yaml
+++ b/whisper/config.yaml
@@ -19,7 +19,7 @@ options:
   debug_logging: false
 schema:
   model: |
-    list(turbo|tiny-int8|tiny|tiny.en|base-int8|base|base.en|small-int8|distil-small.en|small|small.en|distil-medium.en|medium-int8|medium|medium.en|large|large-v1|distil-large-v2|large-v2|distil-large-v3|large-v3|custom)
+    list(tiny-int8|tiny|tiny.en|base-int8|base|base.en|small-int8|distil-small.en|small|small.en|distil-medium.en|medium-int8|medium|medium.en|large|large-v1|distil-large-v2|large-v2|distil-large-v3|large-v3|turbo|custom)
   custom_model: str?
   language: |
     list(auto|af|am|ar|as|az|ba|be|bg|bn|bo|br|bs|ca|cs|cy|da|de|el|en|es|et|eu|fa|fi|fo|fr|gl|gu|ha|haw|he|hi|hr|ht|hu|hy|id|is|it|ja|jw|ka|kk|km|kn|ko|la|lb|ln|lo|lt|lv|mg|mi|mk|ml|mn|mr|ms|mt|my|ne|nl|nn|no|oc|pa|pl|ps|pt|ro|ru|sa|sd|si|sk|sl|sn|so|sq|sr|su|sv|sw|ta|te|tg|th|tk|tl|tr|tt|uk|ur|uz|vi|yi|yo|zh|yue)

--- a/whisper/config.yaml
+++ b/whisper/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 2.3.0
+version: 2.3.1
 slug: whisper
 name: Whisper
 description: Speech-to-text with Whisper


### PR DESCRIPTION
Move Turbo closer to Large to avoid confusing it with Tiny.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the Whisper add-on documentation for clarity on the `turbo` model's performance compared to `large-v3`.
  
- **Configuration**
	- Reordered the list of acceptable model values in the configuration file, moving `turbo` to the end of the list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->