### PR TITLE
Bump speech-to-phrase to 1.3.0

### DIFF
--- a/speech_to_phrase/CHANGELOG.md
+++ b/speech_to_phrase/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.3.0
+
+- Add Coqui STT
+- Support range fractions in custom sentences (https://github.com/OHF-Voice/speech-to-phrase/issues/5)
+- Do full re-train at startup (https://github.com/OHF-Voice/speech-to-phrase/issues/11)
+- Remove websocket command message limit (https://github.com/OHF-Voice/speech-to-phrase/issues/6)
+- Bump `unicode-rbnf` to 2.3.0 (https://github.com/OHF-Voice/speech-to-phrase/issues/15)
+
 ## 1.2.0
 
 - Split words on dashes `-` and underscores `_`

--- a/speech_to_phrase/build.yaml
+++ b/speech_to_phrase/build.yaml
@@ -6,4 +6,4 @@ codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
 args:
-  SPEECH_TO_PHRASE_VERSION: 1.2.0
+  SPEECH_TO_PHRASE_VERSION: 1.3.0

--- a/speech_to_phrase/config.yaml
+++ b/speech_to_phrase/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 1.2.0
+version: 1.3.0
 slug: speech-to-phrase
 name: Speech-to-Phrase
 description: Fast and personalized local speech-to-text


### PR DESCRIPTION
https://github.com/OHF-Voice/speech-to-phrase/compare/v1.2.0...v1.3.0

Fixes for issues:
* https://github.com/OHF-Voice/speech-to-phrase/issues/15
* https://github.com/OHF-Voice/speech-to-phrase/issues/14
* https://github.com/OHF-Voice/speech-to-phrase/issues/5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Released version 1.3.0 with advanced speech-to-text integration using Coqui STT.
  - Added support for range fractions in custom phrases and initiated an automated full re-training process at startup.
  - Removed the websocket command message limit for improved performance.

- **Chores**
  - Updated version numbers and relevant dependencies to align with the new release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->