### PR TITLE
Start nginx_proxy as a service

### DIFF
--- a/nginx_proxy/CHANGELOG.md
+++ b/nginx_proxy/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.13.1
+
+- Start the addon earlier so HA is accessible earlier.
+
 ## 3.13.0
 
 - Update Alpine Linux to 3.22 (nginx 1.28.x)

--- a/nginx_proxy/config.yaml
+++ b/nginx_proxy/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 3.13.0
+version: 3.13.1
 hassio_api: true
 slug: nginx_proxy
 name: NGINX Home Assistant SSL proxy

--- a/nginx_proxy/config.yaml
+++ b/nginx_proxy/config.yaml
@@ -13,6 +13,7 @@ arch:
   - i386
 image: homeassistant/{arch}-addon-nginx_proxy
 init: false
+startup: services
 map:
   - ssl
   - share

--- a/nginx_proxy/rootfs/etc/s6-overlay/s6-rc.d/nginx/run
+++ b/nginx_proxy/rootfs/etc/s6-overlay/s6-rc.d/nginx/run
@@ -51,6 +51,19 @@ if bashio::config.true 'cloudflare'; then
     fi
 fi
 
+bashio::log.info "Waiting for core to be ready..."
+port=$(bashio::core.port)
+until curl \
+   --output /dev/null \
+   --silent \
+   --fail \
+   "http://homeassistant.local.hass.io:$port";
+do
+    printf '.'
+    sleep 0.1
+done
+
+
 # start server
 bashio::log.info "Running nginx..."
 stat "/ssl/$(bashio::config 'certfile')" -c %y > /tmp/certificate_timestamp


### PR DESCRIPTION
Before this PR, home assistant starts before the nginx proxy. On my system the add-on takes a while to start.

I am not sure when all addons with "startup: application" are started, is it maybe after all integrations have started to load or maybe later?

Anyway, after this PR, the nginx_proxy addon starts first, and waits for the frontend to be ready (We wait to prevent 504 errors from nginx).

This makes the frontend available earlier to the user, at least on my system and my experience.