### PR TITLE
LetsEncrypt: Allow to set User-Agent

### DIFF
--- a/letsencrypt/CHANGELOG.md
+++ b/letsencrypt/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.4.12
+
+- Allow to change User-Agent (either fully or partially)
+
 ## 5.4.10
 
 - Update certbot-dns-desec to 1.3.1

--- a/letsencrypt/DOCS.md
+++ b/letsencrypt/DOCS.md
@@ -256,6 +256,27 @@ When you specify a custom ACME server, the *Dry Run* and *Issue test certificate
 </details>
 
 <details>
+  <summary>Change User-Agent</summary>
+
+For auditing purposes it might be useful to override User-Agent HTTP header that addon and its providers send when making requests.
+
+Setting field `user_agent` will completely override value of User-Agent:
+
+  ```yaml
+  user_agent: "HomeAssistant"
+  ```
+
+Setting field `user_agent_comment` will add value to CertBot User-Agent header:
+
+  ```yaml
+  user_agent_comment: "HomeAssistant"
+  ```
+
+Note `user_agent_comment` will be ignored if `user_agent` is set.
+
+</details>
+
+<details>
   <summary>Selecting the Key Type</summary>
 
   By default the ECDSA key type is used. You can choose to use an RSA key for compatibility with systems where ECDSA keys are not supported. ECDSA is widely supported in modern software with security and performance benefits.

--- a/letsencrypt/config.yaml
+++ b/letsencrypt/config.yaml
@@ -169,6 +169,8 @@ schema:
   elliptic_curve: list(secp256r1|secp384r1)?
   acme_server: url?
   acme_root_ca_cert: str?
+  user_agent: str?
+  user_agent_comment: str?
   verbose: bool?
   dry_run: bool?
   test_cert: bool?

--- a/letsencrypt/rootfs/etc/services.d/lets-encrypt/run
+++ b/letsencrypt/rootfs/etc/services.d/lets-encrypt/run
@@ -19,6 +19,8 @@ CHALLENGE=$(bashio::config 'challenge')
 DNS_PROVIDER=$(bashio::config 'dns.provider')
 ACME_SERVER=$(bashio::config 'acme_server')
 ACME_ROOT_CA_CERT=$(bashio::config 'acme_root_ca_cert')
+USER_AGENT=$(bashio::config 'user_agent')
+USER_AGENT_COMMENT=$(bashio::config 'user_agent_comment')
 EAB_KID=$(bashio::config 'eab_kid')
 EAB_HMAC_KEY=$(bashio::config 'eab_hmac_key')
 DRY_RUN=$(bashio::config 'dry_run')
@@ -352,6 +354,14 @@ fi
 
 if [ "${VERBOSE}" = "true" ]; then
     ADDITIONAL_ARGS+=("-vvv")
+fi
+
+# Add user agent if set
+if [ -n "${USER_AGENT}" ]; then
+    ADDITIONAL_ARGS+=("--user-agent" "${USER_AGENT}")
+fi
+if [ -n "${USER_AGENT_COMMENT}" ]; then
+    ADDITIONAL_ARGS+=("--user-agent-comment" "${USER_AGENT_COMMENT}") 
 fi
 
 # Gather all domains into a plaintext file

--- a/letsencrypt/translations/en.yaml
+++ b/letsencrypt/translations/en.yaml
@@ -28,6 +28,12 @@ configuration:
       Only relevant with a custom ACME server using a certificate signed by an
       untrusted certificate authority (CA) that requires addition to the trust
       store.
+  user_agent:
+    name: User Agent
+    description: User-Agent HTTP header sent by addon.
+  user_agent_comment:
+    name: User Agent Comment
+    description: Comment added to addon User-Agent HTTP header.
   dns:
     name: DNS
     description: DNS Provider configuration


### PR DESCRIPTION
* Add user_agent and user_agent_comment that directly map to certbot arguments of same name.

This allows to edit User-Agent header sent by certbot to DNS provider which might be required for audit purposes or as another form of scoping the security policy at DNS host side.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional settings to customize the HTTP User-Agent (full override) and an additional User-Agent comment for outbound Certbot requests; defaults unchanged if not set.
* **Documentation**
  * Updated configuration docs to explain the two User-Agent options, their effects and precedence.
* **Chores**
  * Added English UI labels and descriptions for the new settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->