### PR TITLE
ssh: Bump CLI to 4.45.0

### DIFF
--- a/ssh/CHANGELOG.md
+++ b/ssh/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 9.22.0
+
+- Upgrade Home Assistant CLI to 4.45.0
+
 ## 9.21.0
 
 - Remove support for armhf, armv7, and i386 architectures

--- a/ssh/build.yaml
+++ b/ssh/build.yaml
@@ -3,6 +3,6 @@ build_from:
   aarch64: ghcr.io/home-assistant/aarch64-base:3.22
   amd64: ghcr.io/home-assistant/amd64-base:3.22
 args:
-  CLI_VERSION: 4.44.0
+  CLI_VERSION: 4.45.0
   LIBWEBSOCKETS_VERSION: 4.4.1
   TTYD_VERSION: 1.7.7

--- a/ssh/config.yaml
+++ b/ssh/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 9.21.0
+version: 9.22.0
 slug: ssh
 name: Terminal & SSH
 description: Allow logging in remotely to Home Assistant using SSH


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded Home Assistant CLI to version 4.45.0

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->