### PR TITLE
Added detail on formatting of ACME custom root certificate in LetsEncrypt UI config flow.

### DIFF
--- a/letsencrypt/DOCS.md
+++ b/letsencrypt/DOCS.md
@@ -251,6 +251,9 @@ If your custom ACME server uses a certificate signed by an untrusted certificate
     -----END CERTIFICATE-----
   ```
 
+When you use the UI config flow, the "ACME Root CA Certificate" must be formatted as:   
+-----BEGIN CERTIFICATE-----(SPACE)(KEY value all on one line)(space)-----END CERTIFICATE-----
+
 When you specify a custom ACME server, the *Dry Run* and *Issue test certificates* options, which are intended for use with the [Let's Encrypt staging server](https://letsencrypt.org/docs/staging-environment/), are automatically disregarded.
 
 </details>


### PR DESCRIPTION
The example config is fine for editing the yaml, but for people using HAOS etc. there needs to be explanation on how to input the ACME custom root certificate via the UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated instructions to clarify the required single-line format for the "ACME Root CA Certificate" field in the UI configuration flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->