### PR TITLE
Add anonymous option back to Mosquitto Addon

### DIFF
--- a/mosquitto/config.yaml
+++ b/mosquitto/config.yaml
@@ -36,6 +36,7 @@ schema:
     - username: str
       password: password
       password_pre_hashed: "bool?"
+  anonymous: bool?
   require_certificate: bool
   certfile: str
   cafile: str?

--- a/mosquitto/rootfs/etc/cont-init.d/mosquitto.sh
+++ b/mosquitto/rootfs/etc/cont-init.d/mosquitto.sh
@@ -80,6 +80,7 @@ fi
 bashio::var.json \
   cafile "${cafile}" \
   certfile "${certfile}" \
+  anonymous "^$(bashio::config 'anonymous')" \
   customize "^$(bashio::config 'customize.active')" \
   customize_folder "$(bashio::config 'customize.folder')" \
   keyfile "${keyfile}" \

--- a/mosquitto/rootfs/usr/share/tempio/mosquitto.gtpl
+++ b/mosquitto/rootfs/usr/share/tempio/mosquitto.gtpl
@@ -19,6 +19,11 @@ persistence_location /data/
 # is busy and cannot read messages fast enough
 max_queued_messages 8192
 
+# Anonymous
+# disables Authentification plugin and enables anonymous
+{{ if .anonymous }}
+allow_anonymous  true
+{{ else }}
 # Authentication plugin
 auth_plugin /usr/share/mosquitto/go-auth.so
 auth_opt_backends files,http
@@ -40,6 +45,7 @@ auth_opt_http_port 80
 auth_opt_http_getuser_uri /authentication
 auth_opt_http_superuser_uri /superuser
 auth_opt_http_aclcheck_uri /acl
+{{ end }}
 
 {{ if .customize }}
 include_dir /share/{{ .customize_folder }}

--- a/mosquitto/translations/en.yaml
+++ b/mosquitto/translations/en.yaml
@@ -8,6 +8,13 @@ configuration:
       without any configuration. You can also specify
       `password_pre_hashed: true` to utilize a pre-hashed password from the
       output of the `pw` command (which is present inside the container).
+  anonymous:
+    name: Anonymous
+    description: >-
+      If enabled, allows clients to connect without authentication.
+      This may be necessary in some cases, but can be a security risk.
+      Ensure proper network restrictions are in place when using this option.
+      WARNING: This option is not recommended!
   require_certificate:
     name: Require Client Certificate
     description: >-


### PR DESCRIPTION
This PR restores the anonymous option to the Mosquitto Addon. 
Reference: https://github.com/home-assistant/addons/pull/3949