### PR TITLE
Bump deCONZ to v2.30.2

### DIFF
--- a/deconz/CHANGELOG.md
+++ b/deconz/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 8.2.0
+
+- Bump deCONZ to 2.30.2 [[CHANGELOG](https://github.com/dresden-elektronik/deconz-rest-plugin/releases/tag/v2.30.2)]
+
 ## 8.1.0
 
 - Bump deCONZ to 2.29.5 [[CHANGELOG](https://github.com/dresden-elektronik/deconz-rest-plugin/releases/tag/v2.29.5)]

--- a/deconz/build.yaml
+++ b/deconz/build.yaml
@@ -7,4 +7,4 @@ codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
 args:
-  DECONZ_VERSION: 2.29.5
+  DECONZ_VERSION: 2.30.2

--- a/deconz/config.yaml
+++ b/deconz/config.yaml
@@ -1,9 +1,9 @@
 ---
-version: 8.1.0
+version: 8.2.0
 slug: deconz
 name: deCONZ
 description: >-
-  Control a Zigbee network with ConBee or RaspBee by Dresden Elektronik.
+  Control a Zigbee network with ConBee or RaspBee by Dresden Elektronik
 url: https://github.com/home-assistant/addons/tree/master/deconz
 apparmor: false
 arch:


### PR DESCRIPTION
Update to the latest stable deconz release [v2.30.2](https://github.com/dresden-elektronik/deconz-rest-plugin/releases/tag/v2.30.2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated deCONZ add-on to version 8.2.0 with deCONZ software version 2.30.2.
  - Updated documentation with a new changelog entry and minor description adjustment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->