### PR TITLE
letsencrypt: Improve docs for Lets Encrypt YAML to help prevent usage + copy/paste errors

### DIFF
--- a/letsencrypt/DOCS.md
+++ b/letsencrypt/DOCS.md
@@ -296,9 +296,10 @@ When you specify a custom ACME server, the *Dry Run* and *Issue test certificate
 
 ## Example Configurations
 
-Note: These configuration examples are raw YAML configs. When you use UI edit
-mode (default), and configure DNS, simply copy the attributes underneath *dns*
-into the *DNS Provider configuration* field.
+**Important Note for UI Edit Mode:** These configuration examples are raw YAML configs.
+When using the UI edit mode (which is the default), and configuring DNS, you **must**
+only copy the attributes *underneath* the `dns:` key into the "DNS Provider configuration" field.
+Do NOT include the `dns:` key itself when pasting into the UI field, as this will cause parsing errors.
 
 <details>
   <summary>HTTP challenge</summary>

--- a/letsencrypt/config.yaml
+++ b/letsencrypt/config.yaml
@@ -32,6 +32,9 @@ schema:
   certfile: str
   challenge: list(dns|http)
   dns:
+    # Note: When configuring DNS in the UI, only copy the attributes below this line
+    # (e.g., 'provider: dns-cloudflare', 'cloudflare_email: ...') into the
+    # "DNS Provider configuration" field. Do NOT include the 'dns:' key itself.
     # Developer note: please add a new plugin alphabetically into all lists
     aws_access_key_id: str?
     aws_secret_access_key: str?

--- a/letsencrypt/config.yaml
+++ b/letsencrypt/config.yaml
@@ -32,8 +32,8 @@ schema:
   certfile: str
   challenge: list(dns|http)
   dns:
-    # Note: When configuring DNS in the UI, only copy the attributes below this line
-    # (e.g., 'provider: dns-cloudflare', 'cloudflare_email: ...') into the
+    # Note: When configuring DNS in the UI, only copy the attributes below this
+    # line (e.g., 'provider: dns-cloudflare', 'cloudflare_email: ...') into the
     # "DNS Provider configuration" field. Do NOT include the 'dns:' key itself.
     # Developer note: please add a new plugin alphabetically into all lists
     aws_access_key_id: str?


### PR DESCRIPTION
Just documentation updates because we can't enforce a schema on the YAML. This should hopefully help avoid the numerous issues filed for `NoneType` errors like #3790 #3410 #3661 etc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Clarified DNS configuration instructions for UI users: copy only the attributes under the dns section and exclude the dns: key to avoid parsing errors.
  - Emphasized this guidance in the “Example Configurations” section for better visibility.
  - Added inline comments in the configuration schema to guide users entering DNS Provider settings via the UI.
- Chores
  - Improved in-file comments for configuration clarity without changing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->