### PR TITLE
letsencrypt: expose `--force-renewal` in configuration

### DIFF
--- a/letsencrypt/CHANGELOG.md
+++ b/letsencrypt/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.4.5
+
+- Expose the certbot `--force-renewal` option to the configuration
+
 ## 5.4.4
 
 - Update certbot to 3.3.0

--- a/letsencrypt/DOCS.md
+++ b/letsencrypt/DOCS.md
@@ -292,6 +292,37 @@ If your custom ACME server uses a certificate signed by an untrusted certificate
 
 </details>
 
+<details>
+  <summary>Using Certbot CLI options</summary>
+
+  The configuration supports different Certbot command line options, as detailed below.
+
+  Dry Run: Do a dry-run when requesting a certificate.
+  
+  ```yaml
+  dry_run: true
+  ```
+
+  Force Renewal: Force renew pre-existing certificates.
+
+  ```yaml
+  force_renewal: true
+  ```
+
+  Test certificates: Obtain a test certificate from the Let's Encrypt staging server.
+
+  ```yaml
+  test_cert: true
+  ```
+
+  Verbose Mode: Enable verbose mode for the certbot log output.
+
+  ```yaml
+  verbose: true
+  ```
+
+</details>
+
 ## Example Configurations
 
 Note: These configuration examples are raw YAML configs. When you use UI edit

--- a/letsencrypt/config.yaml
+++ b/letsencrypt/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 5.4.4
+version: 5.4.5
 breaking_versions: [5.3.0]
 slug: letsencrypt
 name: Let's Encrypt
@@ -41,6 +41,7 @@ schema:
   key_type: list(ecdsa|rsa)?
   elliptic_curve: list(secp256r1|secp384r1)?
   dry_run: bool?
+  force_renewal: bool?
   test_cert: bool?
   verbose: bool?
   dns:

--- a/letsencrypt/rootfs/etc/services.d/lets-encrypt/run
+++ b/letsencrypt/rootfs/etc/services.d/lets-encrypt/run
@@ -22,6 +22,7 @@ ACME_ROOT_CA=$(bashio::config 'acme_root_ca_cert')
 EAB_KID=$(bashio::config 'eab_kid')
 EAB_HMAC_KEY=$(bashio::config 'eab_hmac_key')
 DRY_RUN=$(bashio::config 'dry_run')
+FORCE_RENEWAL=$(bashio::config 'force_renewal')
 TEST_CERT=$(bashio::config 'test_cert')
 VERBOSE=$(bashio::config 'verbose')
 
@@ -356,6 +357,11 @@ ADDITIONAL_ARGS=()
 if [ "${DRY_RUN}" = "true" ]; then
     ADDITIONAL_ARGS+=("--dry-run")
 fi
+if [ "${FORCE_RENEWAL}" = "true" ]; then
+    ADDITIONAL_ARGS+=("--force-renewal")
+else
+    ADDITIONAL_ARGS+=("--keep-until-expiring")
+fi
 if [ "${TEST_CERT}" = "true" ]; then
     ADDITIONAL_ARGS+=("--test-cert")
 fi
@@ -363,9 +369,10 @@ if [ "${VERBOSE}" = "true" ]; then
     ADDITIONAL_ARGS+=("-vvv")
 fi
 
+
 # Generate a new certificate if necessary or expand a previous certificate if domains has changed
 if [ "$CHALLENGE" == "dns" ]; then
-    certbot certonly --non-interactive --keep-until-expiring --expand \
+    certbot certonly --non-interactive --expand \
         --email "$EMAIL" --agree-tos \
         "${KEY_ARGUMENTS[@]}" \
         "${ADDITIONAL_ARGS[@]}" \
@@ -375,7 +382,7 @@ if [ "$CHALLENGE" == "dns" ]; then
         --preferred-chain "ISRG Root X1" \
         "${EAB_ARGUMENTS[@]}"
 else
-    certbot certonly --non-interactive --keep-until-expiring --expand \
+    certbot certonly --non-interactive --expand \
         --email "$EMAIL" --agree-tos \
         "${KEY_ARGUMENTS[@]}" \
         "${ADDITIONAL_ARGS[@]}" \

--- a/letsencrypt/translations/en.yaml
+++ b/letsencrypt/translations/en.yaml
@@ -49,11 +49,11 @@ configuration:
   force_renewal:
     name: Force Renewal
     description: >-
-      Do a certbot force-renewal for requesting the certificates.
+      Do a certbot force-renewal when requesting the certificates.
   test_cert:
     name: Issue test certificates
     description: >-
-      Obtain a test certificate from a staging server.
+      Obtain a test certificate from the Let's Encrypt staging server.
   verbose:
     name: Verbose Mode
     description: >-

--- a/letsencrypt/translations/en.yaml
+++ b/letsencrypt/translations/en.yaml
@@ -46,6 +46,10 @@ configuration:
     name: Dry Run
     description: >-
       Do a certbot dry-run for requesting the certificates.
+  force_renewal:
+    name: Force Renewal
+    description: >-
+      Do a certbot force-renewal for requesting the certificates.
   test_cert:
     name: Issue test certificates
     description: >-


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a configuration option to force certificate renewal for greater control.
  - Added command line options for Certbot, including Dry Run, Force Renewal, Test Certificates, and Verbose Mode.

- **Documentation**
  - Updated the release notes and added a new section detailing various command line options available for Certbot in the latest version (5.4.5).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->