### PR TITLE
Matter server: primary_interface config option

### DIFF
--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 8.0.1
+
+- Allow to configure primary_device
+
 ## 8.0.0
 
 - Bump Python Matter Server to [8.0.0](https://github.com/home-assistant-libs/python-matter-server/releases/tag/8.0.0)

--- a/matter_server/config.yaml
+++ b/matter_server/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 8.0.0
+version: 8.0.1
 slug: matter_server
 name: Matter Server
 description: Matter WebSocket Server for Home Assistant Matter support.
@@ -28,6 +28,7 @@ options:
   log_level_sdk: error
   beta: false
   enable_test_net_dcl: false
+  primary_interface:: null
 schema:
   log_level: list(verbose|debug|info|warning|error|critical)
   log_level_sdk: list(automation|detail|progress|error|none)?
@@ -38,6 +39,7 @@ schema:
     - str?
   matter_server_version: str?
   matter_sdk_wheels_version: str?
+  primary_interface: str?
 ports:
   5580/tcp: null
 stage: stable

--- a/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
+++ b/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
@@ -53,7 +53,11 @@ if bashio::config.true "enable_test_net_dcl"; then
     extra_args+=('--enable-test-net-dcl')
 fi
 
-primary_interface="$(bashio::api.supervisor 'GET' '/network/info' '' 'first(.interfaces[] | select (.primary == true)) .interface')"
+if bashio::config.has_value "primary_interface"; then
+  primary_interface=$(bashio::config 'primary_interface')
+else
+  primary_interface="$(bashio::api.supervisor 'GET' '/network/info' '' 'first(.interfaces[] | select (.primary == true)) .interface')"
+fi
 
 # Try fallback method (e.g. in case NetworkManager is not available)
 # shellcheck disable=SC2086

--- a/matter_server/translations/en.yaml
+++ b/matter_server/translations/en.yaml
@@ -42,5 +42,10 @@ configuration:
     description: >-
       Install custom Matter SDK wheels version. NOTE: The API might not be
       compatible with the Python Matter server.
+  primary_interface:
+    name: Primary network interface
+    description: >-
+      Override the default system primary interface. This should be the interface
+      used for provisioning new Matter devices.
 network:
   5580/tcp: Matter Server WebSocket server port.


### PR DESCRIPTION
Allow to configure primary_interface in addon json

That was probably the intent of https://github.com/home-assistant/addons/pull/3468, but the run script overrides `--primary_interface` even when provided in `matter_server_args`


Closes: #4028

See also: https://community.home-assistant.io/t/home-assistant-cant-add-matter-devices-that-are-in-a-different-vlan/750324/54

```
[23:15:19] INFO: Using 'end0.2' as primary network interface.
[...]
2025-07-05 23:29:34.356 (MainThread) INFO [matter_server.server.device_controller] Starting Matter commissioning with code using Node ID 19.
2025-07-05 23:29:35.656 (Dummy-2) INFO [chip.ChipDeviceCtrl] Established secure session with Device
2025-07-05 23:29:40.972 (Dummy-2) INFO [chip.ChipDeviceCtrl] Commissioning complete
2025-07-05 23:29:40.973 (MainThread) INFO [matter_server.server.device_controller] Commissioned Node ID: 19 vs 19
2025-07-05 23:29:40.974 (MainThread) INFO [matter_server.server.device_controller] Matter commissioning of Node ID 19 successful.
2025-07-05 23:29:40.974 (MainThread) INFO [matter_server.server.device_controller] Interviewing node: 19
2025-07-05 23:29:41.898 (MainThread) INFO [matter_server.server.device_controller] <Node:19> Setting-up node...
2025-07-05 23:29:41.902 (MainThread) INFO [matter_server.server.device_controller] <Node:19> Setting up attributes and events subscription.
2025-07-05 23:29:42.164 (MainThread) INFO [matter_server.server.device_controller] <Node:19> Subscription succeeded with report interval [1, 60]
2025-07-05 23:29:42.166 (MainThread) INFO [matter_server.server.device_controller] Commissioning of Node ID 19 completed.
```