### PR TITLE
Bump Z-Wave JS to 15.11.0

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 0.21.0
+
+### Features
+
+- Z-Wave JS: Add support for defining Scene labels in config files
+- Z-Wave JS: Disable SmartStart provisioning entries after 5 failed inclusion attempts
+
+### Bug fixes
+
+- Z-Wave JS: Fixed an issue where Aeotec Z-Stick 5 would become unresponsive during NVM backup
+- Z-Wave JS: Fixed firmware update progress jumping back and forth
+- Z-Wave JS: Fixed incorrect long-term averaging of RSSI values
+- Z-Wave JS: Ensure failures during NVM migration are surfaced to the application
+
+### Config file changes
+
+- Prepare Inovelli VZW31-SN for future firmware upgrade
+- Add productID `0x0111` to Fakro AMZ Solar awning
+- Add ECO-DIM.07 800 series version
+- Update Aeotec Trisensor 8 to firmware 2.8.4
+- Remove non-existent parameter 107 for Shelly Wave Plus S
+- Fix typo in Shelly dimmer output label
+
+### Detailed changelogs
+
+- [Z-Wave JS 15.11.0](https://github.com/zwave-js/zwave-js/releases/tag/v15.11.0)
+
 ## 0.20.0
 
 ### Features

--- a/zwave_js/build.yaml
+++ b/zwave_js/build.yaml
@@ -10,4 +10,4 @@ codenotary:
   base_image: notary@home-assistant.io
 args:
   ZWAVEJS_SERVER_VERSION: 3.2.1
-  ZWAVEJS_VERSION: 15.10.0
+  ZWAVEJS_VERSION: 15.11.0

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.20.0
+version: 0.21.0
 slug: zwave_js
 name: Z-Wave JS
 description: Control a Z-Wave network with Home Assistant Z-Wave JS


### PR DESCRIPTION
Built and tested locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped add-on to version 0.21.0.
  * Updated bundled Z-Wave JS to 15.11.0.

* **Documentation**
  * Added 0.21.0 changelog highlighting:
    * New: scene label support in configs; SmartStart auto-disable after repeated failures.
    * Fixes: NVM backup responsiveness, firmware update progress stability, improved RSSI averaging, clearer NVM migration errors.
    * Config updates for several devices (e.g., Inovelli, Fakro, ECO-DIM, Aeotec, Shelly).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->