### PR TITLE
Samba: Add the ability to enable and disable trying to become a local master browser on a subnet

### DIFF
--- a/samba/CHANGELOG.md
+++ b/samba/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+
+## 12.5.0
+
+- Add the ability to enable and disable trying to become a local master browser on a subnet
+
 ## 12.4.0
 
 - Add the ability to enable and disable specific shares, improving user control over folder access

--- a/samba/DOCS.md
+++ b/samba/DOCS.md
@@ -36,6 +36,7 @@ Add-on configuration:
 
 ```yaml
 workgroup: WORKGROUP
+local_master: true
 username: homeassistant
 password: YOUR_PASSWORD
 enabled_shares:
@@ -63,6 +64,10 @@ compatibility_mode: false
 ### Option: `workgroup` (required)
 
 Change WORKGROUP to reflect your network needs.
+
+### Option: `local_master` (required)
+
+Enable to try and become a local master browser on a subnet.
 
 ### Option: `username` (required)
 

--- a/samba/config.yaml
+++ b/samba/config.yaml
@@ -27,6 +27,7 @@ options:
   username: homeassistant
   password: null
   workgroup: WORKGROUP
+  local_master: true
   enabled_shares:
     - addons
     - addon_configs
@@ -53,6 +54,7 @@ schema:
   username: str
   password: password
   workgroup: str
+  local_master: bool
   enabled_shares:
     - "match(^(?i:(addons|addon_configs|backup|config|media|share|ssl))$)"
   compatibility_mode: bool

--- a/samba/config.yaml
+++ b/samba/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 12.4.0
+version: 12.5.0
 slug: samba
 name: Samba share
 description: Expose Home Assistant folders with SMB/CIFS

--- a/samba/rootfs/usr/share/tempio/smb.gtpl
+++ b/samba/rootfs/usr/share/tempio/smb.gtpl
@@ -2,6 +2,7 @@
    netbios name = {{ env "HOSTNAME" }}
    workgroup = {{ .workgroup }}
    server string = Samba Home Assistant
+   local master = {{ .local_master | ternary "yes" "no" }}
 
    security = user
    ntlm auth = yes

--- a/samba/translations/en.yaml
+++ b/samba/translations/en.yaml
@@ -11,6 +11,9 @@ configuration:
   workgroup:
     name: Workgroup
     description: Change WORKGROUP to reflect your network needs.
+  local_master:
+    name: Local master
+    description: Enable to try and become a local master browser on a subnet.
   enabled_shares:
     name: >-
       Enabled Shares - allowed values are:


### PR DESCRIPTION
Solution for the feature request #1716 and https://community.home-assistant.io/t/samba-smb-disable-master-browser/722039


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a configurable option that lets users enable or disable the Samba server’s local master browser functionality on a subnet.

- **Documentation**
  - Updated release notes and configuration guides to include the new option and its usage details, ensuring clear instructions for users. 
  - Introduced a new configuration option `local_master` in the Samba add-on documentation, specifying its purpose and functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->