### PR TITLE
Z-Wave JS 0.27.0

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.27.0
+
+### Changes
+
+- Revert automatic reconnection when communication with adapter is lost. Home Assistant already handles this.
+
+### Detailed changelogs
+
+- [Z-Wave JS Server 3.4.0](https://github.com/zwave-js/zwave-js-server/releases/tag/3.4.0)
+
 ## 0.26.0
 
 ### Features

--- a/zwave_js/build.yaml
+++ b/zwave_js/build.yaml
@@ -9,5 +9,5 @@ codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
 args:
-  ZWAVEJS_SERVER_VERSION: 3.3.0
+  ZWAVEJS_SERVER_VERSION: 3.4.0
   ZWAVEJS_VERSION: 15.15.0

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.26.0
+version: 0.27.0
 slug: zwave_js
 name: Z-Wave JS
 description: Control a Z-Wave network with Home Assistant Z-Wave JS


### PR DESCRIPTION
Bump ZJS Server to 3.4.0 https://github.com/zwave-js/zwave-js-server/releases/tag/3.4.0

This reverts the auto connection added in 0.25.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Revert
  - Removed automatic reconnection when adapter communication is lost.
- Chores
  - Updated to Z-Wave JS Server 3.4.0.
  - Bumped integration version to 0.27.0.
- Documentation
  - Added changelog entry for 0.27.0 detailing the reconnection behavior change and server version update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->