### PR TITLE
Bump Z-Wave JS Server to 3.2.1

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.20.0
+
+### Features
+
+- Z-Wave JS Server: Bump schema to 44
+- Z-Wave JS Server: Support OTW updates through the FW update service
+
+### Detailed changelogs
+
+- [Z-Wave JS Server 3.2.1](https://github.com/zwave-js/zwave-js-server/releases/tag/3.2.1)
+- [Z-Wave JS Server 3.2.0](https://github.com/zwave-js/zwave-js-server/releases/tag/3.2.0)
+
 ## 0.19.0
 
 ### Features

--- a/zwave_js/build.yaml
+++ b/zwave_js/build.yaml
@@ -9,5 +9,5 @@ codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
 args:
-  ZWAVEJS_SERVER_VERSION: 3.1.0
+  ZWAVEJS_SERVER_VERSION: 3.2.1
   ZWAVEJS_VERSION: 15.10.0

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.19.0
+version: 0.20.0
 slug: zwave_js
 name: Z-Wave JS
 description: Control a Z-Wave network with Home Assistant Z-Wave JS


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the changelog with details for version 0.20.0, including new features and links to related updates.

* **Chores**
  * Updated the server version to 3.2.1 in the build configuration.
  * Increased the integration version number to 0.20.0 in the configuration file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->