### PR TITLE
Fix: Set explicit ShellCheck version in GitHub Actions workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -51,6 +51,7 @@ jobs:
       - name: Run linter
         uses: ludeeus/action-shellcheck@2.0.0
         with:
+          version: v0.10.0
           # Names of scripts with custom shebangs that the action would not
           # discover on its own:
           additional_files: >-


### PR DESCRIPTION
It should fix the `ShellCheck` error.

<img width="560" height="149" alt="linter" src="https://github.com/user-attachments/assets/8aea34f2-cf67-4f55-b118-c9f5584af0ed" />
