### PR TITLE
whisper: Improve support for local custom Whisper models

### DIFF
--- a/whisper/CHANGELOG.md
+++ b/whisper/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+- Added configuration mapping to access local models.
+- Updated documentation about `custom_model` usage.
+
 ## 2.4.0
 
 - Add "auto" for model and beam size (0) to select values based on CPU

--- a/whisper/CHANGELOG.md
+++ b/whisper/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## 2.5.0
 
 - Added configuration mapping to access local models.
 - Updated documentation about `custom_model` usage.

--- a/whisper/DOCS.md
+++ b/whisper/DOCS.md
@@ -86,7 +86,8 @@ See [this discussion](https://github.com/openai/whisper/discussions/963) for an 
 
 ## Backups
 
-Whisper model files can be quite large, so they are automatically excluded from backups. The models will be re-downloaded when the backup is restored.
+Whisper model files can be quite large, so they are automatically excluded from backups. The models will be re-downloaded when the backup is restored for a remote model.
+If you're using a local custom Whisper model, you will need to manually copy the model directory again after restoring a backup.
 
 ## Support
 

--- a/whisper/DOCS.md
+++ b/whisper/DOCS.md
@@ -86,8 +86,8 @@ See [this discussion](https://github.com/openai/whisper/discussions/963) for an 
 
 ## Backups
 
-Whisper model files can be quite large, so they are automatically excluded from backups. The models will be re-downloaded when the backup is restored for a remote model.
-If you're using a local custom Whisper model, you will need to manually copy the model directory again after restoring a backup.
+Whisper model files can be large, so they are automatically excluded from backups and re-downloaded on restore for remote models.
+After restoring a backup with a local custom Whisper model, manually copy your model directory again.
 
 ## Support
 

--- a/whisper/DOCS.md
+++ b/whisper/DOCS.md
@@ -67,6 +67,10 @@ Available models:
 ### Option: `custom_model`
 
 Path to a converted model directory, or a CTranslate2-converted Whisper model ID from the HuggingFace Hub like "Systran/faster-distil-whisper-small.en". 
+To use a local custom Whisper model, copy your model directory into the add-on's configuration directory on your Home Assistant instance:
+`/addon_configs/core_whisper/<your-model-dir>`
+Then, set the `custom_model` path to:
+"`/config/<your-model-dir>`". For a local model, the path must start with `/config/`, as this is how the add-on accesses your Home Assistant configuration directory through the container's mounted volume.
 
 ### Option: `beam_size`
 

--- a/whisper/DOCS.md
+++ b/whisper/DOCS.md
@@ -68,9 +68,9 @@ Available models:
 
 Path to a converted model directory, or a CTranslate2-converted Whisper model ID from the HuggingFace Hub like "Systran/faster-distil-whisper-small.en". 
 To use a local custom Whisper model, copy your model directory into the add-on's configuration directory on your Home Assistant instance:
-`/addon_configs/core_whisper/<your-model-dir>`
+`/addon_configs/core_whisper/<your-model-dir>`.
 Then, set the `custom_model` path to:
-"`/config/<your-model-dir>`". For a local model, the path must start with `/config/`, as this is how the add-on accesses your Home Assistant configuration directory through the container's mounted volume.
+`/config/<your-model-dir>`. For a local model, the path must start with `/config/`, as this is how the add-on accesses your Home Assistant configuration directory through the container's mounted volume.
 
 ### Option: `beam_size`
 

--- a/whisper/DOCS.md
+++ b/whisper/DOCS.md
@@ -67,10 +67,10 @@ Available models:
 ### Option: `custom_model`
 
 Path to a converted model directory, or a CTranslate2-converted Whisper model ID from the HuggingFace Hub like "Systran/faster-distil-whisper-small.en". 
-To use a local custom Whisper model, copy your model directory into the add-on's configuration directory on your Home Assistant instance:
-`/addon_configs/core_whisper/<your-model-dir>`.
+To use a local custom Whisper model, first create a `models` subdirectory in the add-on's configuration directory if it does not already exist. Then copy your model directory into:
+`/addon_configs/core_whisper/models/<your-model-dir>`.
 Then, set the `custom_model` path to:
-`/config/<your-model-dir>`. For a local model, the path must start with `/config/`, as this is how the add-on accesses your Home Assistant configuration directory through the container's mounted volume.
+`/config/models/<your-model-dir>`. For a local model, the path must start with `/config/models/`, as this is how the add-on accesses your Home Assistant configuration directory through the container's mounted volume.
 
 ### Option: `beam_size`
 

--- a/whisper/config.yaml
+++ b/whisper/config.yaml
@@ -12,6 +12,9 @@ discovery:
   - wyoming
 backup_exclude:
   - "models*"
+map:
+  - type: addon_config
+    read_only: false
 options:
   model: auto
   language: en

--- a/whisper/config.yaml
+++ b/whisper/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 2.4.0
+version: 2.5.0
 slug: whisper
 name: Whisper
 description: Speech-to-text with Whisper

--- a/whisper/config.yaml
+++ b/whisper/config.yaml
@@ -12,7 +12,6 @@ discovery:
   - wyoming
 backup_exclude:
   - "models*"
-  - "/data/addon_configs/*"
 map:
   - addon_config:rw
 options:

--- a/whisper/config.yaml
+++ b/whisper/config.yaml
@@ -12,9 +12,9 @@ discovery:
   - wyoming
 backup_exclude:
   - "models*"
+  - "/data/addon_configs/*"
 map:
-  - type: addon_config
-    read_only: false
+  - addon_config:rw
 options:
   model: auto
   language: en


### PR DESCRIPTION
## Proposed change
This updates the 'whisper' add-on to clarify how to configure and use a local custom Whisper model.

### Changes:
- Added configuration mapping to access local models.
- Updated documentation about `custom_model` usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Enhanced instructions for using a local custom Whisper model, specifying directory paths and configuration steps.
  - Added new changelog entries highlighting recent documentation and configuration updates.

- **Chores**
  - Updated configuration to enable access to local models by adding a new mapping section and backup exclusions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->