### PR TITLE
fix typo in readme.md for lets encrypt

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ systems that have installed Home Assistant.
 
 - **[Let's Encrypt](/letsencrypt/README.md)**
 
-    Manage an create certificates from Let's Encrypt.
+    Manage and create certificates from Let's Encrypt.
 
 - **[MariaDB](/mariadb/README.md)**
 


### PR DESCRIPTION
fixes typo, should be and not an in readme.md 
quick pr to fix it as it was annoying me 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Fixed a typographical error in the description of the "Let's Encrypt" add-on in the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->