### PR TITLE
Bump to wyoming-openwakeword 2.1.0

### DIFF
--- a/openwakeword/CHANGELOG.md
+++ b/openwakeword/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.1.0
+
+- Upgrade to wyoming-openwakeword 2.1.0
+- Fix zeroconf discovery
+- Drop support for `armv7`
+
 ## 1.10.0
 
 - Upgrade to wyoming 1.5.3

--- a/openwakeword/Dockerfile
+++ b/openwakeword/Dockerfile
@@ -15,13 +15,13 @@ RUN \
         netcat-traditional \
         python3 \
         python3-pip \
-        libopenblas0 \
     \
     && pip3 install --no-cache-dir -U \
         setuptools \
         wheel \
     && pip3 install --no-cache-dir \
         --extra-index-url https://www.piwheels.org/simple \
+        "wyoming[zeroconf]>=1.8,<2" \
         "wyoming-openwakeword @ https://github.com/rhasspy/wyoming-openwakeword/archive/refs/tags/v${WYOMING_OPENWAKEWORD_VERSION}.tar.gz" \
     \
     && rm -rf /var/lib/apt/lists/*

--- a/openwakeword/README.md
+++ b/openwakeword/README.md
@@ -1,6 +1,6 @@
 # Home Assistant Add-on: openWakeWord
 
-![Supports aarch64 Architecture][aarch64-shield] ![Supports amd64 Architecture][amd64-shield] ![Supports armv7 Architecture][armv7-shield]
+![Supports aarch64 Architecture][aarch64-shield] ![Supports amd64 Architecture][amd64-shield]
 
 Home Assistant add-on that uses [openWakeWord](https://github.com/dscripka/openwakeword) for wake word detection.
 
@@ -10,6 +10,3 @@ Requires Home Assistant 2023.9 or later.
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
-[armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
-[armhf-shield]: https://img.shields.io/badge/armhf-no-red.svg
-[i386-shield]: https://img.shields.io/badge/i386-no-red.svg

--- a/openwakeword/build.yaml
+++ b/openwakeword/build.yaml
@@ -2,6 +2,5 @@
 build_from:
   amd64: ghcr.io/home-assistant/amd64-base-debian:bookworm
   aarch64: ghcr.io/home-assistant/aarch64-base-debian:bookworm
-  armv7: ghcr.io/home-assistant/armv7-base-debian:bookworm
 args:
-  WYOMING_OPENWAKEWORD_VERSION: 1.10.0
+  WYOMING_OPENWAKEWORD_VERSION: 2.1.0

--- a/openwakeword/config.yaml
+++ b/openwakeword/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 1.10.0
+version: 2.1.0
 slug: openwakeword
 name: openWakeWord
 description: openWakeWord using the Wyoming protocol
@@ -7,7 +7,6 @@ url: https://github.com/home-assistant/addons/blob/master/openwakeword
 arch:
   - amd64
   - aarch64
-  - armv7
 init: false
 discovery:
   - wyoming

--- a/openwakeword/rootfs/etc/s6-overlay/s6-rc.d/openwakeword/run
+++ b/openwakeword/rootfs/etc/s6-overlay/s6-rc.d/openwakeword/run
@@ -13,7 +13,7 @@ fi
 # shellcheck disable=SC2068
 exec python3 -m wyoming_openwakeword \
     --uri 'tcp://0.0.0.0:10400' \
-    --preload-model 'ok_nabu' \
+    --zeroconf \
     --custom-model-dir /share/openwakeword \
     --threshold "$(bashio::config 'threshold')" \
     --trigger-level "$(bashio::config 'trigger_level')" ${flags[@]}


### PR DESCRIPTION
- Upgrade to wyoming-openwakeword 2.1.0: https://github.com/rhasspy/wyoming-openwakeword/compare/v1.10.0...v2.1.0
- Fix zeroconf discovery
- Drop support for `armv7`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed zeroconf discovery

* **Supported Platforms**
  * Dropped armv7 support; now supports amd64 and aarch64

* **Updates**
  * Upgraded to version 2.1.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->