### PR TITLE
google_assistant: Deprecate Google Assistant add-on

### DIFF
--- a/google_assistant/README.md
+++ b/google_assistant/README.md
@@ -1,5 +1,12 @@
 # Home Assistant Add-on: Google Assistant SDK
 
+> [!CAUTION]
+> **Deprecation notice**
+> The [Google Assistant SDK for device][google-assistant-sdk] Python library
+> this add-on depends on is no longer developed and has been archived. The
+> OAuth out-of-band (OOB) flow used by the add-on has been deprecated as well.
+> Hence a new setup is currently no longer possible.
+
 A virtual personal assistant developed by Google.
 
 ![Supports aarch64 Architecture][aarch64-shield] ![Supports amd64 Architecture][amd64-shield] ![Supports armhf Architecture][armhf-shield] ![Supports armv7 Architecture][armv7-shield] ![Supports i386 Architecture][i386-shield]
@@ -21,5 +28,6 @@ If you want to use Google Assistant (for example, from your phone or Google Home
 [google-actions]: https://actions.google.com/
 [google-assistant-integration]: https://www.home-assistant.io/integrations/google_assistant/
 [google-assistant]: https://assistant.google.com/
+[google-assistant-sdk]: https://github.com/googlesamples/assistant-sdk-python
 [i386-shield]: https://img.shields.io/badge/i386-no-red.svg
 [aarch64-shield]: https://img.shields.io/badge/aarch64-no-red.svg

--- a/google_assistant/config.yaml
+++ b/google_assistant/config.yaml
@@ -31,5 +31,5 @@ schema:
   feedback:
     enable: bool
     volume: int(0,100)
-stage: experimental
+stage: deprecated
 webui: http://[HOST]:[PORT:9324]


### PR DESCRIPTION
The Google Assistant SDK Python library is no longer developed. Currently it seems no longer possible to setup this add-on since the [OAuth Out-of-Band flow has been deprecated](https://developers.google.com/identity/protocols/oauth2/resources/oob-migration).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added a deprecation notice in the README for the Google Assistant SDK add-on, indicating it is no longer developed and archived.

- **Configuration Changes**
	- Updated the `stage` attribute from `experimental` to `deprecated` in the configuration file, reflecting the lack of active support for the Google Assistant SDK.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->