### PR TITLE
Wait for TXT record to propagate

### DIFF
--- a/duckdns/CHANGELOG.md
+++ b/duckdns/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.19.0
+
+- Wait for up to 60 seconds for TXT record to propagate when deploying challenges
+
 ## 1.18.0
 
 - Update to use s6-overlay to manage service

--- a/duckdns/config.yaml
+++ b/duckdns/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 1.18.0
+version: 1.19.0
 slug: duckdns
 name: Duck DNS
 description: >-

--- a/duckdns/rootfs/root/hooks.sh
+++ b/duckdns/rootfs/root/hooks.sh
@@ -33,7 +33,7 @@ deploy_challenge() {
 
     curl -s "https://www.duckdns.org/update?domains=$ALIAS&token=$SYS_TOKEN&txt=$TOKEN_VALUE"
     timeout 60s bash -c -- "
-        while ! dig -t txt _acme-challenge.$ALIAS | grep $TOKEN_VALUE > /dev/null; do
+        while ! dig -t txt \"_acme-challenge.$ALIAS\" | grep -F \"$TOKEN_VALUE\" > /dev/null; do
             sleep 5;
         done
     "

--- a/duckdns/rootfs/root/hooks.sh
+++ b/duckdns/rootfs/root/hooks.sh
@@ -32,6 +32,7 @@ deploy_challenge() {
     #   be found in the $TOKEN_FILENAME file.
 
     curl -s "https://www.duckdns.org/update?domains=$ALIAS&token=$SYS_TOKEN&txt=$TOKEN_VALUE"
+    timeout 60s bash -c -- "while ! dig -t txt _acme-challenge.$ALIAS | grep $TOKEN_VALUE > /dev/null; do sleep 5; done"
 }
 
 clean_challenge() {

--- a/duckdns/rootfs/root/hooks.sh
+++ b/duckdns/rootfs/root/hooks.sh
@@ -32,7 +32,11 @@ deploy_challenge() {
     #   be found in the $TOKEN_FILENAME file.
 
     curl -s "https://www.duckdns.org/update?domains=$ALIAS&token=$SYS_TOKEN&txt=$TOKEN_VALUE"
-    timeout 60s bash -c -- "while ! dig -t txt _acme-challenge.$ALIAS | grep $TOKEN_VALUE > /dev/null; do sleep 5; done"
+    timeout 60s bash -c -- "
+        while ! dig -t txt _acme-challenge.$ALIAS | grep $TOKEN_VALUE > /dev/null; do
+            sleep 5;
+        done
+    "
 }
 
 clean_challenge() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the deployment process by introducing a wait of up to 60 seconds for DNS TXT record propagation, improving reliability during challenge deployment.  
- **Chores**
  - Updated the application version to 1.19.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->