### PR TITLE
samba: Bind on enabled interfaces only

### DIFF
--- a/samba/CHANGELOG.md
+++ b/samba/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 12.5.2
+
+- Avoid binding to disabled network interfaces
+
 ## 12.5.1
 
 - Add configurations option to disable Apple devices interoperability. Disabling this setting might be required for file systems that do not support extended attributes such as exFAT.

--- a/samba/config.yaml
+++ b/samba/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 12.5.1
+version: 12.5.2
 slug: samba
 name: Samba share
 description: Expose Home Assistant folders with SMB/CIFS

--- a/samba/rootfs/etc/s6-overlay/s6-rc.d/init-smbd/run
+++ b/samba/rootfs/etc/s6-overlay/s6-rc.d/init-smbd/run
@@ -26,7 +26,10 @@ bashio::log.info "Hostname: ${HOSTNAME}"
 
 # Get supported interfaces
 for interface in $(bashio::network.interfaces); do
-    interfaces+=("${interface}")
+    interface_enabled=$(bashio::network.enabled "${interface}")
+    if bashio::var.true "${interface_enabled}"; then
+        interfaces+=("${interface}")
+    fi
 done
 if [ ${#interfaces[@]} -eq 0 ]; then
     bashio::exit.nok 'No supported interfaces found to bind on.'

--- a/samba/rootfs/usr/share/tempio/smb.gtpl
+++ b/samba/rootfs/usr/share/tempio/smb.gtpl
@@ -15,7 +15,7 @@
    log level = 1
 
    bind interfaces only = yes
-   interfaces = 127.0.0.1 {{ .interfaces | join " " }}
+   interfaces = lo {{ .interfaces | join " " }}
    hosts allow = 127.0.0.1 {{ .allow_hosts | join " " }}
 
    {{ if .compatibility_mode }}


### PR DESCRIPTION
Do not try to bind on disabled interfaces. Those don't have an IP address and Samba won't be able to bind them. Also, Samba does not automatically bind to interfaces if they get enabled at runtime. So simply only pass the ones which are enabled.

This avoid spurious DNS requests from Samba. it seems that if an interface is not up, Samba tries to resolve the string (probably in an attempt to find a useful address for the given string).

Fixes: https://github.com/home-assistant/plugin-dns/issues/160

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved network interface detection to include only enabled interfaces.
  - Updated Samba configuration to specify the loopback interface by name instead of IP address, enhancing compatibility with interface binding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->