### PR TITLE
Formally deprecate the DHCP Server add-on

### DIFF
--- a/dhcp_server/CHANGELOG.md
+++ b/dhcp_server/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.5.0
+
+**Deprecation notice**
+This will be the final update for this add-on. The maintenance of the ISC DHCP
+Server has been ended in 2022 already.
+
+- Update base image to alpine 3.20
+
 ## 1.4.0
 
 - Update base image to alpine 3.19

--- a/dhcp_server/README.md
+++ b/dhcp_server/README.md
@@ -1,5 +1,11 @@
 # Home Assistant Add-on: DHCP server
 
+> [!CAUTION]
+> **Deprecation notice**
+> The maintenance of the ISC DHCP Server has been ended in 2022 already. Alpine
+> Linux dropped the package in Alpine 3.21. Hence the add-on is deprecated as
+> well. Consider using the DHCP functionality of your router instead.
+
 A simple DHCP server.
 
 ![Supports aarch64 Architecture][aarch64-shield] ![Supports amd64 Architecture][amd64-shield] ![Supports armhf Architecture][armhf-shield] ![Supports armv7 Architecture][armv7-shield] ![Supports i386 Architecture][i386-shield]

--- a/dhcp_server/config.yaml
+++ b/dhcp_server/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 1.4.0
+version: 1.5.0
 slug: dhcp_server
 name: DHCP server
 description: A simple DHCP server
@@ -53,3 +53,4 @@ schema:
       subnet: str
 startup: system
 init: false
+stage: deprecated


### PR DESCRIPTION
The maintenance of the ISC DHCP Server has been ended in 2022 already. Alpine Linux dropped the package in Alpine 3.21. Hence the add-on is deprecated as well.