### PR TITLE
Add support for HuggingFace transformers Whisper models

### DIFF
--- a/whisper/CHANGELOG.md
+++ b/whisper/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.6.0
+
+- Upgrade to Debian bookworm
+- Add support for HuggingFace transformers Whisper models
+
 ## 2.5.0
 
 - Added configuration mapping to access local models.

--- a/whisper/DOCS.md
+++ b/whisper/DOCS.md
@@ -67,10 +67,22 @@ Available models:
 ### Option: `custom_model`
 
 Path to a converted model directory, or a CTranslate2-converted Whisper model ID from the HuggingFace Hub like "Systran/faster-distil-whisper-small.en". 
+
+If `custom_model_type` is set to `transformers`, a HuggingFace transformers Whisper model ID from HuggingFace like "openai/whisper-tiny.en" must be used.
+
 To use a local custom Whisper model, first create a `models` subdirectory in the add-on's configuration directory if it does not already exist. Then copy your model directory into:
 `/addon_configs/core_whisper/models/<your-model-dir>`.
 Then, set the `custom_model` path to:
 `/config/models/<your-model-dir>`. For a local model, the path must start with `/config/models/`, as this is how the add-on accesses your Home Assistant configuration directory through the container's mounted volume.
+
+### Option: `custom_model_type`
+
+Either `faster-whisper` (the default) or `transformers`.
+
+When set to `transformers`, the `custom_model` option must be a HuggingFace transformers-based Whisper model like "openai/whisper-tiny.en".
+
+**Note:** Initial prompt is currently not supported for transformers-based models.
+
 
 ### Option: `beam_size`
 

--- a/whisper/Dockerfile
+++ b/whisper/Dockerfile
@@ -4,12 +4,13 @@ FROM ${BUILD_FROM}
 # Install Whisper
 WORKDIR /usr/src
 ARG WYOMING_WHISPER_VERSION
+ENV PIP_BREAK_SYSTEM_PACKAGES=1
 
 RUN \
     apt-get update \
     && apt-get install -y --no-install-recommends \
         build-essential \
-        netcat \
+        netcat-traditional \
         python3 \
         python3-dev \
         python3-pip \
@@ -19,6 +20,11 @@ RUN \
         wheel \
     && pip3 install --no-cache-dir \
         "wyoming-faster-whisper @ https://github.com/rhasspy/wyoming-faster-whisper/archive/refs/tags/v${WYOMING_WHISPER_VERSION}.tar.gz" \
+        'transformers==4.52.4' \
+    \
+    && pip3 install --no-cache-dir \
+        --index-url 'https://download.pytorch.org/whl/cpu' \
+        'torch==2.6.0' \
     \
     && apt-get purge -y --auto-remove \
         build-essential \

--- a/whisper/build.yaml
+++ b/whisper/build.yaml
@@ -1,9 +1,9 @@
 ---
 build_from:
-  amd64: ghcr.io/home-assistant/amd64-base-debian:bullseye
-  aarch64: ghcr.io/home-assistant/aarch64-base-debian:bullseye
+  amd64: ghcr.io/home-assistant/amd64-base-debian:bookworm
+  aarch64: ghcr.io/home-assistant/aarch64-base-debian:bookworm
 codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
 args:
-  WYOMING_WHISPER_VERSION: 2.4.0
+  WYOMING_WHISPER_VERSION: 2.5.0

--- a/whisper/config.yaml
+++ b/whisper/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 2.5.0
+version: 2.6.0
 slug: whisper
 name: Whisper
 description: Speech-to-text with Whisper
@@ -18,11 +18,14 @@ options:
   model: auto
   language: en
   beam_size: 0
+  custom_model_type: "faster-whisper"
   debug_logging: false
 schema:
   model: |
     list(auto|tiny-int8|tiny|tiny.en|base-int8|base|base.en|small-int8|distil-small.en|small|small.en|distil-medium.en|medium-int8|medium|medium.en|large|large-v1|distil-large-v2|large-v2|distil-large-v3|large-v3|turbo|custom)
   custom_model: str?
+  custom_model_type: |
+    list(faster-whisper|transformers)
   language: |
     list(auto|af|am|ar|as|az|ba|be|bg|bn|bo|br|bs|ca|cs|cy|da|de|el|en|es|et|eu|fa|fi|fo|fr|gl|gu|ha|haw|he|hi|hr|ht|hu|hy|id|is|it|ja|jw|ka|kk|km|kn|ko|la|lb|ln|lo|lt|lv|mg|mi|mk|ml|mn|mr|ms|mt|my|ne|nl|nn|no|oc|pa|pl|ps|pt|ro|ru|sa|sd|si|sk|sl|sn|so|sq|sr|su|sv|sw|ta|te|tg|th|tk|tl|tr|tt|uk|ur|uz|vi|yi|yo|zh|yue)
   beam_size: int

--- a/whisper/rootfs/etc/s6-overlay/s6-rc.d/whisper/run
+++ b/whisper/rootfs/etc/s6-overlay/s6-rc.d/whisper/run
@@ -4,6 +4,7 @@
 # ==============================================================================
 # Start Whisper service
 # ==============================================================================
+flags=()
 
 if [ "$(uname -m)" == "x86_64" ] && ! grep -qw 'avx' /proc/cpuinfo; then
     bashio::log.warning "Your CPU does not support Advanced Vector Extensions (AVX). Whisper will run slower than normal."
@@ -15,6 +16,10 @@ if [ "${model}" = 'custom' ]; then
     model="$(bashio::config 'custom_model')"
     if [ -z "${model}" ]; then
       bashio::exit.nok "Custom model is not set"
+    fi
+    custom_model_type="$(bashio::config 'custom_model_type')"
+    if [ "${custom_model_type}" = 'transformers' ]; then
+      flags+=('--use-transformers')
     fi
 fi
 

--- a/whisper/translations/en.yaml
+++ b/whisper/translations/en.yaml
@@ -26,6 +26,18 @@ configuration:
       Path to a converted model directory, or a CTranslate2-converted Whisper
       model ID from the HuggingFace Hub like
       "Systran/faster-distil-whisper-small.en".
+
+      If custom_model_type is set to 'transformers', a HuggingFace transformers
+      Whisper model ID from HuggingFace like 'openai/whisper-tiny.en' may be
+      used.
+  custom_model_type:
+    name: Custom model type
+    description: |
+      Type of Whisper model expected from custom model.
+
+      The default is 'faster-whisper' which requires a CTranslate2-converted
+      Whisper model. If set to 'transformers', a HuggingFace transformers-based
+      Whisper model may be used.
   initial_prompt:
     name: Initial prompt
     description: >-


### PR DESCRIPTION
The Whisper add-on currently only supports [faster-whisper](https://github.com/SYSTRAN/faster-whisper), an accelerated version of Whisper that requires a special model format. Many fine-tuned Whisper models for different languages are available, but only compatible with HuggingFace's [transformers](https://huggingface.co/docs/transformers/model_doc/whisper) library.

This PR adds a new `custom_model_type` option that can be set to `transformers`. This makes `custom_model` become a model ID for a HuggingFace transformers-based Whisper model like "openai/whisper-tiny.en" or "pierreguillou/whisper-medium-french".

This is a stepping stone on the path to using better community models as the default for specific languages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for HuggingFace transformers Whisper models via a new configuration option.
  - Introduced the ability to specify the type of custom Whisper model with the new custom_model_type setting.
- **Documentation**
  - Updated documentation to clarify model type selection and configuration for custom models.
  - Provided additional guidance on compatibility and usage of the new custom_model_type option.
- **Chores**
  - Upgraded the system base to Debian bookworm and updated related dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->