### PR TITLE
nRF54L15 SDK firmware needs OT baud rate 1000000

### DIFF
--- a/openthread_border_router/CHANGELOG.md
+++ b/openthread_border_router/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.15.2
+- Add baudrate list option 1000000 (Nordic Semiconductor nRF Connect SDK firmware)
+
 ## 2.15.1
 - Make radio spinel recovery more reliable by clearing source match tables before restoring
 

--- a/openthread_border_router/config.yaml
+++ b/openthread_border_router/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 2.15.1
+version: 2.15.2
 slug: openthread_border_router
 name: OpenThread Border Router
 description: OpenThread Border Router add-on
@@ -39,7 +39,7 @@ ports_description:
   8081/tcp: OpenThread REST API port
 schema:
   device: device(subsystem=tty)
-  baudrate: list(57600|115200|230400|460800|921600)
+  baudrate: list(57600|115200|230400|460800|921600|1000000)
   flow_control: bool
   network_device: str?
   otbr_log_level: list(debug|info|notice|warning|error|critical|alert|emergency)


### PR DESCRIPTION
Owning some Seeed Studio XIAO nRF54L15, based on Nordic Semiconductor nRF54L15.

Stick was flashed with locally built nrf Connect SDK default RCP firmware, as found e.g. under https://github.com/nrfconnect/sdk-nrf/tree/main/samples/openthread/coprocessor

However, on a Linux PC I can only start "otbr-agent" with Radio URLs with baudrate 100000. Other baud rates like 460800 are rejected with immediate "response timeout".

Baud rate 1000000 is officially documented as recommendation, e.g. under https://docs.nordicsemi.com/bundle/ncs-2.9.2/page/nrf/protocols/thread/overview/architectures.html#uart_recommendations_for_co-processor_designs
Unfortunately, the HA addon integration of OTBR does not yet offer that value in the list box, and also does not seem to allow using unlisted values (?).

With some locally patched addon to support value 100000, the nRF54L15 stick works like a charm with HA, i.e. OTBR agent starts and sensor values of some ESP32C6 can be subscribed via OT.

This PR shall bring that value option to upstream.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for 1000000 baud rate option for Nordic Semiconductor nRF Connect SDK firmware compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->