### PR TITLE
Refactor git-pull

### DIFF
--- a/git_pull/CHANGELOG.md
+++ b/git_pull/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 8.0.0
+- Refactor git_pull to use HA Api with bashio
+- Update base image to Alpine 3.21
+- Remove ha cli dependency
+
+
 ## 7.14.1
 - Fix error where $HOME is not defined
 

--- a/git_pull/Dockerfile
+++ b/git_pull/Dockerfile
@@ -4,13 +4,6 @@ FROM $BUILD_FROM
 # Setup base
 RUN apk add --no-cache jq curl git openssh-client
 
-# Home Assistant CLI
-ARG BUILD_ARCH
-ARG CLI_VERSION
-RUN curl -Lso /usr/bin/ha \
-        "https://github.com/home-assistant/cli/releases/download/${CLI_VERSION}/ha_${BUILD_ARCH}" \
-    && chmod a+x /usr/bin/ha
-
 # Copy data
 COPY data/run.sh /
 

--- a/git_pull/build.yaml
+++ b/git_pull/build.yaml
@@ -1,12 +1,10 @@
 ---
 build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-base:3.19
-  amd64: ghcr.io/home-assistant/amd64-base:3.19
-  armhf: ghcr.io/home-assistant/armhf-base:3.19
-  armv7: ghcr.io/home-assistant/armv7-base:3.19
-  i386: ghcr.io/home-assistant/i386-base:3.19
+  aarch64: ghcr.io/home-assistant/aarch64-base:3.21
+  amd64: ghcr.io/home-assistant/amd64-base:3.21
+  armhf: ghcr.io/home-assistant/armhf-base:3.21
+  armv7: ghcr.io/home-assistant/armv7-base:3.21
+  i386: ghcr.io/home-assistant/i386-base:3.21
 codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
-args:
-  CLI_VERSION: 4.31.0

--- a/git_pull/config.yaml
+++ b/git_pull/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 7.14.1
+version: 8.0.0
 slug: git_pull
 name: Git pull
 description: Simple git pull to update the local configuration

--- a/git_pull/data/run.sh
+++ b/git_pull/data/run.sh
@@ -49,7 +49,7 @@ function git-clone {
     cp -rf /config/* "${BACKUP_LOCATION}" || bashio::exit.nok "[Error] Copy files to backup directory failed"
 
     # remove config folder content
-    rm -rf /config/{,.[!.],..?}* || { bashio::exit.nok "[Error] Clearing /config failed"
+    rm -rf /config/{,.[!.],..?}* || bashio::exit.nok "[Error] Clearing /config failed"
 
     # git clone
     bashio::log.info "[Info] Start git clone"

--- a/git_pull/data/run.sh
+++ b/git_pull/data/run.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/with-contenv bashio
+# vim: ft=bash
+# shellcheck shell=bash
 
-#### config ####
-
+# shellcheck disable=SC2034
 CONFIG_PATH=/data/options.json
 HOME=~
 

--- a/git_pull/data/run.sh
+++ b/git_pull/data/run.sh
@@ -135,7 +135,7 @@ function git-synchronize {
 
     # Always do a fetch to update repos
     bashio::log.info "[Info] Start git fetch..."
-    git fetch "$GIT_REMOTE" || bashio::exit.nok "[Error] Git fetch failed";
+    git fetch "$GIT_REMOTE" "$GIT_BRANCH" || bashio::exit.nok "[Error] Git fetch failed";
 
     # Prune if configured
     if [ "$GIT_PRUNE" == "true" ]
@@ -192,7 +192,6 @@ function validate-config {
     bashio::log.info "Changed Files: $CHANGED_FILES"
     if [ -n "$RESTART_IGNORED_FILES" ]; then
         for changed_file in $CHANGED_FILES; do
-            bashio::log.info "[Info] Checking: $changed_file"
             restart_required_file=""
             for restart_ignored_file in $RESTART_IGNORED_FILES; do
                 bashio::log.info "[Info] Checking: $changed_file for $restart_ignored_file"
@@ -226,7 +225,6 @@ function validate-config {
     else
         bashio::log.info "[Info] No Restart Required, only ignored changes detected"
     fi
-    bashio::log.info "Finished validation of config"
 }
 
 ###################

--- a/git_pull/data/run.sh
+++ b/git_pull/data/run.sh
@@ -1,23 +1,23 @@
-#!/bin/bash
+#!/usr/bin/with-contenv bashio
 
 #### config ####
 
 CONFIG_PATH=/data/options.json
 HOME=~
 
-DEPLOYMENT_KEY=$(jq --raw-output ".deployment_key[]" $CONFIG_PATH)
-DEPLOYMENT_KEY_PROTOCOL=$(jq --raw-output ".deployment_key_protocol" $CONFIG_PATH)
-DEPLOYMENT_USER=$(jq --raw-output ".deployment_user" $CONFIG_PATH)
-DEPLOYMENT_PASSWORD=$(jq --raw-output ".deployment_password" $CONFIG_PATH)
-GIT_BRANCH=$(jq --raw-output '.git_branch' $CONFIG_PATH)
-GIT_COMMAND=$(jq --raw-output '.git_command' $CONFIG_PATH)
-GIT_REMOTE=$(jq --raw-output '.git_remote' $CONFIG_PATH)
-GIT_PRUNE=$(jq --raw-output '.git_prune' $CONFIG_PATH)
-REPOSITORY=$(jq --raw-output '.repository' $CONFIG_PATH)
-AUTO_RESTART=$(jq --raw-output '.auto_restart' $CONFIG_PATH)
-RESTART_IGNORED_FILES=$(jq --raw-output '.restart_ignore | join(" ")' $CONFIG_PATH)
-REPEAT_ACTIVE=$(jq --raw-output '.repeat.active' $CONFIG_PATH)
-REPEAT_INTERVAL=$(jq --raw-output '.repeat.interval' $CONFIG_PATH)
+DEPLOYMENT_KEY=$(bashio::config 'deployment_key')
+DEPLOYMENT_KEY_PROTOCOL=$(bashio::config 'deployment_key_protocol')
+DEPLOYMENT_USER=$(bashio::config 'deployment_user')
+DEPLOYMENT_PASSWORD=$(bashio::config 'deployment_password')
+GIT_BRANCH=$(bashio::config 'git_branch')
+GIT_COMMAND=$(bashio::config 'git_command')
+GIT_REMOTE=$(bashio::config 'git_remote')
+GIT_PRUNE=$(bashio::config 'git_prune')
+REPOSITORY=$(bashio::config 'repository')
+AUTO_RESTART=$(bashio::config 'auto_restart')
+RESTART_IGNORED_FILES=$(bashio::config 'restart_ignore | join(" ")')
+REPEAT_ACTIVE=$(bashio::config 'repeat.active')
+REPEAT_INTERVAL=$(bashio::config 'repeat.interval')
 ################
 
 #### functions ####
@@ -179,7 +179,7 @@ function validate-config {
     NEW_COMMIT=$(git rev-parse HEAD)
     if [ "$NEW_COMMIT" != "$OLD_COMMIT" ]; then
         echo "[Info] Something has changed, checking Home-Assistant config..."
-        if ha --no-progress core check; then
+        if bashio::core.check; then
             if [ "$AUTO_RESTART" == "true" ]; then
                 DO_RESTART="false"
                 CHANGED_FILES=$(git diff "$OLD_COMMIT" "$NEW_COMMIT" --name-only)
@@ -207,7 +207,7 @@ function validate-config {
                 fi
                 if [ "$DO_RESTART" == "true" ]; then
                     echo "[Info] Restart Home-Assistant"
-                    ha --no-progress core restart 2&> /dev/null
+                    bashio::core.restart
                 else
                     echo "[Info] No Restart Required, only ignored changes detected"
                 fi


### PR DESCRIPTION
I noticed that git pull was error'ing out when trying to restart HA due to a lack of supervisor token. I opted to update the script to use bashio contexts and functions to smooth out the use of it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Simplified Dockerfile by removing Home Assistant CLI setup.
	- Updated `run.sh` script to use the `bashio` library for improved configuration management and logging.
	- Enhanced error handling and logging in the deployment script.
	- Improved maintainability and clarity in the Git synchronization logic.
	- Updated base images in the build configuration to version 3.21.
- **Version Update**
	- Incremented project version from 7.14.1 to 8.0.0 in the configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->