### PR TITLE
feat(letsencrypt): Add AWS profile support for Route 53 DNS challenge

### DIFF
--- a/letsencrypt/DOCS.md
+++ b/letsencrypt/DOCS.md
@@ -1285,7 +1285,7 @@ An example configuration:
 <details>
   <summary>route53</summary>
 
-  **Option 1: Using AWS Profile (recommended for IAM Roles Anywhere)**
+  ### Option 1: Using AWS profile (recommended for IAM Roles Anywhere)
 
   ```yaml
   email: your.email@example.com
@@ -1301,7 +1301,7 @@ An example configuration:
 
   This uses the AWS credentials file at `/share/.aws/config` with a `credential_process` for IAM Roles Anywhere.
 
-  **Option 2: Using Access Keys**
+  ### Option 2: Using access keys
 
   ```yaml
   email: your.email@example.com

--- a/letsencrypt/DOCS.md
+++ b/letsencrypt/DOCS.md
@@ -1298,6 +1298,13 @@ An example configuration:
     aws_secret_access_key: 0123456789abcdef0123456789/abcdef0123456
   ```
 
+**AWS Credentials are Optional**: If you don't provide `aws_access_key_id` and `aws_secret_access_key`, boto3 will use the default AWS credential chain, which includes:
+- EC2 instance profiles
+- IAM Roles Anywhere
+- Environment variables
+- AWS credentials file
+- IAM roles for tasks (ECS/Fargate)
+
 For security reasons, don't use your main account's credentials. Instead, add a new [AWS user](https://console.aws.amazon.com/iam/home?#/users) with _Access Type: Programmatic access_ and use that user's access key. Assign a minimum [policy](https://console.aws.amazon.com/iam/home?#/policies$new?step=edit) like the following example. Make sure to replace the Resource ARN in the first statement to your domain's hosted zone ARN or use _*_ for all.
 
   ```json

--- a/letsencrypt/DOCS.md
+++ b/letsencrypt/DOCS.md
@@ -1299,7 +1299,7 @@ An example configuration:
     aws_profile: letsencrypt
   ```
 
-  This uses the AWS credentials file at `/root/.aws/config` with a `credential_process` for IAM Roles Anywhere.
+  This uses the AWS credentials file at `/share/.aws/config` with a `credential_process` for IAM Roles Anywhere.
 
   **Option 2: Using Access Keys**
 
@@ -1316,14 +1316,7 @@ An example configuration:
     aws_secret_access_key: 0123456789abcdef0123456789/abcdef0123456
   ```
 
-  **Option 3: Default Credential Chain**
-
-  If you don't provide any AWS credentials, boto3 will use the default AWS credential chain:
-  - EC2 instance profiles
-  - IAM Roles Anywhere
-  - Environment variables
-  - AWS credentials file
-  - IAM roles for tasks (ECS/Fargate)
+  **Note:** You must provide either `aws_profile` OR both `aws_access_key_id` and `aws_secret_access_key`.
 
 For security reasons, don't use your main account's credentials. Instead, add a new [AWS user](https://console.aws.amazon.com/iam/home?#/users) with _Access Type: Programmatic access_ and use that user's access key. Assign a minimum [policy](https://console.aws.amazon.com/iam/home?#/policies$new?step=edit) like the following example. Make sure to replace the Resource ARN in the first statement to your domain's hosted zone ARN or use _*_ for all.
 

--- a/letsencrypt/DOCS.md
+++ b/letsencrypt/DOCS.md
@@ -1299,7 +1299,7 @@ An example configuration:
     aws_profile: letsencrypt
   ```
 
-  This uses the AWS credentials file at `/share/.aws/config` with a `credential_process` for IAM Roles Anywhere.
+  If present, the AWS config file at `/share/.aws/config` will be used to support `credential_process` for IAM Roles Anywhere.
 
   ### Option 2: Using access keys
 
@@ -1316,7 +1316,7 @@ An example configuration:
     aws_secret_access_key: 0123456789abcdef0123456789/abcdef0123456
   ```
 
-  **Note:** You must provide either `aws_profile` OR both `aws_access_key_id` and `aws_secret_access_key`.
+  **Note:** You must provide either `aws_profile` OR both `aws_access_key_id` and `aws_secret_access_key`. If both are configured, `aws_profile` takes precedence.
 
 For security reasons, don't use your main account's credentials. Instead, add a new [AWS user](https://console.aws.amazon.com/iam/home?#/users) with _Access Type: Programmatic access_ and use that user's access key. Assign a minimum [policy](https://console.aws.amazon.com/iam/home?#/policies$new?step=edit) like the following example. Make sure to replace the Resource ARN in the first statement to your domain's hosted zone ARN or use _*_ for all.
 

--- a/letsencrypt/DOCS.md
+++ b/letsencrypt/DOCS.md
@@ -1285,6 +1285,24 @@ An example configuration:
 <details>
   <summary>route53</summary>
 
+  **Option 1: Using AWS Profile (recommended for IAM Roles Anywhere)**
+
+  ```yaml
+  email: your.email@example.com
+  domains:
+    - your.domain.tld
+  certfile: fullchain.pem
+  keyfile: privkey.pem
+  challenge: dns
+  dns:
+    provider: dns-route53
+    aws_profile: letsencrypt
+  ```
+
+  This uses the AWS credentials file at `/root/.aws/config` with a `credential_process` for IAM Roles Anywhere.
+
+  **Option 2: Using Access Keys**
+
   ```yaml
   email: your.email@example.com
   domains:
@@ -1298,12 +1316,14 @@ An example configuration:
     aws_secret_access_key: 0123456789abcdef0123456789/abcdef0123456
   ```
 
-**AWS Credentials are Optional**: If you don't provide `aws_access_key_id` and `aws_secret_access_key`, boto3 will use the default AWS credential chain, which includes:
-- EC2 instance profiles
-- IAM Roles Anywhere
-- Environment variables
-- AWS credentials file
-- IAM roles for tasks (ECS/Fargate)
+  **Option 3: Default Credential Chain**
+
+  If you don't provide any AWS credentials, boto3 will use the default AWS credential chain:
+  - EC2 instance profiles
+  - IAM Roles Anywhere
+  - Environment variables
+  - AWS credentials file
+  - IAM roles for tasks (ECS/Fargate)
 
 For security reasons, don't use your main account's credentials. Instead, add a new [AWS user](https://console.aws.amazon.com/iam/home?#/users) with _Access Type: Programmatic access_ and use that user's access key. Assign a minimum [policy](https://console.aws.amazon.com/iam/home?#/policies$new?step=edit) like the following example. Make sure to replace the Resource ARN in the first statement to your domain's hosted zone ARN or use _*_ for all.
 

--- a/letsencrypt/DOCS.md
+++ b/letsencrypt/DOCS.md
@@ -1285,7 +1285,7 @@ An example configuration:
 <details>
   <summary>route53</summary>
 
-  ### Option 1: Using AWS profile (recommended for IAM Roles Anywhere)
+### Option 1: Using AWS profile (recommended for IAM Roles Anywhere)
 
   ```yaml
   email: your.email@example.com
@@ -1301,7 +1301,7 @@ An example configuration:
 
   If present, the AWS config file at `/share/.aws/config` will be used to support `credential_process` for IAM Roles Anywhere.
 
-  ### Option 2: Using access keys
+### Option 2: Using access keys
 
   ```yaml
   email: your.email@example.com

--- a/letsencrypt/config.yaml
+++ b/letsencrypt/config.yaml
@@ -38,6 +38,7 @@ schema:
     # Developer note: please add a new plugin alphabetically into all lists
     aws_access_key_id: str?
     aws_secret_access_key: str?
+    aws_profile: str?
     azure_config: str?
     cloudflare_api_key: str?
     cloudflare_api_token: str?

--- a/letsencrypt/rootfs/etc/services.d/lets-encrypt/run
+++ b/letsencrypt/rootfs/etc/services.d/lets-encrypt/run
@@ -281,12 +281,14 @@ if [ "${CHALLENGE}" == "dns" ]; then
 
         # route53 - AWS
         'dns-route53')
-            bashio::config.require 'dns.aws_access_key_id'
-            bashio::config.require 'dns.aws_secret_access_key'
-            AWS_ACCESS_KEY_ID="$(bashio::config 'dns.aws_access_key_id')"
-            AWS_SECRET_ACCESS_KEY="$(bashio::config 'dns.aws_secret_access_key')"
-            export AWS_ACCESS_KEY_ID
-            export AWS_SECRET_ACCESS_KEY
+            if bashio::config.has_value 'dns.aws_access_key_id'; then
+                AWS_ACCESS_KEY_ID="$(bashio::config 'dns.aws_access_key_id')"
+                export AWS_ACCESS_KEY_ID
+            fi
+            if bashio::config.has_value 'dns.aws_secret_access_key'; then
+                AWS_SECRET_ACCESS_KEY="$(bashio::config 'dns.aws_secret_access_key')"
+                export AWS_SECRET_ACCESS_KEY
+            fi
             ACME_ARGUMENTS+=("--${DNS_PROVIDER}")
             ;;
 

--- a/letsencrypt/rootfs/etc/services.d/lets-encrypt/run
+++ b/letsencrypt/rootfs/etc/services.d/lets-encrypt/run
@@ -281,13 +281,20 @@ if [ "${CHALLENGE}" == "dns" ]; then
 
         # route53 - AWS
         'dns-route53')
-            if bashio::config.has_value 'dns.aws_access_key_id'; then
+            if bashio::config.has_value 'dns.aws_profile'; then
+                AWS_PROFILE="$(bashio::config 'dns.aws_profile')"
+                export AWS_PROFILE
+                bashio::log.info "Using AWS profile: ${AWS_PROFILE}"
+            elif bashio::config.has_value 'dns.aws_access_key_id'; then
                 AWS_ACCESS_KEY_ID="$(bashio::config 'dns.aws_access_key_id')"
                 export AWS_ACCESS_KEY_ID
-            fi
-            if bashio::config.has_value 'dns.aws_secret_access_key'; then
-                AWS_SECRET_ACCESS_KEY="$(bashio::config 'dns.aws_secret_access_key')"
-                export AWS_SECRET_ACCESS_KEY
+                if bashio::config.has_value 'dns.aws_secret_access_key'; then
+                    AWS_SECRET_ACCESS_KEY="$(bashio::config 'dns.aws_secret_access_key')"
+                    export AWS_SECRET_ACCESS_KEY
+                fi
+                bashio::log.info "Using AWS access key credentials"
+            else
+                bashio::log.info "Using default AWS credential chain"
             fi
             ACME_ARGUMENTS+=("--${DNS_PROVIDER}")
             ;;

--- a/letsencrypt/rootfs/etc/services.d/lets-encrypt/run
+++ b/letsencrypt/rootfs/etc/services.d/lets-encrypt/run
@@ -284,17 +284,22 @@ if [ "${CHALLENGE}" == "dns" ]; then
             if bashio::config.has_value 'dns.aws_profile'; then
                 AWS_PROFILE="$(bashio::config 'dns.aws_profile')"
                 export AWS_PROFILE
+                # Check for AWS config in /share/.aws (for IAM Roles Anywhere)
+                if [ -f "/share/.aws/config" ]; then
+                    export AWS_CONFIG_FILE="/share/.aws/config"
+                    bashio::log.info "Using AWS config from /share/.aws/config"
+                fi
                 bashio::log.info "Using AWS profile: ${AWS_PROFILE}"
             elif bashio::config.has_value 'dns.aws_access_key_id'; then
+                bashio::config.require 'dns.aws_secret_access_key'
                 AWS_ACCESS_KEY_ID="$(bashio::config 'dns.aws_access_key_id')"
+                AWS_SECRET_ACCESS_KEY="$(bashio::config 'dns.aws_secret_access_key')"
                 export AWS_ACCESS_KEY_ID
-                if bashio::config.has_value 'dns.aws_secret_access_key'; then
-                    AWS_SECRET_ACCESS_KEY="$(bashio::config 'dns.aws_secret_access_key')"
-                    export AWS_SECRET_ACCESS_KEY
-                fi
+                export AWS_SECRET_ACCESS_KEY
                 bashio::log.info "Using AWS access key credentials"
             else
-                bashio::log.info "Using default AWS credential chain"
+                bashio::log.error "Route 53 requires either 'aws_profile' or 'aws_access_key_id' and 'aws_secret_access_key'"
+                exit 1
             fi
             ACME_ARGUMENTS+=("--${DNS_PROVIDER}")
             ;;


### PR DESCRIPTION
## Summary
Add support for AWS named profiles in the Route 53 DNS provider, enabling IAM Roles Anywhere authentication with `credential_process`.

## Changes
- Add `aws_profile` option to config schema
- Auto-detect `/share/.aws/config` for credential_process support
- Require either `aws_profile` OR `aws_access_key_id` + `aws_secret_access_key` (no implicit default credential chain)
- Update documentation with both authentication options

## Use Case
This enables users to authenticate with AWS using X.509 certificates via IAM Roles Anywhere instead of static IAM access keys. Benefits:
- Short-lived credentials (1 hour by default)
- No static access keys to manage or rotate
- Certificate-based authentication

## Configuration Example

**Using AWS Profile (IAM Roles Anywhere):**
```yaml
dns:
  provider: dns-route53
  aws_profile: letsencrypt
```

**Using Access Keys (existing behavior):**
```yaml
dns:
  provider: dns-route53
  aws_access_key_id: AKIA...
  aws_secret_access_key: ...
```

## Testing
Tested on Home Assistant OS (aarch64) with IAM Roles Anywhere and `aws_signing_helper` credential_process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Route53 DNS now supports using an AWS profile as an authentication option in addition to access key/secret.

* **Documentation**
  * Added guidance for both AWS Profile and access key methods, noted that profile takes precedence when both are set, and documented use of shared AWS config for advanced credential flows.

* **Bug Fixes**
  * Removed previous unconditional requirement for access keys; credential handling clarified.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->