### PR TITLE
Fix using wrong log level from bashio. Fixes #3917

### DIFF
--- a/git_pull/CHANGELOG.md
+++ b/git_pull/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 8.0.1
+- Fix bashio warn(ing) logger usage breaking deployment keys
+
 ## 8.0.0
 - Refactor git_pull to use HA Api with bashio
 - Update base image to Alpine 3.21

--- a/git_pull/config.yaml
+++ b/git_pull/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 8.0.0
+version: 8.0.1
 slug: git_pull
 name: Git pull
 description: Simple git pull to update the local configuration

--- a/git_pull/data/run.sh
+++ b/git_pull/data/run.sh
@@ -72,7 +72,7 @@ if [ -n "$DEPLOYMENT_KEY" ]; then
     if OUTPUT_CHECK=$(ssh -T -o "StrictHostKeyChecking=no" -o "BatchMode=yes" "$DOMAIN" 2>&1) || { [[ $DOMAIN = *"@github.com"* ]] && [[ $OUTPUT_CHECK = *"You've successfully authenticated"* ]]; }; then
         bashio::log.info "[Info] Valid SSH connection for $DOMAIN"
     else
-        bashio::log.warn "[Warn] No valid SSH connection for $DOMAIN"
+        bashio::log.warning "[Warn] No valid SSH connection for $DOMAIN"
         add-ssh-key
     fi
 fi
@@ -118,7 +118,7 @@ fi
 function git-synchronize {
     # is /config a local git repo?
     if ! git rev-parse --is-inside-work-tree &>/dev/null; then
-        bashio::log.warn "[Warn] Git repository doesn't exist"
+        bashio::log.warning "[Warn] Git repository doesn't exist"
         git-clone
         return
     fi


### PR DESCRIPTION
Fixing the wrongly used log names to ensure proper working without getting any "command not found" error logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Standardized system warning messages to ensure more consistent internal logging.
- **Bug Fixes**
	- Added a changelog entry for version 8.0.1 addressing a logger issue affecting deployment keys.
- **Version Update**
	- Updated version number from 8.0.0 to 8.0.1 in the configuration file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->