### PR TITLE
silabs_flasher: Make EZSP baudrate optional

### DIFF
--- a/silabs_flasher/CHANGELOG.md
+++ b/silabs_flasher/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.4
+
+- Make custom ezsp baudrate a truly optional configuration
+
 ## 0.3.3
 
 - Allow to start universal-silabs-flasher with custom ezsp baudrate

--- a/silabs_flasher/config.yaml
+++ b/silabs_flasher/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.3.3
+version: 0.3.4
 slug: silabs_flasher
 name: Silicon Labs Flasher
 description: Silicon Labs firmware flasher add-on
@@ -18,7 +18,6 @@ init: false
 options:
   device: null
   bootloader_baudrate: "115200"
-  ezsp_baudrate: null
   flow_control: true
   verbose: false
 schema:


### PR DESCRIPTION
Make the EZSP baudrate really an optional configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made the custom EZSP baud rate truly optional — no default value is prepopulated unless the user sets it.

* **Chores**
  * Bumped add-on version to 0.3.4.

* **Documentation**
  * Added a 0.3.4 changelog entry describing the optional EZSP baud rate change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->