### PR TITLE
letsencrypt: Fix documentation link to Supervisor restart

### DIFF
--- a/letsencrypt/DOCS.md
+++ b/letsencrypt/DOCS.md
@@ -225,7 +225,7 @@ renewal via [Home Assistant automation][haauto], and then restarting this
 automation every night via the [Supervisor Addon restart action][supervisorrestart].
 
 [haauto]: https://www.home-assistant.io/docs/automation/editor/
-[supervisorrestart]: https://www.home-assistant.io/integrations/hassio/#service-hassioaddon_restart
+[supervisorrestart]: https://www.home-assistant.io/integrations/hassio/#action-hassioaddon_restart
 
 In this example, the automation will run every day at the chosen time, checking
 if a renewal is due, and will request it if needed.


### PR DESCRIPTION
Reflect change made in https://github.com/home-assistant/home-assistant.io/pull/33807

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected the documentation link for the "Supervisor Addon restart action" to ensure it directs to the correct section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->