### PR TITLE
duckdns: Only deploy challenge for main domain

### DIFF
--- a/duckdns/CHANGELOG.md
+++ b/duckdns/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.20.0
+
+- Only deploy challenge for the main domain, aliases are handled through CNAME records
+
 ## 1.19.0
 
 - Wait for up to 60 seconds for TXT record to propagate when deploying challenges

--- a/duckdns/config.yaml
+++ b/duckdns/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 1.19.0
+version: 1.20.0
 slug: duckdns
 name: Duck DNS
 description: >-

--- a/duckdns/rootfs/root/hooks.sh
+++ b/duckdns/rootfs/root/hooks.sh
@@ -31,12 +31,14 @@ deploy_challenge() {
     #   TXT record. For HTTP validation it is the value that is expected
     #   be found in the $TOKEN_FILENAME file.
 
-    curl -s "https://www.duckdns.org/update?domains=$ALIAS&token=$SYS_TOKEN&txt=$TOKEN_VALUE"
-    timeout 60s bash -c -- "
-        while ! dig -t txt \"_acme-challenge.$ALIAS\" | grep -F \"$TOKEN_VALUE\" > /dev/null; do
-            sleep 5;
-        done
-    "
+    if [ "$DOMAIN" = "$ALIAS" ]; then
+        curl -s "https://www.duckdns.org/update?domains=$ALIAS&token=$SYS_TOKEN&txt=$TOKEN_VALUE"
+        timeout 60s bash -c -- "
+            while ! dig -t txt \"_acme-challenge.$ALIAS\" | grep -F \"$TOKEN_VALUE\" > /dev/null; do
+                sleep 5;
+            done
+        "
+    fi
 }
 
 clean_challenge() {
@@ -49,7 +51,9 @@ clean_challenge() {
     #
     # The parameters are the same as for deploy_challenge.
 
-    curl -s "https://www.duckdns.org/update?domains=$ALIAS&token=$SYS_TOKEN&txt=removed&clear=true"
+    if [ "$DOMAIN" = "$ALIAS" ]; then
+        curl -s "https://www.duckdns.org/update?domains=$ALIAS&token=$SYS_TOKEN&txt=removed&clear=true"
+    fi
 }
 
 deploy_cert() {


### PR DESCRIPTION
- domain aliases are handled through CNAME records
- update CHANGELOG
- bump version

When using domain aliases and configuring CNAME records for the alias as described:

CNAME .duckdns.org
_acme-challenge. CNAME _acme-challenge..duckdns.org

then it is not necessary to install a DNS token for the alias-domain, because this will automatically be found by letsencrypt. The hook.sh script fails when trying to install the DNS token and will timeout with error due to the added verification step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a changelog entry for version 1.20.0, detailing updated deployment behavior for main domains and aliases.

* **Chores**
  * Updated the version number to 1.20.0 in configuration files.

* **Bug Fixes**
  * Improved challenge deployment and cleanup to only update DNS records for the main domain, with aliases now managed via CNAME records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->