### PR TITLE
openthread_border_router: Fix start with containerd.io to 1.7.24-1

### DIFF
--- a/openthread_border_router/CHANGELOG.md
+++ b/openthread_border_router/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.12.4
+
+- Fix OTBR addon does not start after updating containerd.io to 1.7.24-1
+
 ## 2.12.3
 
 - Enable recovery mechanism from "radio tx timeout" errors

--- a/openthread_border_router/config.yaml
+++ b/openthread_border_router/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 2.12.3
+version: 2.12.4
 slug: openthread_border_router
 name: OpenThread Border Router
 description: OpenThread Border Router add-on
@@ -20,6 +20,8 @@ host_uts: true
 privileged:
   - IPC_LOCK
   - NET_ADMIN
+devices:
+  - /dev/net/tun
 image: homeassistant/{arch}-addon-otbr
 init: false
 options:


### PR DESCRIPTION
### Issue

OTBR Addon fails to load with `platformConfigureTunDevice() at netif.cpp:2022: Operation not permitted`

I upgraded containerd.io to `1.7.24-1` on Debian 12 and this started to happen preventing the container from starting.

Logs are available here:
https://github.com/home-assistant/core/issues/132124
https://github.com/home-assistant/addons/issues/3826#issuecomment-2509751613

As a temporary solution, I downgraded to `containerd.io=1.7.23-1`, which worked for me and some other users.

### Reason and solution

https://github.com/containerd/containerd/issues/11078#issuecomment-2510511238

so the recommended solution is to enable the `/dev/net/tun` device:
```yaml
devices:
  - /dev/net/tun
```

### Testing

I only did local testing on my Home Assistant Supervised machine, such as:

- Uninstalled OTBR addon
- Modified `/usr/share/hassio/addons/core/openthread_border_router/config.yaml` by adding the `/dev/net/tun` to devices  (and didn't bump the version, as OTBR addon won't install then)
- Checked for updates in `Add-on Store`
- installed OTBR addon again, restored config and ran it

Not sure if this is the right way to test, but it was the fastest for me and it solved my issue.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved an issue preventing the OpenThread Border Router addon from starting after a containerd.io update
	- Added recovery mechanism for "radio tx timeout" errors
	- Increased mesh header fragmentation tag entries to mitigate log messages

- **Chores**
	- Updated addon version from 2.12.3 to 2.12.4
	- Added device configuration for `/dev/net/tun`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->