### PR TITLE
Fix restrict-task-creation workflow

### DIFF
--- a/.github/workflows/restrict-task-creation.yml
+++ b/.github/workflows/restrict-task-creation.yml
@@ -10,7 +10,7 @@ jobs:
   check-authorization:
     runs-on: ubuntu-latest
     # Only run if this is a Task issue type (from the issue form)
-    if: github.event.issue.issue_type == 'Task'
+    if: github.event.issue.type.name == 'Task'
     steps:
       - name: Check if user is authorized
         uses: actions/github-script@v7


### PR DESCRIPTION
## Proposed change
Fix restrict-task-creation workflow by correctly using `type.name` of the `issue` object.

Same as:
- https://github.com/home-assistant/core/pull/150774 (which was confirmed working [here](https://github.com/home-assistant/core/issues/150777))