### PR TITLE
Allow to specify ezsp-baudrate in silabs_flasher

### DIFF
--- a/silabs_flasher/CHANGELOG.md
+++ b/silabs_flasher/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.3
+
+- Allow to start universal-silabs-flasher with custom ezsp baudrate
+
 ## 0.3.2
 
 - Update flasher script to work with Home Assistant Yellow with CM5

--- a/silabs_flasher/DOCS.md
+++ b/silabs_flasher/DOCS.md
@@ -21,12 +21,13 @@ SkyConnect/ZBT-1 or other USB based wireless adapters).
 
 Add-on configuration:
 
-| Configuration      | Description                                            |
-|--------------------|--------------------------------------------------------|
-| device (mandatory) | Serial service where the Silicon Labs radio is attached |
-| baudrate           | Serial port baudrate (depends on firmware)   |
-| flow_control       | If hardware flow control should be enabled (depends on firmware) |
-| firmware_url       | Custom URL to flash firmware from                      |
+| Configuration       | Description                                            |
+|---------------------|--------------------------------------------------------|
+| device (mandatory)  | Serial service where the Silicon Labs radio is attached |
+| bootloader_baudrate | Serial port baudrate for gecko bootloader (depends on firmware)   |
+| ezsp_baudrate       | Serial port baudrate for ezsp (depends on firmware)   |
+| flow_control        | If hardware flow control should be enabled (depends on firmware) |
+| firmware_url        | Custom URL to flash firmware from                      |
 
 ## Support
 

--- a/silabs_flasher/config.yaml
+++ b/silabs_flasher/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.3.2
+version: 0.3.3
 slug: silabs_flasher
 name: Silicon Labs Flasher
 description: Silicon Labs firmware flasher add-on
@@ -18,11 +18,13 @@ init: false
 options:
   device: null
   bootloader_baudrate: "115200"
+  ezsp_baudrate: "115200"
   flow_control: true
   verbose: false
 schema:
   device: device(subsystem=tty)?
   bootloader_baudrate: list(57600|115200|230400|460800|921600)
+  ezsp_baudrate: list(115200|230400|460800)
   flow_control: bool?
   firmware_url: str?
   verbose: bool?

--- a/silabs_flasher/config.yaml
+++ b/silabs_flasher/config.yaml
@@ -18,13 +18,13 @@ init: false
 options:
   device: null
   bootloader_baudrate: "115200"
-  ezsp_baudrate: "115200"
+  ezsp_baudrate: null
   flow_control: true
   verbose: false
 schema:
   device: device(subsystem=tty)?
   bootloader_baudrate: list(57600|115200|230400|460800|921600)
-  ezsp_baudrate: list(115200|230400|460800)
+  ezsp_baudrate: int?
   flow_control: bool?
   firmware_url: str?
   verbose: bool?

--- a/silabs_flasher/rootfs/etc/s6-overlay/scripts/universal-silabs-flasher-up
+++ b/silabs_flasher/rootfs/etc/s6-overlay/scripts/universal-silabs-flasher-up
@@ -11,6 +11,7 @@ set -e
 declare autoflash_firmware
 declare device
 declare bootloader_baudrate
+declare ezsp_baudrate
 declare firmware
 declare verbose
 declare usb_device_path
@@ -55,6 +56,7 @@ function is_home_assistant_yellow {
 
 device=$(bashio::config 'device')
 bootloader_baudrate=$(bashio::config 'bootloader_baudrate')
+ezsp_baudrate=$(bashio::config 'ezsp_baudrate')
 
 if is_home_assistant_yellow; then
     bashio::log.info "Detected Home Assistant Yellow"
@@ -109,12 +111,13 @@ if bashio::config.true 'verbose'; then
     verbose="-v"
 fi
 
-bashio::log.info "Starting universal-silabs-flasher with ${device} (bootloader baudrate ${bootloader_baudrate})"
+bashio::log.info "Starting universal-silabs-flasher with ${device} (bootloader baudrate ${bootloader_baudrate}) (ezsp baudrate ${ezsp_baudrate})"
 # shellcheck disable=SC2086
 universal-silabs-flasher \
     ${verbose} \
     --device ${device} \
     --bootloader-baudrate "${bootloader_baudrate}" \
+    --ezsp-baudrate "${ezsp_baudrate}" \
     ${gpio_reset_flag} \
     flash --force --firmware "/root/${firmware}"
 

--- a/silabs_flasher/rootfs/etc/s6-overlay/scripts/universal-silabs-flasher-up
+++ b/silabs_flasher/rootfs/etc/s6-overlay/scripts/universal-silabs-flasher-up
@@ -11,7 +11,6 @@ set -e
 declare autoflash_firmware
 declare device
 declare bootloader_baudrate
-declare ezsp_baudrate
 declare firmware
 declare verbose
 declare usb_device_path
@@ -56,7 +55,6 @@ function is_home_assistant_yellow {
 
 device=$(bashio::config 'device')
 bootloader_baudrate=$(bashio::config 'bootloader_baudrate')
-ezsp_baudrate=$(bashio::config 'ezsp_baudrate')
 
 if is_home_assistant_yellow; then
     bashio::log.info "Detected Home Assistant Yellow"
@@ -111,9 +109,9 @@ if bashio::config.true 'verbose'; then
     verbose="-v"
 fi
 
-ezsp_baudrate_arg=""
+ezsp_baudrate_arg=()
 if bashio::config.has_value 'ezsp_baudrate'; then
-    ezsp_baudrate_arg="--ezsp-baudrate \"${ezsp_baudrate}\""
+    ezsp_baudrate_arg=("--ezsp-baudrate", bashio::config 'ezsp_baudrate')
 fi
 
 bashio::log.info "Starting universal-silabs-flasher with ${device} (bootloader baudrate ${bootloader_baudrate})"
@@ -122,6 +120,6 @@ universal-silabs-flasher \
     ${verbose} \
     --device ${device} \
     --bootloader-baudrate "${bootloader_baudrate}" \
-    ${ezsp_baudrate_arg} \
+    "${ezsp_baudrate_arg[@]}" \
     ${gpio_reset_flag} \
     flash --force --firmware "/root/${firmware}"

--- a/silabs_flasher/rootfs/etc/s6-overlay/scripts/universal-silabs-flasher-up
+++ b/silabs_flasher/rootfs/etc/s6-overlay/scripts/universal-silabs-flasher-up
@@ -121,9 +121,7 @@ bashio::log.info "Starting universal-silabs-flasher with ${device} (bootloader b
 universal-silabs-flasher \
     ${verbose} \
     --device ${device} \
-    --bootloader-baudrate ${bootloader_baudrate}" \
+    --bootloader-baudrate "${bootloader_baudrate}" \
     ${ezsp_baudrate_arg} \
     ${gpio_reset_flag} \
     flash --force --firmware "/root/${firmware}"
-
-

--- a/silabs_flasher/rootfs/etc/s6-overlay/scripts/universal-silabs-flasher-up
+++ b/silabs_flasher/rootfs/etc/s6-overlay/scripts/universal-silabs-flasher-up
@@ -111,7 +111,7 @@ fi
 
 ezsp_baudrate_arg=()
 if bashio::config.has_value 'ezsp_baudrate'; then
-    ezsp_baudrate_arg=("--ezsp-baudrate", $(bashio::config 'ezsp_baudrate'))
+    ezsp_baudrate_arg=("--ezsp-baudrate" $(bashio::config 'ezsp_baudrate'))
 fi
 
 bashio::log.info "Starting universal-silabs-flasher with ${device} (bootloader baudrate ${bootloader_baudrate})"

--- a/silabs_flasher/rootfs/etc/s6-overlay/scripts/universal-silabs-flasher-up
+++ b/silabs_flasher/rootfs/etc/s6-overlay/scripts/universal-silabs-flasher-up
@@ -109,9 +109,10 @@ if bashio::config.true 'verbose'; then
     verbose="-v"
 fi
 
-ezsp_baudrate_arg=()
+declare -a ezsp_baudrate_arg=()
 if bashio::config.has_value 'ezsp_baudrate'; then
-    ezsp_baudrate_arg=("--ezsp-baudrate" $(bashio::config 'ezsp_baudrate'))
+    baud="$(bashio::config 'ezsp_baudrate')"
+    ezsp_baudrate_arg=(--ezsp-baudrate "$baud")
 fi
 
 bashio::log.info "Starting universal-silabs-flasher with ${device} (bootloader baudrate ${bootloader_baudrate})"

--- a/silabs_flasher/rootfs/etc/s6-overlay/scripts/universal-silabs-flasher-up
+++ b/silabs_flasher/rootfs/etc/s6-overlay/scripts/universal-silabs-flasher-up
@@ -111,7 +111,7 @@ fi
 
 ezsp_baudrate_arg=()
 if bashio::config.has_value 'ezsp_baudrate'; then
-    ezsp_baudrate_arg=("--ezsp-baudrate", bashio::config 'ezsp_baudrate')
+    ezsp_baudrate_arg=("--ezsp-baudrate", $(bashio::config 'ezsp_baudrate'))
 fi
 
 bashio::log.info "Starting universal-silabs-flasher with ${device} (bootloader baudrate ${bootloader_baudrate})"

--- a/silabs_flasher/rootfs/etc/s6-overlay/scripts/universal-silabs-flasher-up
+++ b/silabs_flasher/rootfs/etc/s6-overlay/scripts/universal-silabs-flasher-up
@@ -111,13 +111,18 @@ if bashio::config.true 'verbose'; then
     verbose="-v"
 fi
 
-bashio::log.info "Starting universal-silabs-flasher with ${device} (bootloader baudrate ${bootloader_baudrate}) (ezsp baudrate ${ezsp_baudrate})"
+ezsp_baudrate_arg=""
+if bashio::config.has_value 'ezsp_baudrate'; then
+    ezsp_baudrate_arg="--ezsp-baudrate \"${ezsp_baudrate}\""
+fi
+
+bashio::log.info "Starting universal-silabs-flasher with ${device} (bootloader baudrate ${bootloader_baudrate})"
 # shellcheck disable=SC2086
 universal-silabs-flasher \
     ${verbose} \
     --device ${device} \
-    --bootloader-baudrate "${bootloader_baudrate}" \
-    --ezsp-baudrate "${ezsp_baudrate}" \
+    --bootloader-baudrate ${bootloader_baudrate}" \
+    ${ezsp_baudrate_arg} \
     ${gpio_reset_flag} \
     flash --force --firmware "/root/${firmware}"
 

--- a/silabs_flasher/translations/en.yaml
+++ b/silabs_flasher/translations/en.yaml
@@ -8,6 +8,11 @@ configuration:
     description: >-
       The serial port baudrate used to communicate with the Silicon Labs radio
       in bootloader mode.
+  ezsp_baudrate:
+    name: EZSP Baudrate
+    description: >-
+      The serial port baudrate used to communicate with the Silicon Labs radio
+      in ezsp mode.
   flow_control:
     name: Hardware flow control
     description: Enable hardware flow control for serial port.


### PR DESCRIPTION
There are some [firmwares](https://github.com/darkxst/silabs-firmware-builder/blob/main/firmware_builds/zbdonglee/ncp-uart-hw-v7.4.5.0-zbdonglee-230400.gbl) with not standard (115200) baudrate for ezsp application. 
Added config variable to specify that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring a custom EZSP baudrate for the universal-silabs-flasher.

* **Documentation**
  * Docs and changelog updated to show separate baudrate options for bootloader and EZSP and how to use them.

* **Chores**
  * Configuration schema and translations updated to include the new EZSP baudrate option; package version bumped to 0.3.3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->