### PR TITLE
Samba: Make the vfs objects entry in smb.conf optional

### DIFF
--- a/samba/CHANGELOG.md
+++ b/samba/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## 12.5.1
 
-- Add the ability to enable or disable the configurations that improve interoperability with Apple devices.
-  Disabling this setting can fix issues with file systems that do not support xattr such as exFAT.
+- Add configurations option to disable Apple devices interoperability. Disabling this setting might be required for file systems that do not support extended attributes such as exFAT.
 
 ## 12.5.0
 

--- a/samba/CHANGELOG.md
+++ b/samba/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## 12.5.1
 
-Add the ability to enable or disable the configurations that improve interoperability with Apple devices.
-Disabling this setting can fix issues with file systems that do not support xattr such as exFAT.
+- Add the ability to enable or disable the configurations that improve interoperability with Apple devices.
+  Disabling this setting can fix issues with file systems that do not support xattr such as exFAT.
 
 ## 12.5.0
 

--- a/samba/CHANGELOG.md
+++ b/samba/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 12.5.1
+
+Add the ability to enable or disable the configurations that improve interoperability with Apple devices.
+Disabling this setting can fix issues with file systems that do not support xattr such as exFAT.
+
 ## 12.5.0
 
 - Add the ability to enable and disable trying to become a local master browser on a subnet

--- a/samba/DOCS.md
+++ b/samba/DOCS.md
@@ -100,7 +100,7 @@ when you absolutely need it and understand the possible consequences.
 
 Defaults to `false`.
 
-### Option: `apple_compatability_mode`
+### Option: `apple_compatibility_mode`
 
 Enable Samba configurations to improve interoperability with Apple devices.
 This can cause issues with file systems that do not support xattr such as exFAT.

--- a/samba/DOCS.md
+++ b/samba/DOCS.md
@@ -100,6 +100,13 @@ when you absolutely need it and understand the possible consequences.
 
 Defaults to `false`.
 
+### Option: `apple_compatability_mode`
+
+Enable Samba configurations to improve interoperability with Apple devices.
+This can cause issues with file systems that do not support xattr such as exFAT.
+
+Defaults to `true`.
+
 ## Support
 
 Got questions?

--- a/samba/config.yaml
+++ b/samba/config.yaml
@@ -59,7 +59,7 @@ schema:
   enabled_shares:
     - "match(^(?i:(addons|addon_configs|backup|config|media|share|ssl))$)"
   compatibility_mode: bool
-  apple_compatability_mode: bool
+  apple_compatibility_mode: bool
   veto_files:
     - str
   allow_hosts:

--- a/samba/config.yaml
+++ b/samba/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 12.5.0
+version: 12.5.1
 slug: samba
 name: Samba share
 description: Expose Home Assistant folders with SMB/CIFS
@@ -37,6 +37,7 @@ options:
     - share
     - ssl
   compatibility_mode: false
+  apple_compatability_mode: true
   veto_files:
     - ._*
     - .DS_Store
@@ -58,6 +59,7 @@ schema:
   enabled_shares:
     - "match(^(?i:(addons|addon_configs|backup|config|media|share|ssl))$)"
   compatibility_mode: bool
+  apple_compatability_mode: bool
   veto_files:
     - str
   allow_hosts:

--- a/samba/config.yaml
+++ b/samba/config.yaml
@@ -37,7 +37,7 @@ options:
     - share
     - ssl
   compatibility_mode: false
-  apple_compatability_mode: true
+  apple_compatibility_mode: true
   veto_files:
     - ._*
     - .DS_Store

--- a/samba/rootfs/usr/share/tempio/smb.gtpl
+++ b/samba/rootfs/usr/share/tempio/smb.gtpl
@@ -27,7 +27,7 @@
    dos charset = CP850
    unix charset = UTF-8
    
-   {{ if .apple_compatability_mode }}
+   {{ if .apple_compatibility_mode }}
    vfs objects = catia fruit streams_xattr
    {{ end }}
 

--- a/samba/rootfs/usr/share/tempio/smb.gtpl
+++ b/samba/rootfs/usr/share/tempio/smb.gtpl
@@ -26,8 +26,10 @@
    mangled names = no
    dos charset = CP850
    unix charset = UTF-8
-
+   
+   {{ if .apple_compatability_mode }}
    vfs objects = catia fruit streams_xattr
+   {{ end }}
 
 {{ if (has "config" .enabled_shares) }}
 [config]

--- a/samba/translations/en.yaml
+++ b/samba/translations/en.yaml
@@ -30,8 +30,9 @@ configuration:
   apple_compatibility_mode:
     name: Enable Compatibility Settings for Apple Devices
     description: >-
-      Enable Samba configurations to improve interoperability with Apple devices.
-      May cause issues with file systems that do not support xattr such as exFAT.
+      Enable Samba configurations to improve interoperability with Apple
+      devices. May cause issues with file systems that do not support xattr
+      such as exFAT.
   veto_files:
     name: Veto Files
     description: List of files that are neither visible nor accessible.

--- a/samba/translations/en.yaml
+++ b/samba/translations/en.yaml
@@ -27,8 +27,8 @@ configuration:
     name: Enable Compatibility Mode
     description: >-
       Enable this to use old legacy Samba protocols on the Samba add-on.
-  apple_compatability_mode:
-    name: Enable Compatability Settings for Apple Devices
+  apple_compatibility_mode:
+    name: Enable Compatibility Settings for Apple Devices
     description: >-
       Enable Samba configurations to improve interoperability with Apple devices.
       May cause issues with file systems that do not support xattr such as exFAT.

--- a/samba/translations/en.yaml
+++ b/samba/translations/en.yaml
@@ -27,6 +27,11 @@ configuration:
     name: Enable Compatibility Mode
     description: >-
       Enable this to use old legacy Samba protocols on the Samba add-on.
+  apple_compatability_mode:
+    name: Enable Compatability Settings for Apple Devices
+    description: >-
+      Enable Samba configurations to improve interoperability with Apple devices.
+      May cause issues with file systems that do not support xattr such as exFAT.
   veto_files:
     name: Veto Files
     description: List of files that are neither visible nor accessible.


### PR DESCRIPTION
The 'vfs objects' entry in smb.conf introduced in version 12.3.3 causes problems with file systems that do not support xattr such as exFAT. This change makes the inclusion of this entry optional by exposing it as a configuration option.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Released version 12.5.1 with a new Apple compatibility mode that allows users to toggle enhanced settings for improved interoperability with Apple devices. This option, enabled by default, helps address potential issues on file systems that do not support extended attributes.

- **Documentation**
  - Updated configuration guides and user documentation to explain the new Apple compatibility option, its default activation, and considerations for systems with limited extended attribute support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->