### PR TITLE
Upgrade to Z-Wave JS Server 3.3.0

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.25.0
+
+### Features
+
+- Try re-establishing connection when communication with adapter is lost
+
+### Detailed changelogs
+
+- [Z-Wave JS Server 3.3.0](https://github.com/zwave-js/zwave-js-server/releases/tag/3.3.0)
+
 ## 0.24.0
 
 ### Features

--- a/zwave_js/build.yaml
+++ b/zwave_js/build.yaml
@@ -9,5 +9,5 @@ codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
 args:
-  ZWAVEJS_SERVER_VERSION: 3.2.1
+  ZWAVEJS_SERVER_VERSION: 3.3.0
   ZWAVEJS_VERSION: 15.14.0

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.24.0
+version: 0.25.0
 slug: zwave_js
 name: Z-Wave JS
 description: Control a Z-Wave network with Home Assistant Z-Wave JS


### PR DESCRIPTION
Bump Z-Wave JS Server to 3.3.0

https://github.com/zwave-js/zwave-js-server/releases/tag/3.3.0