### PR TITLE
Update trusted_proxies to match docker.address range

### DIFF
--- a/nginx_proxy/DOCS.md
+++ b/nginx_proxy/DOCS.md
@@ -19,7 +19,7 @@ The NGINX Proxy add-on is commonly used in conjunction with the [Duck DNS](https
    http:
      use_x_forwarded_for: true
      trusted_proxies:
-       - 172.30.33.0/24
+       - 172.30.32.0/23
    ```
 3. In the nginx addon configuration, change the `domain` option to the domain name you registered (from DuckDNS or any other domain you control).
 4. Leave all other options as-is.


### PR DESCRIPTION
Updating `DOCS.md` to reflect that HA/Supervisor uses `172.30.32.0/23` network for docker so `trusted_proxies` should match or it's possible for connections to fail with a error of `Connection refused) while connecting to upstream`.
```
~# ha net info
docker:
  address: 172.30.32.0/23
  dns: 172.30.32.3
  gateway: 172.30.32.1
  interface: hassio
```
See https://community.home-assistant.io/t/nginx-configuration-connection-refused/62407 and https://github.com/home-assistant/supervisor/blob/7c6c982414794172298b2f29ce2358df062b1c0a/supervisor/const.py#L35 for additional info.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the example configuration to expand the trusted proxy IP range, now covering both 172.30.32.0/24 and 172.30.33.0/24 subnets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->