### PR TITLE
Remove incorrect `--find-links` arguments that were being passed to pip

### DIFF
--- a/letsencrypt/Dockerfile
+++ b/letsencrypt/Dockerfile
@@ -51,8 +51,7 @@ RUN \
         musl-dev \
         openssl-dev \
         cargo \
-    && pip3 install --no-cache-dir --find-links \
-        "https://wheels.home-assistant.io/alpine-$(cut -d '.' -f 1-2 < /etc/alpine-release)/${BUILD_ARCH}/" \
+    && pip3 install--no-cache-dir \
         acme==${ACME_VERSION} \
         certbot-dns-azure==${CERTBOT_DNS_AZURE_VERSION} \
         certbot-dns-cloudflare==${CERTBOT_VERSION} \

--- a/letsencrypt/Dockerfile
+++ b/letsencrypt/Dockerfile
@@ -51,7 +51,7 @@ RUN \
         musl-dev \
         openssl-dev \
         cargo \
-    && pip3 install--no-cache-dir \
+    && pip3 install --no-cache-dir \
         acme==${ACME_VERSION} \
         certbot-dns-azure==${CERTBOT_DNS_AZURE_VERSION} \
         certbot-dns-cloudflare==${CERTBOT_VERSION} \

--- a/silabs_flasher/Dockerfile
+++ b/silabs_flasher/Dockerfile
@@ -13,7 +13,6 @@ RUN \
     && pip3 install \
         --no-cache-dir \
         --prefer-binary \
-        --find-links "https://wheels.home-assistant.io/musllinux/${BUILD_ARCH}/" \
         universal-silabs-flasher=="${UNIVERSAL_SILABS_FLASHER}"
 
 COPY rootfs /


### PR DESCRIPTION
While the specific URLs were different, both of them assume a directory structure at https://wheels.home-assistant.io that no longer exists (I assume they probably did at one point, I know that `musllinux` wasn't always the name used).

I imagine the arguments I've removed were intended to accomplish roughly the same thing as this, which is now applied to all pip installations in all Home Assistant docker containers:

https://github.com/home-assistant/docker-base/blob/597ee655f913037c4bc9c8d3c2c6b887a7c1efc8/alpine/rootfs/etc/pip.conf#L3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Python package installation process in Docker images to use default package sources, removing reliance on a custom wheel repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->