### PR TITLE
Allow --primary-interface matter server arg

### DIFF
--- a/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
+++ b/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
@@ -59,7 +59,7 @@ if bashio::config.has_value "matter_server_args"; then
 fi
 
 # Only determine primary_interface if not already specified in matter_server_args (from config)
-primary_interface_pattern=" --primary-interface (.*) "
+primary_interface_pattern=" --primary-interface ([^\s]*) "
 if [[ " ${extra_args[*]} " =~ $primary_interface_pattern ]]; then
   bashio::log.info "Using primary interface from config: ${BASH_REMATCH[1]}."
 else


### PR DESCRIPTION
The "--primary-interface" argument is always ignored since the resolved interface is always specified first in the matter server args. This PR uses the specified interface and only resolves the primary interface if one isn't specified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents duplication of the primary network interface argument when user-specified, ensuring proper handling of custom configurations.
  * Improves detection and logging of the primary network interface, with clearer error handling if none is found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->