### PR TITLE
matter_server: Bump Python Matter server to 8.1.0

### DIFF
--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 8.1.0
+
+- Bump Python Matter Server to [8.1.0](https://github.com/home-assistant-libs/python-matter-server/releases/tag/8.1.0)
+- Update bashio to 0.17.1
+
 ## 8.0.0
 
 - Bump Python Matter Server to [8.0.0](https://github.com/home-assistant-libs/python-matter-server/releases/tag/8.0.0)

--- a/matter_server/build.yaml
+++ b/matter_server/build.yaml
@@ -1,8 +1,8 @@
 ---
 build_from:
-  aarch64: ghcr.io/home-assistant-libs/python-matter-server:8.0.0
-  amd64: ghcr.io/home-assistant-libs/python-matter-server:8.0.0
+  aarch64: ghcr.io/home-assistant-libs/python-matter-server:8.1.0
+  amd64: ghcr.io/home-assistant-libs/python-matter-server:8.1.0
 args:
-  BASHIO_VERSION: 0.16.2
+  BASHIO_VERSION: 0.17.1
   TEMPIO_VERSION: 2024.11.2
   S6_OVERLAY_VERSION: 3.1.6.2

--- a/matter_server/config.yaml
+++ b/matter_server/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 8.0.0
+version: 8.1.0
 slug: matter_server
 name: Matter Server
 description: Matter WebSocket Server for Home Assistant Matter support.


### PR DESCRIPTION
Update to the latest Python Matter server. This release comes with the latest Matter SDK updates.

See [Python Matter Server release 8.1.0](https://github.com/home-assistant-libs/python-matter-server/releases/tag/8.1.0) for full list of changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Version
  - Released 8.1.0 of the Matter Server add-on.

- Chores
  - Upgraded runtime to Matter Server 8.1.0 for aarch64 and amd64.
  - Updated Bashio to 0.17.1 for improved stability and compatibility.
  - Bumped add-on metadata version to 8.1.0.

- Documentation
  - Added 8.1.0 changelog entry outlining the version updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->