### PR TITLE
Proper Support for Single-TXT Domains Fix Let's Encrypt Rate-Limit Resolution

### DIFF
--- a/duckdns/CHANGELOG.md
+++ b/duckdns/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.26.0
+
+- Updated dehydrated fork with support for single-txt domains
+- Use the new dehydrated script parameters which handles individual domain processing now
+
 ## 1.25.0
 
 - Wildcard support when using domains as "*.yourDomain.duckdns.org > yourDomain.duckdns.org"

--- a/duckdns/Dockerfile
+++ b/duckdns/Dockerfile
@@ -5,7 +5,7 @@ FROM $BUILD_FROM
 ARG DEHYDRATED_VERSION
 RUN apk add --no-cache openssl \
   && curl -s -o /usr/bin/dehydrated \
-    "https://raw.githubusercontent.com/lukas2511/dehydrated/v${DEHYDRATED_VERSION}/dehydrated" \
+    "https://raw.githubusercontent.com/Xebozone/dehydrated/${DEHYDRATED_VERSION}/dehydrated" \
   && chmod a+x /usr/bin/dehydrated
 
 # Copy root filesystem 

--- a/duckdns/build.yaml
+++ b/duckdns/build.yaml
@@ -9,4 +9,4 @@ codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
 args:
-  DEHYDRATED_VERSION: 0.7.1
+  DEHYDRATED_VERSION: 0.8.0

--- a/duckdns/config.yaml
+++ b/duckdns/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 1.25.0
+version: 1.26.0
 slug: duckdns
 name: Duck DNS
 description: >-

--- a/duckdns/rootfs/etc/s6-overlay/s6-rc.d/duckdns/run
+++ b/duckdns/rootfs/etc/s6-overlay/s6-rc.d/duckdns/run
@@ -46,18 +46,13 @@ function le_renew() {
 		fi
 	done
 	
-	# Actually do the renewals below
-
+	# Prepare arguments
     for domain in "${domainsAndAliases[@]}"; do
 		domain_args+=("--domain" "${domain}")
-		
-		# DuckDNS does not support more than a single TXT record, so, process each domain or alias separately and combine later
-		dehydrated --cron --algo "${ALGO}" --hook /root/hooks.sh --challenge dns-01 --domain "${domain}" --out "${CERT_DIR}" --config "${WORK_DIR}/config" || true
     done
 	
-	# This final stage will combine everything into a single cert with SANs for the aliases
-	bashio::log.info "Final pass to combine individual certificates"
-	dehydrated --cron --algo "${ALGO}" --hook /root/hooks.sh --challenge dns-01 "${domain_args[@]}" --out "${CERT_DIR}" --config "${WORK_DIR}/config" || true
+	# Do the certificate renewals
+	dehydrated --cron --separate-challenges --algo "${ALGO}" --hook /root/hooks.sh --challenge dns-01 "${domain_args[@]}" --out "${CERT_DIR}" --config "${WORK_DIR}/config" || true
 
     LE_UPDATE="$(date +%s)"
 }


### PR DESCRIPTION
- Use Xebozone fork of Dehydrated with support for Single-TXT domains (such as DuckDNS)
- Revise run to use the new parameters for dehydrated
- Version bump
- Updated Changelogs