### PR TITLE
Update speech-to-phrase to 1.4.0

### DIFF
--- a/speech_to_phrase/CHANGELOG.md
+++ b/speech_to_phrase/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.4.0
+
+- Load answers from `assist_satellite.ask_question` in automations and scripts
+- Initial support for Catalan, Czech, Greek, Basque, Romanian, Portuguese, Russian, Polish, Hindi, Persian, Finnish, Mongolian, Slovenian, Swahili, and Turkish
+- Rebalance sentence probabilities to reduce number confusion
+- Timer minutes step by 5 instead of 10 after 20
+
 ## 1.3.0
 
 - Add Coqui STT

--- a/speech_to_phrase/DOCS.md
+++ b/speech_to_phrase/DOCS.md
@@ -23,23 +23,33 @@ for more information.
 
 ### Voice commands
 
-- [English](https://github.com/OHF-Voice/speech-to-phrase/blob/main/docs/english.md)
-- [Français (French)](https://github.com/OHF-Voice/speech-to-phrase/blob/main/docs/french.md)
-- [Deutsch (German)](https://github.com/OHF-Voice/speech-to-phrase/blob/main/docs/german.md)
-- [Nederlands (Dutch)](https://github.com/OHF-Voice/speech-to-phrase/blob/main/docs/dutch.md)
-- [Spanish (Español)](https://github.com/OHF-Voice/speech-to-phrase/blob/main/docs/spanish.md)
-- [Italian (Italiano)](https://github.com/OHF-Voice/speech-to-phrase/blob/main/docs/italian.md)
+See [available voice commands](https://github.com/OHF-Voice/speech-to-phrase/blob/main/SENTENCES.md)
 
 ### Custom sentences
 
 You can add [custom sentences][] to `/share/speech-to-phrase/custom_sentences/<language>/sentences.yaml` where `<language>` is:
 
-* `en` - English
-* `fr` - French
+* `ca` - Catalan
+* `cs` - Czech
 * `de` - German
-* `nl` - Dutch
+* `el` - Greek
+* `en` - English
 * `es` - Spanish
+* `eu` - Basque
+* `fa` - Persian/Farsi
+* `fi` - Finnish
+* `fr` - French
+* `hi` - Hindi
 * `it` - Italian
+* `mn` - Mongolian
+* `nl` - Dutch
+* `pl` - Polish
+* `pt_PT` - Portuguese
+* `ro` - Romanian
+* `ru` - Russian
+* `sl` - Slovenian
+* `sw` - Swahili
+* `tr` - Turkish
 
 ## Support
 

--- a/speech_to_phrase/build.yaml
+++ b/speech_to_phrase/build.yaml
@@ -6,4 +6,4 @@ codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
 args:
-  SPEECH_TO_PHRASE_VERSION: 1.3.0
+  SPEECH_TO_PHRASE_VERSION: 1.4.0

--- a/speech_to_phrase/config.yaml
+++ b/speech_to_phrase/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 1.3.0
+version: 1.4.0
 slug: speech-to-phrase
 name: Speech-to-Phrase
 description: Fast and personalized local speech-to-text


### PR DESCRIPTION
https://github.com/OHF-Voice/speech-to-phrase/compare/v1.3.0...v1.4.0

- Load answers from `assist_satellite.ask_question` in automations and scripts
- Initial support for Catalan, Czech, Greek, Basque, Romanian, Portuguese, Russian, Polish, Hindi, Persian, Finnish, Mongolian, Slovenian, Swahili, and Turkish
- Rebalance sentence probabilities to reduce number confusion
- Timer minutes step by 5 instead of 10 after 20


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded language support to include Catalan, Czech, Greek, Basque, Romanian, Portuguese, Russian, Polish, Hindi, Persian, Finnish, Mongolian, Slovenian, Swahili, and Turkish.
  * Answers can now be loaded from assist_satellite.ask_question for use in automations and scripts.

* **Improvements**
  * Sentence probability calculations have been rebalanced to reduce errors related to number confusion.
  * Timer now increments minutes by 5 (instead of 10) after reaching 20 minutes.
  * Documentation updated and consolidated for easier access to supported languages and voice commands.

* **Chores**
  * Updated version to 1.4.0 in changelog, build, and configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->