### PR TITLE
Drop build for deprecated archs, use latest native runners

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   init:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     name: Initialize builds
     outputs:
       changed_files: ${{ steps.changed_files.outputs.all }}
@@ -64,13 +64,17 @@ jobs:
 
   build:
     needs: init
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.runs-on }}
     if: needs.init.outputs.changed == 'true'
     name: Build ${{ matrix.arch }} ${{ matrix.addon }} add-on
     strategy:
       matrix:
         addon: ${{ fromJson(needs.init.outputs.changed_addons) }}
-        arch: ["aarch64", "amd64", "armhf", "armv7", "i386"]
+        arch: ["aarch64", "amd64"]
+        include:
+          - runs-on: ubuntu-24.04
+          - runs-on: ubuntu-24.04-arm
+            arch: aarch64
 
     steps:
       - name: Check out repository
@@ -109,6 +113,7 @@ jobs:
         if: steps.check.outputs.build_arch == 'true'
         uses: home-assistant/builder@2025.11.0
         with:
+          image: ${{ matrix.arch }}
           args: |
             ${{ env.BUILD_ARGS }} \
             --${{ matrix.arch }} \


### PR DESCRIPTION
In #4248 breaking bump of the builder action was merged. This means that future attempts at builds of deprecated architectures will fail. This change removes the deprecated architectures from the build matrix and changes the build job to use native runner for aarch64 build, while updating to latest runner versions as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal infrastructure updates to build and deployment workflows.

---

**Note:** These changes are internal infrastructure updates with no direct impact on end-user functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->