### PR TITLE
Remove Codenotary signing information

### DIFF
--- a/configurator/config.yaml
+++ b/configurator/config.yaml
@@ -4,7 +4,6 @@ slug: configurator
 name: File editor
 description: Simple browser-based file editor for Home Assistant
 url: https://github.com/home-assistant/addons/tree/master/configurator
-codenotary: notary@home-assistant.io
 arch:
   - armhf
   - armv7

--- a/deconz/config.yaml
+++ b/deconz/config.yaml
@@ -12,7 +12,6 @@ arch:
   - aarch64
 backup_exclude:
   - "*/otau"
-codenotary: notary@home-assistant.io
 devices:
   - /dev/mem
 discovery:

--- a/dhcp_server/config.yaml
+++ b/dhcp_server/config.yaml
@@ -4,7 +4,6 @@ slug: dhcp_server
 name: "DHCP server [deprecated]"
 description: A simple DHCP server
 url: https://home-assistant.io/addons/dhcp_server/
-codenotary: notary@home-assistant.io
 advanced: true
 arch:
   - armhf

--- a/mosquitto/config.yaml
+++ b/mosquitto/config.yaml
@@ -4,7 +4,6 @@ slug: mosquitto
 name: Mosquitto broker
 description: An Open Source MQTT broker
 url: https://github.com/home-assistant/addons/tree/master/mosquitto
-codenotary: notary@home-assistant.io
 arch:
   - armhf
   - armv7

--- a/samba/config.yaml
+++ b/samba/config.yaml
@@ -4,7 +4,6 @@ slug: samba
 name: Samba share
 description: Expose Home Assistant folders with SMB/CIFS
 url: https://github.com/home-assistant/addons/tree/master/samba
-codenotary: notary@home-assistant.io
 arch:
   - armhf
   - armv7

--- a/ssh/config.yaml
+++ b/ssh/config.yaml
@@ -4,7 +4,6 @@ slug: ssh
 name: Terminal & SSH
 description: Allow logging in remotely to Home Assistant using SSH
 url: https://github.com/home-assistant/addons/tree/master/ssh
-codenotary: notary@home-assistant.io
 advanced: true
 arch:
   - armhf

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -10,7 +10,6 @@ arch:
   - armhf
   - armv7
   - aarch64
-codenotary: notary@home-assistant.io
 discovery:
   - zwave_js
 hassio_api: true


### PR DESCRIPTION
Remove the signer username from all add-on configurations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed deprecated notary metadata from several system addons (Configurator, deCONZ, DHCP Server, Mosquitto, Samba, SSH, Z-Wave JS) to streamline addon metadata and improve consistency across configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->