### PR TITLE
Add streaming support to Piper

### DIFF
--- a/piper/CHANGELOG.md
+++ b/piper/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.6.0
+
+- Add support for streaming audio on sentence boundaries
+
 ## 1.5.4
 
 - Add voices for Dutch: ronnie, pim

--- a/piper/DOCS.md
+++ b/piper/DOCS.md
@@ -73,7 +73,7 @@ Increase `max_piper_procs` if you need to quickly switch between multiple voices
 
 Download the list of new voices automatically every time the add-on starts. You must also reload the Wyoming integration for Piper in Home Assistant to see new voices.
 
-### Option: `update_voices`
+### Option: `streaming`
 
 Enable support for streaming audio. This breaks apart text at sentence boundaries and streams the audio as its being produced. Requires at least HA 2025.7.
 

--- a/piper/DOCS.md
+++ b/piper/DOCS.md
@@ -73,6 +73,10 @@ Increase `max_piper_procs` if you need to quickly switch between multiple voices
 
 Download the list of new voices automatically every time the add-on starts. You must also reload the Wyoming integration for Piper in Home Assistant to see new voices.
 
+### Option: `update_voices`
+
+Enable support for streaming audio. This breaks apart text at sentence boundaries and streams the audio as its being produced. Requires at least HA 2025.7.
+
 ### Option: `debug_logging`
 
 Print DEBUG level messages to the add-on's log.

--- a/piper/build.yaml
+++ b/piper/build.yaml
@@ -6,5 +6,5 @@ codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
 args:
-  WYOMING_PIPER_VERSION: 1.5.4
+  WYOMING_PIPER_VERSION: 1.6.0
   BINARY_PIPER_VERSION: 1.2.0

--- a/piper/config.yaml
+++ b/piper/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 1.5.4
+version: 1.6.0
 slug: piper
 name: Piper
 description: Text-to-speech with Piper
@@ -23,6 +23,7 @@ options:
   max_piper_procs: 1
   debug_logging: false
   update_voices: true
+  streaming: true
 schema:
   voice: |
     list(ar_JO-kareem-low|ar_JO-kareem-medium|ca_ES-upc_ona-medium|ca_ES-upc_ona-x_low|ca_ES-upc_pau-x_low|ca-upc_ona-x-low|ca-upc_pau-x-low|cs_CZ-jirka-low|cs_CZ-jirka-medium|cy_GB-bu_tts-medium|cy_GB-gwryw_gogleddol-medium|da_DK-talesyntese-medium|da-nst_talesyntese-medium|de_DE-eva_k-x_low|de_DE-karlsson-low|de_DE-kerstin-low|de_DE-mls-medium|de_DE-pavoque-low|de_DE-ramona-low|de_DE-thorsten_emotional-medium|de_DE-thorsten-high|de_DE-thorsten-low|de_DE-thorsten-medium|de-eva_k-x-low|de-karlsson-low|de-kerstin-low|de-pavoque-low|de-ramona-low|de-thorsten-low|el-gr-rapunzelina-low|el_GR-rapunzelina-low|en-gb-alan-low|en_GB-alan-low|en_GB-alan-medium|en_GB-alba-medium|en_GB-aru-medium|en_GB-cori-high|en_GB-cori-medium|en_GB-jenny_dioco-medium|en_GB-northern_english_male-medium|en_GB-semaine-medium|en-gb-southern_english_female-low|en_GB-southern_english_female-low|en_GB-vctk-medium|en-us-amy-low|en_US-amy-low|en_US-amy-medium|en_US-arctic-medium|en_US-bryce-medium|en-us-danny-low|en_US-danny-low|en_US-hfc_female-medium|en_US-hfc_male-medium|en_US-joe-medium|en_US-john-medium|en-us-kathleen-low|en_US-kathleen-low|en_US-kristin-medium|en_US-kusal-medium|en_US-l2arctic-medium|en_US-lessac-high|en-us-lessac-low|en_US-lessac-low|en-us-lessac-medium|en_US-lessac-medium|en-us-libritts-high|en_US-libritts-high|en_US-libritts_r-medium|en_US-ljspeech-high|en_US-ljspeech-medium|en_US-norman-medium|en_US-reza_ibrahim-medium|en-us-ryan-high|en_US-ryan-high|en-us-ryan-low|en_US-ryan-low|en-us-ryan-medium|en_US-ryan-medium|en_US-sam-medium|es-carlfm-x-low|es_ES-carlfm-x_low|es_ES-davefx-medium|es_ES-mls_10246-low|es_ES-mls_9972-low|es_ES-sharvard-medium|es-mls_10246-low|es-mls_9972-low|es_MX-ald-medium|es_MX-claude-high|fa_IR-amir-medium|fa_IR-ganji_adabi-medium|fa_IR-ganji-medium|fa_IR-gyro-medium|fa_IR-reza_ibrahim-medium|fi_FI-harri-low|fi_FI-harri-medium|fi-harri-low|fr_FR-gilles-low|fr_FR-mls_1840-low|fr_FR-mls-medium|fr_FR-siwis-low|fr_FR-siwis-medium|fr_FR-tom-medium|fr_FR-upmc-medium|fr-gilles-low|fr-mls_1840-low|fr-siwis-low|fr-siwis-medium|hu_HU-anna-medium|hu_HU-berta-medium|hu_HU-imre-medium|is-bui-medium|is_IS-bui-medium|is_IS-salka-medium|is_IS-steinn-medium|is_IS-ugla-medium|is-salka-medium|is-steinn-medium|is-ugla-medium|it_IT-paola-medium|it_IT-riccardo-x_low|it-riccardo_fasol-x-low|ka_GE-natia-medium|kk-iseke-x-low|kk-issai-high|kk_KZ-iseke-x_low|kk_KZ-issai-high|kk_KZ-raya-x_low|kk-raya-x-low|lb_LU-marylux-medium|lv_LV-aivars-medium|ne-google-medium|ne-google-x-low|ne_NP-google-medium|ne_NP-google-x_low|nl_BE-nathalie-medium|nl_BE-nathalie-x_low|nl_BE-rdh-medium|nl_BE-rdh-x_low|nl-mls_5809-low|nl-mls_7432-low|nl-nathalie-x-low|nl_NL-mls_5809-low|nl_NL-mls_7432-low|nl_NL-mls-medium|nl_NL-pim-medium|nl_NL-ronnie-medium|nl-rdh-medium|nl-rdh-x-low|no_NO-talesyntese-medium|no-talesyntese-medium|pl-mls_6892-low|pl_PL-darkman-medium|pl_PL-gosia-medium|pl_PL-mc_speech-medium|pl_PL-mls_6892-low|pt_BR-cadu-medium|pt-br-edresson-low|pt_BR-edresson-low|pt_BR-faber-medium|pt_BR-jeff-medium|pt_PT-tugão-medium|ro_RO-mihai-medium|ru-irinia-medium|ru_RU-denis-medium|ru_RU-dmitri-medium|ru_RU-irina-medium|ru_RU-ruslan-medium|sk_SK-lili-medium|sl_SI-artur-medium|sr_RS-serbski_institut-medium|sv_SE-lisa-medium|sv_SE-nst-medium|sw_CD-lanfrica-medium|tr_TR-dfki-medium|tr_TR-fahrettin-medium|tr_TR-fettah-medium|uk-lada-x-low|uk_UA-lada-x_low|uk_UA-ukrainian_tts-medium|vi-25hours-single-low|vi-vivos-x-low|vi_VN-25hours_single-low|vi_VN-vais1000-medium|vi_VN-vivos-x_low|zh_CN-huayan-medium|zh-cn-huayan-x-low|zh_CN-huayan-x_low)
@@ -33,6 +34,7 @@ schema:
   max_piper_procs: int
   debug_logging: bool
   update_voices: bool
+  streaming: bool
 ports:
   "10200/tcp": null
 homeassistant: 2023.8.0.dev20230718

--- a/piper/rootfs/etc/s6-overlay/s6-rc.d/piper/run
+++ b/piper/rootfs/etc/s6-overlay/s6-rc.d/piper/run
@@ -9,6 +9,10 @@ if bashio::config.true 'update_voices'; then
     flags+=('--update-voices')
 fi
 
+if bashio::config.true 'streaming'; then
+    flags+=('--streaming')
+fi
+
 if bashio::config.true 'debug_logging'; then
     flags+=('--debug')
 fi

--- a/piper/translations/en.yaml
+++ b/piper/translations/en.yaml
@@ -39,6 +39,12 @@ configuration:
       Download the list of new voices automatically every time the add-on
       starts.  You must also reload the Wyoming integration for Piper in Home
       Assistant to see new voices.
+  streaming:
+    name: Streaming
+    description: >-
+      Enable support for streaming audio. This breaks apart text at sentence
+      boundaries and streams the audio as its being produced. Requires at least
+      HA 2025.7.
   debug_logging:
     name: Debug logging
     description: >-


### PR DESCRIPTION
Bump `wyoming-piper` to 1.6.0: https://github.com/rhasspy/wyoming-piper/compare/v1.5.4...v1.6.0

This adds streaming support to the add-on. With a compatible voice assistant pipeline, this allows long text-to-speech response to start speaking after the first sentence rather than the entire response is finished.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new "streaming" configuration option to enable streaming audio support, which splits text at sentence boundaries and streams audio as it is produced.
- **Documentation**
  - Updated documentation to describe the new "streaming" option and its requirements.
  - Added a changelog entry for version 1.6.0 detailing the new streaming audio support.
- **Chores**
  - Updated version numbers to 1.6.0 in configuration and build files.
  - Added English translation for the new "streaming" option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->