### PR TITLE
Fix restrict-task-creation workflow

### DIFF
--- a/.github/workflows/restrict-task-creation.yml
+++ b/.github/workflows/restrict-task-creation.yml
@@ -10,7 +10,7 @@ jobs:
   check-authorization:
     runs-on: ubuntu-latest
     # Only run if this is a Task issue type (from the issue form)
-    if: github.event.issue.issue_type == 'Task'
+    if: github.event.issue.type.name == 'Task'
     steps:
       - name: Check if user is authorized
         uses: actions/github-script@v7


### PR DESCRIPTION
Fix restrict-task-creation workflow by correctly using `type.name` of the `issue` object.

Same as:
- https://github.com/home-assistant/core/pull/150774 (which was confirmed working [here](https://github.com/home-assistant/core/issues/150777))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated issue authorization workflow to correctly detect “Task” issues, ensuring checks run as expected.
  * No user-facing functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->