### PR TITLE
ssh: Bump CLI to 4.44.0, remove unsupported architectures

### DIFF
--- a/ssh/CHANGELOG.md
+++ b/ssh/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 9.21.0
+
+- Remove support for armhf, armv7, and i386 architectures
+- Upgrade Home Assistant CLI to 4.44.0
+
 ## 9.20.1
 
 - Fix default shell

--- a/ssh/README.md
+++ b/ssh/README.md
@@ -2,7 +2,7 @@
 
 Allow logging in remotely to Home Assistant using SSH or just the web terminal with Ingress.
 
-![Supports aarch64 Architecture][aarch64-shield] ![Supports amd64 Architecture][amd64-shield] ![Supports armhf Architecture][armhf-shield] ![Supports armv7 Architecture][armv7-shield] ![Supports i386 Architecture][i386-shield]
+![Supports aarch64 Architecture][aarch64-shield] ![Supports amd64 Architecture][amd64-shield]
 
 ## About
 
@@ -12,6 +12,3 @@ client. It also includes a command-line tool to access the Home Assistant API.
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
-[armhf-shield]: https://img.shields.io/badge/armhf-yes-green.svg
-[armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
-[i386-shield]: https://img.shields.io/badge/i386-yes-green.svg

--- a/ssh/build.yaml
+++ b/ssh/build.yaml
@@ -2,10 +2,7 @@
 build_from:
   aarch64: ghcr.io/home-assistant/aarch64-base:3.22
   amd64: ghcr.io/home-assistant/amd64-base:3.22
-  armhf: ghcr.io/home-assistant/armhf-base:3.22
-  armv7: ghcr.io/home-assistant/armv7-base:3.22
-  i386: ghcr.io/home-assistant/i386-base:3.22
 args:
-  CLI_VERSION: 4.41.0
+  CLI_VERSION: 4.44.0
   LIBWEBSOCKETS_VERSION: 4.4.1
   TTYD_VERSION: 1.7.7

--- a/ssh/config.yaml
+++ b/ssh/config.yaml
@@ -1,16 +1,13 @@
 ---
-version: 9.20.1
+version: 9.21.0
 slug: ssh
 name: Terminal & SSH
 description: Allow logging in remotely to Home Assistant using SSH
 url: https://github.com/home-assistant/addons/tree/master/ssh
 advanced: true
 arch:
-  - armhf
-  - armv7
   - aarch64
   - amd64
-  - i386
 audio: true
 hassio_api: true
 hassio_role: manager


### PR DESCRIPTION
* https://github.com/home-assistant/cli/releases/tag/4.44.0
* https://github.com/home-assistant/cli/releases/tag/4.43.0
* https://github.com/home-assistant/cli/releases/tag/4.42.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Upgraded Home Assistant CLI to version 4.44.0
  * Updated supported architectures to aarch64 and amd64 only (armhf, armv7, and i386 no longer supported)
  * Version bumped to 9.21.0

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->