### PR TITLE
Bump Z-Wave JS to 15.13.0

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.23.0
+
+### Features
+
+- Support checking for all firmware updates at once, and support detecting devices unknown to the firmware update service
+
+### Bugfixes
+
+- Fixed an edge case preventing the migration of some controllers
+- Clean up Battery "isLow" values that are no longer updated by the Z-Wave JS driver
+
+### Config file changes
+
+- Added support for Zooz ZEN75
+- Updated Inovelli VZW32-SN device support to match latest firmware
+
+### Detailed changelogs
+
+- [Z-Wave JS 15.13.0](https://github.com/zwave-js/zwave-js/releases/tag/v15.13.0)
+
 ## 0.22.0
 
 ### Features
@@ -15,6 +35,10 @@
 ### Config file changes
 
 - Add HomeSeer WS300 (#8074)
+
+### Detailed changelogs
+
+- [Z-Wave JS 15.12.0](https://github.com/zwave-js/zwave-js/releases/tag/v15.12.0)
 
 ## 0.21.0
 

--- a/zwave_js/build.yaml
+++ b/zwave_js/build.yaml
@@ -10,4 +10,4 @@ codenotary:
   base_image: notary@home-assistant.io
 args:
   ZWAVEJS_SERVER_VERSION: 3.2.1
-  ZWAVEJS_VERSION: 15.12.0
+  ZWAVEJS_VERSION: 15.13.0

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.22.0
+version: 0.23.0
 slug: zwave_js
 name: Z-Wave JS
 description: Control a Z-Wave network with Home Assistant Z-Wave JS


### PR DESCRIPTION
Confirmed working locally.

This will allow us to support bulk firmware update checks with a single request. Ideally immediately after all nodes are ready or a new one was added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Check all device firmware updates at once.
  * Detect devices unknown to the firmware update service.
  * Add support for Zooz ZEN75 and update Inovelli VZW32-SN definitions.

* **Bug Fixes**
  * Resolve a migration edge case for some controllers.
  * Clean up obsolete Battery “isLow” values.

* **Documentation**
  * Add 0.23.0 changelog and detailed changelog link for 0.22.0.

* **Chores**
  * Bump add-on to 0.23.0.
  * Update bundled Z-Wave JS to 15.13.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->