### PR TITLE
matter_server: Bump Python Matter server to 8.0.0

### DIFF
--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 8.0.0
+
+- Bump Python Matter Server to [8.0.0](https://github.com/home-assistant-libs/python-matter-server/releases/tag/8.0.0)
+
 ## 7.0.0
 
 - Bump Python Matter Server to [7.0.1](https://github.com/home-assistant-libs/python-matter-server/releases/tag/7.0.1)

--- a/matter_server/build.yaml
+++ b/matter_server/build.yaml
@@ -1,7 +1,7 @@
 ---
 build_from:
-  aarch64: ghcr.io/home-assistant-libs/python-matter-server:7.0.1
-  amd64: ghcr.io/home-assistant-libs/python-matter-server:7.0.1
+  aarch64: ghcr.io/home-assistant-libs/python-matter-server:8.0.0
+  amd64: ghcr.io/home-assistant-libs/python-matter-server:8.0.0
 args:
   BASHIO_VERSION: 0.16.2
   TEMPIO_VERSION: 2024.11.2

--- a/matter_server/config.yaml
+++ b/matter_server/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 7.0.0
+version: 8.0.0
 slug: matter_server
 name: Matter Server
 description: Matter WebSocket Server for Home Assistant Matter support.


### PR DESCRIPTION
Update to the latest Python Matter server. This release comes with the latest Matter SDK updates.

See [Python Matter Server release 8.0.0](https://github.com/home-assistant-libs/python-matter-server/releases/tag/8.0.0) for full list of changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated version references to 8.0.0 in configuration and build files.
  - Added a changelog entry for version 8.0.0 with a link to the release page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->