### PR TITLE
Add Z-Wave JS power level config

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.16.0
+
+### Features
+
+- Add radio frequency power level driver configuration.
+
 ## 0.15.0
 
 ### Features

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.15.0
+version: 0.16.0
 slug: zwave_js
 name: Z-Wave JS
 description: Control a Z-Wave network with Home Assistant Z-Wave JS

--- a/zwave_js/rootfs/etc/cont-init.d/config.sh
+++ b/zwave_js/rootfs/etc/cont-init.d/config.sh
@@ -387,7 +387,7 @@ fi
 rf_region_integer=${rf_region_integer_map["${rf_region}"]}
 
 if [[ "${rf_region_integer}" -eq 255 ]]; then
-    rf_json='{txPower: {powerlevel: "auto"}, maxLongRangePowerlevel: "auto"}'
+    rf_json=$(jq -n '{txPower: {powerlevel: "auto"}, maxLongRangePowerlevel: "auto"}')
     bashio::log.info "Using default RF region settings"
 else
     rf_json=$(jq -n --argjson region "${rf_region_integer}" '{region: $region, txPower: {powerlevel: "auto"}, maxLongRangePowerlevel: "auto"}')

--- a/zwave_js/rootfs/etc/cont-init.d/config.sh
+++ b/zwave_js/rootfs/etc/cont-init.d/config.sh
@@ -15,7 +15,7 @@ declare flush_to_disk
 declare host_chassis
 declare rf_region
 declare rf_region_integer
-declare rf_region_json
+declare rf_json
 declare soft_reset
 declare presets_array
 declare presets

--- a/zwave_js/rootfs/etc/cont-init.d/config.sh
+++ b/zwave_js/rootfs/etc/cont-init.d/config.sh
@@ -387,10 +387,10 @@ fi
 rf_region_integer=${rf_region_integer_map["${rf_region}"]}
 
 if [[ "${rf_region_integer}" -eq 255 ]]; then
-    rf_region_json="{}"
+    rf_json='{txPower: {powerlevel: "auto"}, maxLongRangePowerlevel: "auto"}'
     bashio::log.info "Using default RF region settings"
 else
-    rf_region_json=$(jq -n --argjson region "${rf_region_integer}" '{ region: $region }')
+    rf_json=$(jq -n --argjson region "${rf_region_integer}" '{region: $region, txPower: {powerlevel: "auto"}, maxLongRangePowerlevel: "auto"}')
     bashio::log.info "Setting RF region to (${rf_region})"
 fi
 
@@ -457,7 +457,7 @@ bashio::var.json \
     log_level "${log_level}" \
     log_to_file "${log_to_file}" \
     log_max_files "${log_max_files}" \
-    rf_region "${rf_region_json}" \
+    rf_json "${rf_json}" \
     soft_reset "^${soft_reset}" \
     presets "${presets}" |
     tempio \

--- a/zwave_js/rootfs/usr/share/tempio/zwave_config.conf
+++ b/zwave_js/rootfs/usr/share/tempio/zwave_config.conf
@@ -7,7 +7,7 @@
         "filename": "/config/zwave",
         "forceConsole": true
     },
-    "rf": {{ .rf_region }},
+    "rf": {{ .rf_json }},
     "storage": {
         "cacheDir": "/config/cache",
         "throttle": "slow"


### PR DESCRIPTION
- Apply the auto option for RF power level driver settings.
- This will update the RF power level settings of the controller if the driver detects that the wanted RF region configuration differs from the already configured RF region settings of the controller.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for radio frequency power level driver configuration.

- **Chores**
  - Updated version to 0.16.0 in configuration files.
  - Enhanced configuration to include default power level settings for RF regions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->