### PR TITLE
letsencrypt: add beget.com DNS provider

### DIFF
--- a/letsencrypt/Dockerfile
+++ b/letsencrypt/Dockerfile
@@ -6,6 +6,7 @@ FROM $BUILD_FROM
 ARG \
     BUILD_ARCH \
     ACME_VERSION \
+    CERTBOT_BEGET_PLUGIN_VERSION \
     CERTBOT_DNS_AZURE_VERSION \
     CERTBOT_DNS_CLOUDNS_VERSION \
     CERTBOT_DNS_DESEC_VERSION \
@@ -54,6 +55,7 @@ RUN \
     && pip3 install --no-cache-dir --find-links \
         "https://wheels.home-assistant.io/alpine-$(cut -d '.' -f 1-2 < /etc/alpine-release)/${BUILD_ARCH}/" \
         acme==${ACME_VERSION} \
+        certbot-beget-plugin==${CERTBOT_BEGET_PLUGIN_VERSION} \
         certbot-dns-azure==${CERTBOT_DNS_AZURE_VERSION} \
         certbot-dns-cloudflare==${CERTBOT_VERSION} \
         certbot-dns-cloudns==${CERTBOT_DNS_CLOUDNS_VERSION} \

--- a/letsencrypt/build.yaml
+++ b/letsencrypt/build.yaml
@@ -11,6 +11,7 @@ codenotary:
 args:
   # Developer note: please add a new plugin alphabetically into all lists
   ACME_VERSION: 3.2.0
+  CERTBOT_BEGET_PLUGIN_VERSION: 1.0.0.dev9
   CERTBOT_DNS_AZURE_VERSION: 2.6.1
   CERTBOT_DNS_CLOUDNS_VERSION: 0.7.0
   CERTBOT_DNS_DESEC_VERSION: 1.2.1

--- a/letsencrypt/config.yaml
+++ b/letsencrypt/config.yaml
@@ -48,6 +48,8 @@ schema:
     aws_access_key_id: str?
     aws_secret_access_key: str?
     azure_config: str?
+    beget_username: str?
+    beget_password: str?
     cloudflare_api_key: str?
     cloudflare_api_token: str?
     cloudflare_email: email?
@@ -120,6 +122,7 @@ schema:
     porkbun_secret: str?
     propagation_seconds: int(60,3600)?
     provider: "list(\
+        beget-plugin|\
         dns-azure|\
         dns-cloudflare|\
         dns-cloudns|\

--- a/letsencrypt/rootfs/etc/cont-init.d/file-structure.sh
+++ b/letsencrypt/rootfs/etc/cont-init.d/file-structure.sh
@@ -9,6 +9,8 @@ mkdir -p /data/letsencrypt
 # Setup Let's encrypt config
 echo -e "aws_access_key_id = $(bashio::config 'dns.aws_access_key_id')\n" \
       "aws_secret_access_key = $(bashio::config 'dns.aws_secret_access_key')\n" \
+      "beget_plugin_username = $(bashio::config 'dns.beget_username')\n" \
+      "beget_plugin_password = $(bashio::config 'dns.beget_password')\n" \
       "dns_cloudns_auth_password = $(bashio::config 'dns.cloudns_auth_password')\n" \
       "dns_desec_token = $(bashio::config 'dns.desec_token')\n" \
       "dns_digitalocean_token = $(bashio::config 'dns.digitalocean_token')\n" \

--- a/letsencrypt/rootfs/etc/services.d/lets-encrypt/run
+++ b/letsencrypt/rootfs/etc/services.d/lets-encrypt/run
@@ -52,6 +52,12 @@ if [ "${CHALLENGE}" == "dns" ] && [ "${DNS_PROVIDER}" == "dns-azure" ]; then
     fi
     PROVIDER_ARGUMENTS+=("--authenticator" "${DNS_PROVIDER}" "--${DNS_PROVIDER}-config" "/data/azure_creds")
 
+# Beget
+elif [ "${CHALLENGE}" == "dns" ] && [ "${DNS_PROVIDER}" == "beget-plugin" ]; then
+    bashio::config.require 'dns.beget_username'
+    bashio::config.require 'dns.beget_password'
+    PROVIDER_ARGUMENTS+=("--authenticator" "${DNS_PROVIDER}" "--${DNS_PROVIDER}-credentials" "/data/dnsapikey" "--${DNS_PROVIDER}-propagation-seconds" "${PROPAGATION_SECONDS}")
+
 # CloudFlare
 elif [ "${DNS_PROVIDER}" == "dns-cloudflare" ]; then
     if bashio::config.exists 'dns.cloudflare_api_token'; then


### PR DESCRIPTION
This PR adds beget provider supported by certbot-beget-plugin Python module.

Unfortunately, the module has only a dev release available on PyPi, however I tested it and it works OK. It is the same module used by Nginx Proxy Manager in 2.12.* releases, which are not yet available as Home Assistant addon.

**Side note 1:** I have implement specifying username and password as `beget_username` and `beget_password` keys within the `dns` config key, which get mapped to `beget_plugin_username` and `beget_plugin_password` respectively. This is not a 1:1 mapping of configuration parameter naming, and I will be happy to update that if needed.

**Side note 2:** The plugin does have an unconventional naming scheme (`beget-plugin` instead of, say, `dns-beget`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for the Beget DNS plugin to streamline DNS challenge management.
	- Introduced new optional configuration settings for Beget credentials.
	- Enabled a custom build option for specifying the Beget plugin version for greater flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->