### PR TITLE
ssh: Fix Dockerfile to replace 'sh' with 'bash'

### DIFF
--- a/ssh/CHANGELOG.md
+++ b/ssh/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 9.20.1
+
+- Fix default shell
+
 ## 9.20.0
 
 - Upgrade Home Assistant CLI to 4.41.0

--- a/ssh/Dockerfile
+++ b/ssh/Dockerfile
@@ -30,7 +30,7 @@ RUN \
         openssl-dev \
         zlib-dev \
     \
-    && sed -i "s/ash/bash/" /etc/passwd \
+    && sed -i "1s/sh/bash/" /etc/passwd \
     \
     && git clone --branch "v${LIBWEBSOCKETS_VERSION}" --depth=1 \
         https://github.com/warmcat/libwebsockets.git /tmp/libwebsockets \

--- a/ssh/Dockerfile
+++ b/ssh/Dockerfile
@@ -30,7 +30,7 @@ RUN \
         openssl-dev \
         zlib-dev \
     \
-    && sed -i "1s/sh/bash/" /etc/passwd \
+    && sed -i "s|/bin/sh|/bin/bash|" /etc/passwd \
     \
     && git clone --branch "v${LIBWEBSOCKETS_VERSION}" --depth=1 \
         https://github.com/warmcat/libwebsockets.git /tmp/libwebsockets \

--- a/ssh/config.yaml
+++ b/ssh/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 9.20.0
+version: 9.20.1
 slug: ssh
 name: Terminal & SSH
 description: Allow logging in remotely to Home Assistant using SSH


### PR DESCRIPTION
The new Alpine version apparently switched from `/bin/ash` to `/bin/sh` for root shell.

Fixes #4158

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Fixed default shell handling in the SSH container to avoid unintended user substitutions, ensuring only the intended account uses Bash.

- Chores
  - Hardened Docker build step for safer system configuration within the SSH image.

- Documentation
  - Added changelog entry and bumped SSH image version to 9.20.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->