### PR TITLE
Downgrade the builder runner from `ubuntu-latest` to `ubuntu-22.04`

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   init:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Initialize builds
     outputs:
       changed_files: ${{ steps.changed_files.outputs.all }}
@@ -64,7 +64,7 @@ jobs:
 
   build:
     needs: init
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: needs.init.outputs.changed == 'true'
     name: Build ${{ matrix.arch }} ${{ matrix.addon }} add-on
     strategy:


### PR DESCRIPTION
Mentioned by @agners (https://github.com/home-assistant/addons/pull/3833#issuecomment-2671513299), mirroring the changes in the docker-base repo: https://github.com/home-assistant/docker-base/pull/294.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated our build automation to run on a fixed, stable Linux environment. This change helps standardize the build process, reducing inconsistencies and enhancing overall reliability. These behind‐the-scenes improvements support our ongoing efforts to ensure smoother and more predictable product updates for end users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->