### PR TITLE
Bump speech-to-phrase to 1.2.0

### DIFF
--- a/speech_to_phrase/CHANGELOG.md
+++ b/speech_to_phrase/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.2.0
+
+- Split words on dashes `-` and underscores `_`
+- Remove template syntax from names (`[]<>{}()`)
+
 ## 1.1.0
 
 - Add custom sentences

--- a/speech_to_phrase/build.yaml
+++ b/speech_to_phrase/build.yaml
@@ -6,4 +6,4 @@ codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
 args:
-  SPEECH_TO_PHRASE_VERSION: 1.1.0
+  SPEECH_TO_PHRASE_VERSION: 1.2.0

--- a/speech_to_phrase/config.yaml
+++ b/speech_to_phrase/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 1.1.0
+version: 1.2.0
 slug: speech-to-phrase
 name: Speech-to-Phrase
 description: Fast and personalized local speech-to-text


### PR DESCRIPTION
https://github.com/OHF-Voice/speech-to-phrase/compare/v1.1.0...v1.2.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced text processing capabilities by splitting words on dashes (`-`) and underscores (`_`).
	- Updated handling of names by removing template syntax characters (`[]`, `<>`, `{}`, `()`).
- **Chores**
	- Upgraded the speech-to-phrase component to version 1.2.0 in configuration settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->