### PR TITLE
tellstick: Add deprecation notice to README.md

### DIFF
--- a/tellstick/README.md
+++ b/tellstick/README.md
@@ -1,5 +1,11 @@
 # Home Assistant Add-on: TellStick
 
+> [!CAUTION]
+> **Deprecation notice**
+> The library this add-on depends on is abandoned. It's last activity was 5
+> years ago it it cannot be built on alpine >3.15. Currentlly users can continue
+> to use it but no issues or PRs will be accepted for it going forward.
+
 TellStick and TellStick Duo service.
 
 ![Supports aarch64 Architecture][aarch64-shield] ![Supports amd64 Architecture][amd64-shield] ![Supports armhf Architecture][armhf-shield] ![Supports armv7 Architecture][armv7-shield] ![Supports i386 Architecture][i386-shield]

--- a/tellstick/README.md
+++ b/tellstick/README.md
@@ -2,9 +2,9 @@
 
 > [!CAUTION]
 > **Deprecation notice**
-> The library this add-on depends on is abandoned. It's last activity was 5
-> years ago it it cannot be built on alpine >3.15. Currentlly users can continue
-> to use it but no issues or PRs will be accepted for it going forward.
+> The library this add-on depends on is abandoned. Its last activity was 5
+> years ago and it cannot be built on Alpine versions above 3.15. Users can continue
+> using the add-on, but no issues or pull requests will be accepted.
 
 TellStick and TellStick Duo service.
 


### PR DESCRIPTION
Also add the deprecation notice from the CHANGELOG.md to README.md for better visibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Added a deprecation notice in the README for the TellStick Home Assistant add-on, informing users of the abandoned library and limitations on Alpine versions.
	- Minor formatting change with a newline added at the end of the README file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->