### PR TITLE
Bump Z-Wave JS to 15.3.2 and Z-Wave JS Server to 3.0.2

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Z-Wave JS: Fixed a regression from v15 where command delivery verification wouldn't work on S2-capable devices without Supervision
 - Z-Wave JS: Fixed an issue where some CCs could be missing when Z-Wave JS was bundled
 
+### Config file changes
+
+- Disallow manual entry for param 3 on Zooz ZSE70
+
 ### Detailed changelogs
 
 - [Z-Wave JS Server 3.0.2](https://github.com/zwave-js/zwave-js-server/releases/tag/3.0.2)

--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.13.1
+
+### Bug fixes
+
+- Z-Wave JS Server: Fix to reuse the driver's ConfigManager instance instead of creating a new one
+- Z-Wave JS: Fixed a regression from v15 where command delivery verification wouldn't work on S2-capable devices without Supervision
+- Z-Wave JS: Fixed an issue where some CCs could be missing when Z-Wave JS was bundled
+
+### Detailed changelogs
+
+- [Z-Wave JS Server 3.0.2](https://github.com/zwave-js/zwave-js-server/releases/tag/3.0.2)
+- [Z-Wave JS 15.3.2](https://github.com/zwave-js/node-zwave-js/releases/tag/v15.3.2)
+- [Z-Wave JS 15.3.1](https://github.com/zwave-js/node-zwave-js/releases/tag/v15.3.1)
+
 ## 0.13.0
 
 ### Bug fixes

--- a/zwave_js/build.yaml
+++ b/zwave_js/build.yaml
@@ -9,5 +9,5 @@ codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
 args:
-  ZWAVEJS_SERVER_VERSION: 3.0.1
-  ZWAVEJS_VERSION: 15.3.0
+  ZWAVEJS_SERVER_VERSION: 3.0.2
+  ZWAVEJS_VERSION: 15.3.2

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.13.0
+version: 0.13.1
 slug: zwave_js
 name: Z-Wave JS
 description: Control a Z-Wave network with Home Assistant Z-Wave JS


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added release notes for version 0.13.1, highlighting recent bug fixes and configuration changes.
- **Chores**
  - Updated dependency versions to Z-Wave JS Server 3.0.2 and Z-Wave JS 15.3.2.
  - Bumped component version to 0.13.1 in configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->