### PR TITLE
Bump speech-to-phrase to 1.4.1

### DIFF
--- a/speech_to_phrase/CHANGELOG.md
+++ b/speech_to_phrase/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.4.1
+
+- More robust parsing of `ask_question` answers from Home Assistant
+- Remove intent probability normalization
+- Revert to Kneser-Ney smoothing instead of Witten-Bell
+- Re-add German timer sentences
+
 ## 1.4.0
 
 - Load answers from `assist_satellite.ask_question` in automations and scripts

--- a/speech_to_phrase/build.yaml
+++ b/speech_to_phrase/build.yaml
@@ -6,4 +6,4 @@ codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
 args:
-  SPEECH_TO_PHRASE_VERSION: 1.4.0
+  SPEECH_TO_PHRASE_VERSION: 1.4.1

--- a/speech_to_phrase/config.yaml
+++ b/speech_to_phrase/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 1.4.0
+version: 1.4.1
 slug: speech-to-phrase
 name: Speech-to-Phrase
 description: Fast and personalized local speech-to-text


### PR DESCRIPTION
https://github.com/OHF-Voice/speech-to-phrase/compare/v1.4.0...v1.4.1

- More robust parsing of `ask_question` answers from Home Assistant
- Remove intent probability normalization
- Revert to Kneser-Ney smoothing instead of Witten-Bell
- Re-add German timer sentences


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated changelog with details for version 1.4.1.
  * Incremented version number to 1.4.1 in configuration and build files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->