### PR TITLE
Fix trust store when using a custom ACME server

### DIFF
--- a/letsencrypt/CHANGELOG.md
+++ b/letsencrypt/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.4.9
+
+- Fix pending issue in 5.4.8 with trust store when using a custom ACME server
+
 ## 5.4.8
 
 - Further improve root certificate handling when using a custom ACME server

--- a/letsencrypt/config.yaml
+++ b/letsencrypt/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 5.4.8
+version: 5.4.9
 breaking_versions: [5.3.0]
 slug: letsencrypt
 name: Let's Encrypt

--- a/letsencrypt/rootfs/etc/services.d/lets-encrypt/run
+++ b/letsencrypt/rootfs/etc/services.d/lets-encrypt/run
@@ -331,10 +331,13 @@ if bashio::config.has_value 'acme_server'; then
         bashio::log.info "Updating the trust store by adding the provided custom root certificate"
         # Address potential header and footer errors from YAML mutiline configuration.
         # Check the certificate and import it in the local trust store.
+        # Certbot relies on the Requests Python library, which uses a built-in
+        # trust store. This is replaced by the updated local trust store.
         echo "${ACME_ROOT_CA_CERT}" \
           | sed 's/----- /-----\n/g' | sed 's/ -----/\n-----/g' \
           | openssl x509  > /usr/local/share/ca-certificates/acme_root_ca.crt \
-          && update-ca-certificates --fresh
+          && update-ca-certificates --fresh \
+          && export REQUESTS_CA_BUNDLE=/etc/ssl/cert.pem
     fi
 else
     # Relevant only for default Let's Encrypt servers.


### PR DESCRIPTION
Prior to #3999, the code replaced Requests' entire trust store with only the custom ACME server's root certificate. This broke Certbot's ability to establish trusted SSL connections with other servers, such as DNS providers for challenges.

#3999 added the custom certificate to the local system trust store, but this isn't sufficient because Requests uses its own internal trust store.

The final solution involves overriding Requests' trust store to use a combined store containing both the default trusted certificates and the custom ACME server's root certificate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue with the trust store when using a custom ACME server, ensuring proper handling of custom root certificates.

- **Chores**
  - Updated documentation with a new changelog entry for version 5.4.9.
  - Bumped version number to 5.4.9 in the configuration file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->