### PR TITLE
Bump Z-Wave JS to 15.1.3

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.12.1
+
+### Bug fixes
+
+- Z-Wave JS: Fixed an issue where some controllers could lock up when retrying a command to an unresponsive node
+- Z-Wave JS: Several fixes for legacy Multi Channel devices
+
+### Config file changes
+
+- Add fingerprint for FortrezZ LLC SSA1/SSA2
+
+### Detailed changelogs
+
+- [Z-Wave JS 15.1.3](https://github.com/zwave-js/node-zwave-js/releases/tag/v15.1.3)
+- [Z-Wave JS 15.1.2](https://github.com/zwave-js/node-zwave-js/releases/tag/v15.1.2)
+- [Z-Wave JS 15.1.1](https://github.com/zwave-js/node-zwave-js/releases/tag/v15.1.1)
+
 ## 0.12.0
 
 ### Features

--- a/zwave_js/build.yaml
+++ b/zwave_js/build.yaml
@@ -10,4 +10,4 @@ codenotary:
   base_image: notary@home-assistant.io
 args:
   ZWAVEJS_SERVER_VERSION: 3.0.0
-  ZWAVEJS_VERSION: 15.1.0
+  ZWAVEJS_VERSION: 15.1.3

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.12.0
+version: 0.12.1
 slug: zwave_js
 name: Z-Wave JS
 description: Control a Z-Wave network with Home Assistant Z-Wave JS


### PR DESCRIPTION
While debugging another issue, I realized that my controller was acting up when trying to communicate with an unresponsive device. Turns out that some fixes to retry behavior uncovered this strange firmware behavior which could lead to a perpetual unresponsive controller - soft reset - retry loop.

Addon tested locally, as usually.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the changelog with details for version 0.12.1, including bug fixes and device support updates.
- **Chores**
  - Bumped version numbers in configuration files to 0.12.1 and updated Z-Wave JS dependency to 15.1.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->