### PR TITLE
Fix DuckDNS Single TXT record limitations

### DIFF
--- a/duckdns/config.yaml
+++ b/duckdns/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 1.20.0
+version: 1.21.0
 slug: duckdns
 name: Duck DNS
 description: >-

--- a/duckdns/rootfs/etc/s6-overlay/s6-rc.d/duckdns/run
+++ b/duckdns/rootfs/etc/s6-overlay/s6-rc.d/duckdns/run
@@ -36,10 +36,10 @@ function le_renew() {
     bashio::log.info "Renew certificate for domains: $(echo -n "${domains}") and aliases: $(echo -n "${aliases}")"
 
     for domain in $(echo "${domains}" "${aliases}" | tr ' ' '\n' | sort | uniq); do
-        domain_args+=("--domain" "${domain}")
+		# DuckDNS does not support more than a single TXT record, so, you need to process echo domain or alias separately
+		dehydrated --cron --algo "${ALGO}" --hook /root/hooks.sh --challenge dns-01 --domain "${domain}" --out "${CERT_DIR}" --config "${WORK_DIR}/config" || true
     done
 
-    dehydrated --cron --algo "${ALGO}" --hook /root/hooks.sh --challenge dns-01 "${domain_args[@]}" --out "${CERT_DIR}" --config "${WORK_DIR}/config" || true
     LE_UPDATE="$(date +%s)"
 }
 

--- a/duckdns/rootfs/root/hooks.sh
+++ b/duckdns/rootfs/root/hooks.sh
@@ -14,6 +14,9 @@ deploy_challenge() {
     local DOMAIN="${1}" TOKEN_FILENAME="${2}" TOKEN_VALUE="${3}" ALIAS
     ALIAS="$(jq --raw-output --exit-status "[.aliases[]|{(.domain):.alias}]|add.\"$DOMAIN\"" $CONFIG_PATH)" || ALIAS="$DOMAIN"
 
+	echo "Processing domain: $DOMAIN"
+	echo ""
+
     # This hook is called once for every domain that needs to be
     # validated, including any alternative names you may have listed.
     #
@@ -31,14 +34,12 @@ deploy_challenge() {
     #   TXT record. For HTTP validation it is the value that is expected
     #   be found in the $TOKEN_FILENAME file.
 
-    if [ "$DOMAIN" = "$ALIAS" ]; then
-        curl -s "https://www.duckdns.org/update?domains=$ALIAS&token=$SYS_TOKEN&txt=$TOKEN_VALUE"
-        timeout 60s bash -c -- "
-            while ! dig -t txt \"_acme-challenge.$ALIAS\" | grep -F \"$TOKEN_VALUE\" > /dev/null; do
-                sleep 5;
-            done
-        "
-    fi
+	curl -s "https://www.duckdns.org/update?domains=$ALIAS&token=$SYS_TOKEN&txt=$TOKEN_VALUE"
+	timeout 120s bash -c -- "
+		while ! dig -t txt \"_acme-challenge.$ALIAS\" | grep -F \"$TOKEN_VALUE\" > /dev/null; do
+			sleep 5;
+		done
+	"
 }
 
 clean_challenge() {
@@ -51,9 +52,7 @@ clean_challenge() {
     #
     # The parameters are the same as for deploy_challenge.
 
-    if [ "$DOMAIN" = "$ALIAS" ]; then
-        curl -s "https://www.duckdns.org/update?domains=$ALIAS&token=$SYS_TOKEN&txt=removed&clear=true"
-    fi
+	curl -s "https://www.duckdns.org/update?domains=$ALIAS&token=$SYS_TOKEN&txt=removed&clear=true"
 }
 
 deploy_cert() {


### PR DESCRIPTION
**run:**
- Call Dehydrator per-domain or alias due to limitation in DuckDNS which can only handle a single TXT record at a time

**hooks:**
- Output text to show that domain or alias is being processed
- Remove filtering of the domain = alias, otherwise, aliases are not getting renewed
- DuckDNS NameServer TTL is observed at 60s, so, we need to wait longer than that