### PR TITLE
matter_server: Bump Python Matter server to 7.0.1

### DIFF
--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 7.0.0
+
+- Bump Python Matter Server to [7.0.1](https://github.com/home-assistant-libs/python-matter-server/releases/tag/7.0.1)
+  - This updates Matter to 1.4
+- Update base image components to what is being used in Home Assistant Debian
+  base images:
+  - Update tempio to 2024.11.2
+  - Update s6-overlay to 3.1.6.2
+  - Update bashio to 0.16.2
+
 ## 6.6.1
 
 - Bump Python Matter Server to [6.6.1](https://github.com/home-assistant-libs/python-matter-server/releases/tag/6.6.1)

--- a/matter_server/build.yaml
+++ b/matter_server/build.yaml
@@ -1,8 +1,8 @@
 ---
 build_from:
-  aarch64: ghcr.io/home-assistant-libs/python-matter-server:6.6.1
-  amd64: ghcr.io/home-assistant-libs/python-matter-server:6.6.1
+  aarch64: ghcr.io/home-assistant-libs/python-matter-server:7.0.1
+  amd64: ghcr.io/home-assistant-libs/python-matter-server:7.0.1
 args:
-  BASHIO_VERSION: 0.14.3
-  TEMPIO_VERSION: 2021.09.0
-  S6_OVERLAY_VERSION: 3.1.5.0
+  BASHIO_VERSION: 0.16.2
+  TEMPIO_VERSION: 2024.11.2
+  S6_OVERLAY_VERSION: 3.1.6.2

--- a/matter_server/config.yaml
+++ b/matter_server/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 6.6.1
+version: 7.0.0
 slug: matter_server
 name: Matter Server
 description: Matter WebSocket Server for Home Assistant Matter support.


### PR DESCRIPTION
Update to the latest Python Matter server. This release comes with Matter 1.4 support.

Furthermore also update s6-overlay, bashio and tempio which other add-ons typically inherit from the Home Assistant specific base containers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated Matter Server to version 7.0.0
  - Upgraded Python Matter Server to version 7.0.1
  - Updated Matter to version 1.4

- **Chores**
  - Updated base image components:
    - Bashio to version 0.16.2
    - Tempio to version 2024.11.2
    - S6-overlay to version 3.1.6.2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->