### PR TITLE
⬆️ upgrade deconz version to 2.29.1-beta as experimental

### DIFF
--- a/deconz/CHANGELOG.md
+++ b/deconz/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 7.1.0-beta
+
+- Bump deCONZ to 2.29.1-beta
+
 ## 7.0.0
 
 - Bump deCONZ to 2.28.1

--- a/deconz/Dockerfile
+++ b/deconz/Dockerfile
@@ -39,16 +39,17 @@ RUN \
 
 # Install deCONZ
 ARG DECONZ_VERSION
+ARG RELEASE_CHANNEL
 RUN \
     set -x \
     && if [ "${BUILD_ARCH}" = "armhf" ]; \
         then \
-            curl -q -L -o /deconz.deb http://deconz.dresden-elektronik.de/raspbian/stable/deconz-${DECONZ_VERSION}-qt5.deb; \
+            curl -q -L -o /deconz.deb http://deconz.dresden-elektronik.de/raspbian/${RELEASE_CHANNEL}/deconz-${DECONZ_VERSION}-qt5.deb; \
         elif [ "${BUILD_ARCH}" = "aarch64" ]; \
         then \
-            curl -q -L -o /deconz.deb http://deconz.dresden-elektronik.de/debian/stable/deconz_${DECONZ_VERSION}-debian-buster-stable_arm64.deb; \
+            curl -q -L -o /deconz.deb http://deconz.dresden-elektronik.de/debian/${RELEASE_CHANNEL}/deconz_${DECONZ_VERSION}-debian-buster-${RELEASE_CHANNEL}_arm64.deb; \
         else \
-            curl -q -L -o /deconz.deb http://deconz.dresden-elektronik.de/ubuntu/stable/deconz-${DECONZ_VERSION}-qt5.deb; \
+            curl -q -L -o /deconz.deb http://deconz.dresden-elektronik.de/ubuntu/${RELEASE_CHANNEL}/deconz-${DECONZ_VERSION}-qt5.deb; \
         fi \
     && dpkg -i /deconz.deb \
     && rm -f /deconz.deb \

--- a/deconz/build.yaml
+++ b/deconz/build.yaml
@@ -7,4 +7,5 @@ codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
 args:
-  DECONZ_VERSION: 2.28.1
+  DECONZ_VERSION: 2.29.1
+  RELEASE_CHANNEL: beta

--- a/deconz/config.yaml
+++ b/deconz/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 7.0.0
+version: 7.1.0-beta
 slug: deconz
 name: deCONZ
 description: >-
@@ -40,6 +40,7 @@ schema:
   dbg_otau: int?
   dbg_zcl: int?
   dbg_zdp: int?
+stage: experimental
 startup: services
 udev: true
 usb: true


### PR DESCRIPTION
I would be interested to get the most recent bug fixes of deconz by switching to this experimental 2.29.1-beta release. I am just curious, whether the deconz add-on can be upgraded to a beta release, while leaving auto-updating installs unaffected. My attempt do do that is to set the `stage` back from default `stable` to `experimental`.

If `stage: experimental ` also affects prior versions of the deconz add-on, than this likely means there is no support for auto-updates to stable releases only. In this case, I guess it is just to early to upgrade all users to a beta version and I am totally ok with simply closing this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated to a new beta release (7.1.0-beta) with an underlying update to 2.29.1-beta.
	- Enabled flexible release channels for installation, allowing access to beta releases.
	- Reflected an experimental stage in configuration settings for improved feature rollout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->