### PR TITLE
ssh: Bump CLI to 4.41.0, Alpine to 3.22

### DIFF
--- a/ssh/CHANGELOG.md
+++ b/ssh/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 9.20.0
+
+- Upgrade Home Assistant CLI to 4.41.0
+- Upgrade to Alpine Linux 3.22
+- Upgrade libwebsockets to 4.4.1
+
 ## 9.19.0
 
 - Disable keyboard interactive authentication method if keys are used

--- a/ssh/build.yaml
+++ b/ssh/build.yaml
@@ -1,14 +1,14 @@
 ---
 build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-base:3.19
-  amd64: ghcr.io/home-assistant/amd64-base:3.19
-  armhf: ghcr.io/home-assistant/armhf-base:3.19
-  armv7: ghcr.io/home-assistant/armv7-base:3.19
-  i386: ghcr.io/home-assistant/i386-base:3.19
+  aarch64: ghcr.io/home-assistant/aarch64-base:3.22
+  amd64: ghcr.io/home-assistant/amd64-base:3.22
+  armhf: ghcr.io/home-assistant/armhf-base:3.22
+  armv7: ghcr.io/home-assistant/armv7-base:3.22
+  i386: ghcr.io/home-assistant/i386-base:3.22
 codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
 args:
-  CLI_VERSION: 4.39.0
-  LIBWEBSOCKETS_VERSION: 4.3.5
+  CLI_VERSION: 4.41.0
+  LIBWEBSOCKETS_VERSION: 4.4.1
   TTYD_VERSION: 1.7.7

--- a/ssh/config.yaml
+++ b/ssh/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 9.19.0
+version: 9.20.0
 slug: ssh
 name: Terminal & SSH
 description: Allow logging in remotely to Home Assistant using SSH


### PR DESCRIPTION
Bump CLI to 4.41.0 and Alpine 3.22. Also use latest version 4.4.1 of libwebsockets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Version
  - Bumped add-on to 9.20.0.

- Chores
  - Updated underlying base images across all architectures (Alpine Linux bumped to 3.22).
  - Upgraded Home Assistant CLI to 4.41.0.
  - Upgraded libwebsockets to 4.4.1.

- Documentation
  - Added changelog entry for 9.20.0 summarizing dependency upgrades.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->