### PR TITLE
Replace DWM with Openbox window manager for deCONZ addon

### DIFF
--- a/deconz/CHANGELOG.md
+++ b/deconz/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 8.0.0
+
+- Use openbox instead of dwm as window manager
+
 ## 7.0.0
 
 - Bump deCONZ to 2.28.1

--- a/deconz/Dockerfile
+++ b/deconz/Dockerfile
@@ -11,7 +11,7 @@ RUN \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
         curl \
-        dwm \
+        openbox \
         iproute2 \
         iputils-ping \
         kmod \

--- a/deconz/config.yaml
+++ b/deconz/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 7.0.0
+version: 8.0.0
 slug: deconz
 name: deCONZ
 description: >-


### PR DESCRIPTION
The DWM window manager is difficult to use without knowing keyboard commands to control it, e.g.: https://gist.github.com/erlendaakre/12eb90eef84a3ab81f7b531e516c9594

User feedback can be found in:
- https://github.com/home-assistant/addons/pull/3708
- https://forum.phoscon.de/t/new-deconz-gui-windows-control-dwm-issues/5097/35

Openbox is a traditional "boring" window manager like Win95. Like DWM it is light weight and also used in the deCONZ community Docker container.

This PR was tested in my local setup.

![image](https://github.com/user-attachments/assets/4cca1495-bf3a-44b8-8924-f7469b64ab36)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Released version 8.0.0 featuring an improved window management experience with a refined graphical setup.
  
- **Documentation**
  - Updated release notes to reflect the version bump and system enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->