### PR TITLE
Bump Z-Wave JS to 15.1.0

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.12.0
+
+### Features
+
+- Z-Wave JS: Add support for proprietary controller functionality
+
+### Bug fixes
+
+- Z-Wave JS: Fixed two issues that could cause commands to fail with "transmit queue full" errors
+
+### Config file changes
+
+- Add ZWA-2
+
+### Detailed changelogs
+
+- [Z-Wave JS 15.1.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v15.1.0)
+- [Z-Wave JS 15.0.6](https://github.com/zwave-js/node-zwave-js/releases/tag/v15.0.6)
+
 ## 0.11.0
 
 ### Breaking changes

--- a/zwave_js/build.yaml
+++ b/zwave_js/build.yaml
@@ -10,4 +10,4 @@ codenotary:
   base_image: notary@home-assistant.io
 args:
   ZWAVEJS_SERVER_VERSION: 3.0.0
-  ZWAVEJS_VERSION: 15.0.5
+  ZWAVEJS_VERSION: 15.1.0

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.11.0
+version: 0.12.0
 slug: zwave_js
 name: Z-Wave JS
 description: Control a Z-Wave network with Home Assistant Z-Wave JS


### PR DESCRIPTION
Bumps Z-Wave JS to 15.1.0 to fix "transmit queue full" issues.
I tested locally that this builds and runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for proprietary controller functionality in Z-Wave JS.
  - Added support for the ZWA-2 device.

- **Bug Fixes**
  - Resolved issues causing "transmit queue full" errors during command transmission.

- **Documentation**
  - Updated changelog with details for version 0.12.0 and links to recent Z-Wave JS releases.

- **Chores**
  - Updated component version to 0.12.0 and Z-Wave JS to 15.1.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->