### PR TITLE
correct provider name for dnsimple in example in docs

### DIFF
--- a/letsencrypt/DOCS.md
+++ b/letsencrypt/DOCS.md
@@ -550,7 +550,7 @@ Use of this plugin requires a configuration file containing DNSimple API credent
   keyfile: privkey.pem
   challenge: dns
   dns:
-    provider: dns-simple
+    provider: dns-dnsimple
     dnsimple_token: dnssimple-token
 ```
 


### PR DESCRIPTION
The token is `dns-dnsimple` not `dns-simple` as shown in the example.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Corrected the provider identifier in the dnsimple DNS provider plugin example to ensure consistency with supported provider names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->