### PR TITLE
matter_server: Bump Python Matter server to 8.1.2

### DIFF
--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 8.1.2
+
+- Bump Python Matter Server to [8.1.2](https://github.com/matter-js/python-matter-server/releases/tag/8.1.2)
+
 ## 8.1.1
 
 - Bump Python Matter Server to [8.1.1](https://github.com/matter-js/python-matter-server/releases/tag/8.1.1)

--- a/matter_server/build.yaml
+++ b/matter_server/build.yaml
@@ -1,7 +1,7 @@
 ---
 build_from:
-  aarch64: ghcr.io/matter-js/python-matter-server:8.1.1
-  amd64: ghcr.io/matter-js/python-matter-server:8.1.1
+  aarch64: ghcr.io/matter-js/python-matter-server:8.1.2
+  amd64: ghcr.io/matter-js/python-matter-server:8.1.2
 args:
   BASHIO_VERSION: 0.17.1
   TEMPIO_VERSION: 2024.11.2

--- a/matter_server/config.yaml
+++ b/matter_server/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 8.1.1
+version: 8.1.2
 slug: matter_server
 name: Matter Server
 description: Matter WebSocket Server for Home Assistant Matter support.


### PR DESCRIPTION
Update to the latest Python Matter server.

See [Python Matter Server release 8.1.2](https://github.com/matter-js/python-matter-server/releases/tag/8.1.2) for full list of changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Matter Server to version 8.1.2 with corresponding configuration and build updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->