### PR TITLE
duckDns: Revert renew each domain first

### DIFF
--- a/duckdns/CHANGELOG.md
+++ b/duckdns/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.26.0
+
+- Workaround for potential rate-limit for some people
+- Fallback to similar renewal behaviour to 1.19 while still supporting wildcards and other fixes
+
 ## 1.25.0
 
 - Wildcard support when using domains as "*.yourDomain.duckdns.org > yourDomain.duckdns.org"

--- a/duckdns/config.yaml
+++ b/duckdns/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 1.25.0
+version: 1.26.0
 slug: duckdns
 name: Duck DNS
 description: >-

--- a/duckdns/rootfs/etc/s6-overlay/s6-rc.d/duckdns/run
+++ b/duckdns/rootfs/etc/s6-overlay/s6-rc.d/duckdns/run
@@ -51,12 +51,16 @@ function le_renew() {
     for domain in "${domainsAndAliases[@]}"; do
 		domain_args+=("--domain" "${domain}")
 		
+		# Note, the below is commented out for now as dehydrated force-renews each domain when domain input is different from the previous run
+		# This is causing rate-limiting from Let's Encrypt
+		# Need to resolve issue with dehydrated first to properly support single TXT records
+		
 		# DuckDNS does not support more than a single TXT record, so, process each domain or alias separately and combine later
-		dehydrated --cron --algo "${ALGO}" --hook /root/hooks.sh --challenge dns-01 --domain "${domain}" --out "${CERT_DIR}" --config "${WORK_DIR}/config" || true
+		#dehydrated --cron --algo "${ALGO}" --hook /root/hooks.sh --challenge dns-01 --domain "${domain}" --out "${CERT_DIR}" --config "${WORK_DIR}/config" || true
     done
 	
 	# This final stage will combine everything into a single cert with SANs for the aliases
-	bashio::log.info "Final pass to combine individual certificates"
+	#bashio::log.info "Final pass to combine individual certificates"
 	dehydrated --cron --algo "${ALGO}" --hook /root/hooks.sh --challenge dns-01 "${domain_args[@]}" --out "${CERT_DIR}" --config "${WORK_DIR}/config" || true
 
     LE_UPDATE="$(date +%s)"


### PR DESCRIPTION
- Revert behavior for renewing each domain separately
- Dehydrated needs some fixes to support this first

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * Streamlined certificate renewal into a single bulk run, reducing redundant per-domain executions and improving stability.
  * Adjusted renewal behavior to align more closely with earlier versions while retaining wildcard support.
  * Reduced unnecessary log output during renewal.

* Documentation
  * Added 1.26.0 changelog entry summarizing renewal updates and improvements.

* Chores
  * Bumped version to 1.26.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->