### PR TITLE
Update Z-Wave JS to 15.15.0

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.26.0
+
+### Features
+
+- Support creating mixed LR and non-LR "multicast" groups
+
+### Bugfixes
+
+- IP based connections no longer block the process for several minutes on connection failures/timeouts
+- Disable optimistic value updates for slow device classes, like shades and gates
+- Fixed an edge case where support for EU Long Range is not inferred correctly
+- During route rebuilds, invalid and non-existing association targets are now skipped instead of failing the whole process
+
+### Detailed changelogs
+
+- [Z-Wave JS 15.15.0](https://github.com/zwave-js/zwave-js/releases/tag/v15.15.0)
+
 ## 0.25.0
 
 ### Features

--- a/zwave_js/build.yaml
+++ b/zwave_js/build.yaml
@@ -10,4 +10,4 @@ codenotary:
   base_image: notary@home-assistant.io
 args:
   ZWAVEJS_SERVER_VERSION: 3.3.0
-  ZWAVEJS_VERSION: 15.14.0
+  ZWAVEJS_VERSION: 15.15.0

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.25.0
+version: 0.26.0
 slug: zwave_js
 name: Z-Wave JS
 description: Control a Z-Wave network with Home Assistant Z-Wave JS


### PR DESCRIPTION
Changelog: https://github.com/zwave-js/zwave-js/releases/tag/v15.15.0

Bumps add-on to 0.26.0

