### PR TITLE
Add missing nginx_proxy 3.13.0 changelog entry

### DIFF
--- a/nginx_proxy/CHANGELOG.md
+++ b/nginx_proxy/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.13.0
+
+- Update Alpine Linux to 3.22 (nginx 1.28.x)
+- Update to current Mozilla intermediate SSL config
+
 ## 3.12.0
 
 - Add origin and X-Forwarded-Proto headers to fix origin issues affecting Portainer and other addons


### PR DESCRIPTION
This was missing from https://github.com/home-assistant/addons/pull/4059

Should we push a 3.13.1 just with this? 3.13.0 was a largish update, even though nothing really is expected from users of it to do on upgrade.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a changelog entry for version 3.13.0, highlighting the upgrade to Alpine Linux 3.22 (with nginx 1.28.x) and updated SSL configuration to the latest Mozilla intermediate profile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->