### PR TITLE
Avoid ordering deprecated add-ons first

### DIFF
--- a/dhcp_server/config.yaml
+++ b/dhcp_server/config.yaml
@@ -1,7 +1,7 @@
 ---
 version: 1.5.0
 slug: dhcp_server
-name: "[Deprecated] DHCP server"
+name: "DHCP server [deprecated]"
 description: A simple DHCP server
 url: https://home-assistant.io/addons/dhcp_server/
 codenotary: notary@home-assistant.io

--- a/google_assistant/config.yaml
+++ b/google_assistant/config.yaml
@@ -1,7 +1,7 @@
 ---
 version: 2.5.0
 slug: google_assistant
-name: Google Assistant SDK
+name: Google Assistant SDK [deprecated]
 description: A virtual personal assistant developed by Google
 url: >-
   https://github.com/home-assistant/addons/tree/master/google_assistant

--- a/tellstick/config.yaml
+++ b/tellstick/config.yaml
@@ -1,7 +1,7 @@
 ---
 version: 2.2.0
 slug: tellstick
-name: TellStick
+name: TellStick [deprecated]
 description: TellStick and TellStick Duo service
 url: https://github.com/home-assistant/addons/tree/master/tellstick
 arch:


### PR DESCRIPTION
With #3980 with added deprecated as a prefix to the add-on name. However, this leads to sorting it first, which isn't ideal.

Move the deprecation notice to the end. Also add it to all the currently deprecated add-ons.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated addon names in configuration files to clearly indicate deprecated status for DHCP Server, Google Assistant SDK, and TellStick. No functional changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->