### PR TITLE
Bump zwavejs to v15.12.0

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.22.0
+
+### Features
+
+- Firmware updates that fail due to an XMODEM communication error are now retried automatically, reducing the risk to get stuck in bootloader until a new firmware is flashed (#8086)
+
+### Bugfixes
+
+- Fixes an issue where the controller would indefinitely be considered as recovering from a jammed state, preventing commands from being re-transmitted (#8052)
+- Fixed an issue where the key up event would be force-emitted too early on legacy devices that incorrectly report not to support the "slow refresh" capability (#8087)
+- Canceling a "replace failed node" operation no longer prevents other inclusion/exclusion operations from being started (#8084)
+
+### Config file changes
+
+- Add HomeSeer WS300 (#8074)
+
 ## 0.21.0
 
 ### Features

--- a/zwave_js/build.yaml
+++ b/zwave_js/build.yaml
@@ -10,4 +10,4 @@ codenotary:
   base_image: notary@home-assistant.io
 args:
   ZWAVEJS_SERVER_VERSION: 3.2.1
-  ZWAVEJS_VERSION: 15.11.0
+  ZWAVEJS_VERSION: 15.12.0

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.21.0
+version: 0.22.0
 slug: zwave_js
 name: Z-Wave JS
 description: Control a Z-Wave network with Home Assistant Z-Wave JS


### PR DESCRIPTION
https://github.com/zwave-js/zwave-js/compare/v15.11.0...v15.12.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Firmware updates now auto-retry after XMODEM errors, reducing bootloader lockups.
  - Added device support: HomeSeer WS300.
- Bug Fixes
  - Fixed indefinite “recovering from jammed state” that blocked retransmissions.
  - Corrected premature key-up event on legacy devices without slow refresh.
  - Canceling replace-failed-node no longer blocks inclusion/exclusion operations.
- Chores
  - Updated to Z-Wave JS 15.12.0; add-on version bumped to 0.22.0.
- Documentation
  - Changelog updated for 0.22.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->