### PR TITLE
dnsmasq: Enable host networking

### DIFF
--- a/dnsmasq/config.yaml
+++ b/dnsmasq/config.yaml
@@ -13,6 +13,7 @@ arch:
   - i386
 image: homeassistant/{arch}-addon-dnsmasq
 init: false
+host_network: true
 options:
   defaults:
     - 8.8.8.8


### PR DESCRIPTION
This patch enables host networking mode for the dnsmasq addon.

## Why is this helpful?

As per the addon's description, it allows users to assign custom domain names to IP addresses in their network, e.g. `home-assistant.example.com`.
When starting to use this feature, I have hit a limitation that felt quite frustrating:

I have various other hosts in my network that I would like to assign names, such as `nas.example.com`.
The dnsmasq addon resolves these without issue, from anywhere _outside_ of Home Assistant OS. From inside HAOS, and notably from Home Assistant itself, I cannot use that domain name (e.g. for adding the NAS's SMB share as a backup location).

If my Home Assistant OS has the IP addresses 192.0.2.23 inside my LAN, I can access the DNS resolver at that IP from my laptop just fine, but not so inside HAOS. If I try, I get outputs like this:

    > dig nas.example.com

    ; <<>> DiG 9.18.33 <<>> nas.example.com
    ;; global options: +cmd
    ;; Got answer:
    ;; ->>HEADER<<- opcode: QUERY, status: NXDOMAIN, id: 37159
    ;; flags: qr rd ra ad; QUERY: 1, ANSWER: 0, AUTHORITY: 1, ADDITIONAL: 1

    ;; OPT PSEUDOSECTION:
    ; EDNS: version: 0, flags:; udp: 1232
    ; COOKIE: 37b052b040bae689 (echoed)
    ;; QUESTION SECTION:
    ;nas.example.com.		IN	A

    ;; AUTHORITY SECTION:
    example.com.		600	IN	SOA	ns.icann.org. noc.dns.icann.org. 2025011553 7200 3600 1209600 3600

    ;; Query time: 135 msec
    ;; SERVER: 172.30.32.3#53(172.30.32.3) (UDP)
    ;; WHEN: Tue Feb 25 23:15:48 CET 2025
    ;; MSG SIZE  rcvd: 132

Just running dig bypasses the names defined in dnsmasq. On the other hand, if I try to access the server directly via the IP that other devices on my home network use for DNS, I get "connection refused":

    > dig @192.0.2.23 nas.example.com
    ;; communications error to 192.0.2.23#53: connection refused
    ;; communications error to 192.0.2.23#53: connection refused
    ;; communications error to 192.0.2.23#53: connection refused

    ; <<>> DiG 9.18.33 <<>> @192.0.2.23 nas.example.com
    ; (1 server found)
    ;; global options: +cmd
    ;; no servers could be reached

I have found multiple Home Assistant community threads which likely refer to the same issue:

-   https://community.home-assistant.io/t/can-home-assistant-os-use-itself-for-dns/552718
-   https://community.home-assistant.io/t/dnsmasq-configuraton/396360

Activating `host_network` fixes these issues:

    > dig nas.example.com

    ; <<>> DiG 9.18.33 <<>> nas.example.com
    ;; global options: +cmd
    ;; Got answer:
    ;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 24463
    ;; flags: qr aa rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1

    ;; OPT PSEUDOSECTION:
    ; EDNS: version: 0, flags:; udp: 1232
    ; COOKIE: 9df3c10872739d34 (echoed)
    ;; QUESTION SECTION:
    ;nas.example.com.		IN	A

    ;; ANSWER SECTION:
    nas.example.com.	5	IN	A	192.0.2.42

    ;; Query time: 3 msec
    ;; SERVER: 172.30.32.3#53(172.30.32.3) (UDP)
    ;; WHEN: Tue Feb 25 23:39:27 CET 2025
    ;; MSG SIZE  rcvd: 95

## Any other references?

Before testing this change to the `dnsmasq` addon, I tried a similar setup with the [AdGuard Home Addon], which does not have this problem. It also has `host_network` enabled.

[AdGuard Home Addon]: https://github.com/hassio-addons/addon-adguard-home

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an option that allows the DNS service to leverage the host’s network stack, which may influence network interface interactions and routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->