### PR TITLE
Add apple_model option

### DIFF
--- a/samba/CHANGELOG.md
+++ b/samba/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 12.5.2
+- Add an option to choose which icon appears for server on macOS Finder.
+
 ## 12.5.1
 
 - Add configurations option to disable Apple devices interoperability. Disabling this setting might be required for file systems that do not support extended attributes such as exFAT.

--- a/samba/config.yaml
+++ b/samba/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 12.5.1
+version: 12.5.2
 slug: samba
 name: Samba share
 description: Expose Home Assistant folders with SMB/CIFS

--- a/samba/config.yaml
+++ b/samba/config.yaml
@@ -38,6 +38,7 @@ options:
     - ssl
   compatibility_mode: false
   apple_compatibility_mode: true
+  apple_model: AudioAccessory6,1
   veto_files:
     - ._*
     - .DS_Store
@@ -60,6 +61,7 @@ schema:
     - "match(^(?i:(addons|addon_configs|backup|config|media|share|ssl))$)"
   compatibility_mode: bool
   apple_compatibility_mode: bool
+  apple_model: str
   veto_files:
     - str
   allow_hosts:

--- a/samba/rootfs/usr/share/tempio/smb.gtpl
+++ b/samba/rootfs/usr/share/tempio/smb.gtpl
@@ -29,6 +29,8 @@
    
    {{ if .apple_compatibility_mode }}
    vfs objects = catia fruit streams_xattr
+   fruit:aapl = yes
+   fruit:model = {{ .apple_model }}
    {{ end }}
 
 {{ if (has "config" .enabled_shares) }}

--- a/samba/translations/en.yaml
+++ b/samba/translations/en.yaml
@@ -33,6 +33,12 @@ configuration:
       Enable Samba configurations to improve interoperability with Apple
       devices. May cause issues with file systems that do not support xattr
       such as exFAT.
+  apple_model:
+    name: Reported model string on Apple devices
+    description: >- 
+      Changes the reported model to Apple devices, changes the icon that 
+      appears in the sidebar on macOS Finder. 
+      E.g. AudioAccessory6,1 would be the Homepod 2.
   veto_files:
     name: Veto Files
     description: List of files that are neither visible nor accessible.


### PR DESCRIPTION
[Relevant feature request](https://community.home-assistant.io/t/add-support-for-user-configurable-fruit-model-in-the-samba-addon/887170).

I do not have a testing environment set up, so I have no idea if this works or not, but it seemed like a really easy change, hence the pull request.

`fruit:aapl = yes` is probably optional. And not sure about the default value, I put in the homepod value but might better to leave it out.