### PR TITLE
duckdns: Improve GREP in case of dashes in token

### DIFF
--- a/duckdns/CHANGELOG.md
+++ b/duckdns/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.23.0
+
+- Improve GREP syntax for better stability for tokens with dashes
+
 ## 1.22.0
 
 - Fix bashio logger issue

--- a/duckdns/config.yaml
+++ b/duckdns/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 1.22.0
+version: 1.23.0
 slug: duckdns
 name: Duck DNS
 description: >-

--- a/duckdns/rootfs/root/hooks.sh
+++ b/duckdns/rootfs/root/hooks.sh
@@ -36,7 +36,7 @@ deploy_challenge() {
 
 	curl -s "https://www.duckdns.org/update?domains=$ALIAS&token=$SYS_TOKEN&txt=$TOKEN_VALUE"
 	timeout 120s bash -c -- "
-		while ! dig -t txt \"_acme-challenge.$ALIAS\" | grep -F \"$TOKEN_VALUE\" > /dev/null; do
+		while ! dig -t txt \"_acme-challenge.$ALIAS\" | grep -F -- \"$TOKEN_VALUE\" > /dev/null; do
 			sleep 5;
 		done
 	"


### PR DESCRIPTION
- Add '--' to GREP to signify no more parameters. This should help if the Token contains a dash in it
- Bumped version
- Updated changelog