### PR TITLE
README: rename add-on to app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-# Home Assistant Add-ons: The official repository
+# Home Assistant Apps: The official repository
 
-Add-ons for Home Assistant allow you to extend the functionality
-around your Home Assistant setup. These add-ons can consist of an application
+Apps (formerly known as add-ons) for Home Assistant allow you to extend the functionality
+around your Home Assistant setup. These apps can consist of an application
 that Home Assistant can integrate with (e.g., a [MQTT broker](/mosquitto/README.md) or [database server](/mariadb/README.md))
 or allow access to your Home Assistant configuration (e.g., via [Samba](/samba/README.md) or using
 the [File Editor](/configurator/README.md)).
 
-Add-ons can be installed and configured via the Home Assistant frontend on
+Apps can be installed and configured via the Home Assistant frontend on
 systems that have installed Home Assistant.
 
 [![Home Assistant - A project from the Open Home Foundation](https://www.openhomefoundation.org/badges/home-assistant.png)](https://www.openhomefoundation.org/)
 
-## Add-ons provided by this repository
+## Apps provided by this repository
 
 - **[CEC Scanner](/cec_scan/README.md)**
 
@@ -81,11 +81,11 @@ You have several options to get them answered:
 
 In case you've found a bug, please [open an issue on our GitHub][issue].
 
-## Developing your own add-ons
+## Developing your own apps
 
-In case you are interested in developing your own add-on, this
+In case you are interested in developing your own app, this
 repository can be a great source of inspiration. For more information
-about developing an add-on, please see our
+about developing an app, please see our
 [documentation for developers][dev-docs].
 
 [discord]: https://discord.gg/c5DvZ4e


### PR DESCRIPTION
as per Architecture discussion: Rename “Add-ons” to “Apps” https://github.com/home-assistant/architecture/discussions/1287

related to task: https://github.com/home-assistant/home-assistant.io/issues/43180

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Rebranded terminology from "Add-ons" to "Apps" across documentation, with references noting the legacy name.
  * Added descriptive information for each app listed.
  * Updated developer guide section to align with new terminology.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->