### PR TITLE
Add smb encrypt option

### DIFF
--- a/samba/CHANGELOG.md
+++ b/samba/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 12.5.5
+
+- Add option for setting smb encrypted parameter
+
 ## 12.5.4
 
 - Fix invalid inverted commas in server signing parameter

--- a/samba/DOCS.md
+++ b/samba/DOCS.md
@@ -107,6 +107,13 @@ This can cause issues with file systems that do not support xattr such as exFAT.
 
 Defaults to `true`.
 
+### Option: `encryption`
+
+Configure the SMB encryption requirement. This option encrypts all traffic between client and server and prevents guest access if set to required.
+Refer to the man page for smb.conf for detailed information about the values: **off**, **desired** and **required**.
+
+Defaults to `desired`.
+
 ### Option: `server_signing`
 
 Configure the SMB server signing requirement. This option can improve security by requiring message signing, which helps prevent man-in-the-middle attacks.

--- a/samba/config.yaml
+++ b/samba/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 12.5.4
+version: 12.5.5
 slug: samba
 name: Samba share
 description: Expose Home Assistant folders with SMB/CIFS
@@ -37,6 +37,7 @@ options:
     - ssl
   compatibility_mode: false
   apple_compatibility_mode: true
+  encryption: "desired"
   server_signing: "default"
   veto_files:
     - ._*
@@ -60,6 +61,7 @@ schema:
     - "match(^(?i:(addons|addon_configs|backup|config|media|share|ssl))$)"
   compatibility_mode: bool
   apple_compatibility_mode: bool
+  encryption: list(off|desired|required)
   server_signing: list(default|auto|mandatory|disabled)
   veto_files:
     - str

--- a/samba/rootfs/usr/share/tempio/smb.gtpl
+++ b/samba/rootfs/usr/share/tempio/smb.gtpl
@@ -18,9 +18,19 @@
    interfaces = lo {{ .interfaces | join " " }}
    hosts allow = 127.0.0.1 {{ .allow_hosts | join " " }}
 
+   smb encrypt = {{ .encryption }}
+   {{ if eq .encryption "required" }}
+   client min protocol = SMB3
+   client max protocol = SMB3
+   server min protocol = SMB3
+   server max protocol = SMB3
+   server signing = auto
+   {{ else }}
+   server signing = {{ .server_signing }}
    {{ if .compatibility_mode }}
    client min protocol = NT1
    server min protocol = NT1
+   {{ end }}
    {{ end }}
 
    mangled names = no
@@ -30,8 +40,6 @@
    {{ if .apple_compatibility_mode }}
    vfs objects = catia fruit streams_xattr
    {{ end }}
-
-   server signing = {{ .server_signing }}
 
 {{ if (has "config" .enabled_shares) }}
 [config]

--- a/samba/rootfs/usr/share/tempio/smb.gtpl
+++ b/samba/rootfs/usr/share/tempio/smb.gtpl
@@ -24,7 +24,7 @@
    client max protocol = SMB3
    server min protocol = SMB3
    server max protocol = SMB3
-   server signing = auto
+   server signing = mandatory
    {{ else }}
    server signing = {{ .server_signing }}
    {{ if .compatibility_mode }}

--- a/samba/translations/en.yaml
+++ b/samba/translations/en.yaml
@@ -33,6 +33,12 @@ configuration:
       Enable Samba configurations to improve interoperability with Apple
       devices. May cause issues with file systems that do not support xattr
       such as exFAT.
+  encryption:
+    name: Encryption
+    description: >-
+      Configure SMB encryption.
+      SMB3 protocol is used if set to required.
+      Compatibility mode option will be ignored in this case.
   server_signing:
     name: Server signing
     description: >-


### PR DESCRIPTION
Adds option to set "smb encrypt" to off/desired/required. If set to required, all traffic between client and server will be encrypted instead of plain text message traffic.
Encryption requires to use SMB3 and cannot be used in combination with compatibility mode option.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SMB encryption option with three settings — off, desired (default), required — to control encryption of client-server traffic; "required" enforces SMB3 and restricts guest access.

* **Documentation**
  * Added docs and translation strings for the encryption option and expanded guidance on server signing and compatibility mode behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->