### PR TITLE
Mosquitto: rename add-on to app

### DIFF
--- a/mosquitto/rootfs/etc/services.d/mosquitto/discovery
+++ b/mosquitto/rootfs/etc/services.d/mosquitto/discovery
@@ -3,7 +3,7 @@
 # shellcheck shell=bash
 # ==============================================================================
 # Send MQTT discovery information to Home Assistant and service information
-# to the Supervisor (for other apps).
+# to the Supervisor (for other add-ons).
 # ==============================================================================
 readonly SYSTEM_USER="/data/system_user.json"
 declare config
@@ -34,7 +34,7 @@ else
     bashio::log.error "Discovery message to Home Assistant failed!"
 fi
 
-# Create service config payload for other apps
+# Create service config payload for other add-ons
 config=$(bashio::var.json \
     host "$(hostname)" \
     port "^1883" \

--- a/mosquitto/rootfs/etc/services.d/mosquitto/finish
+++ b/mosquitto/rootfs/etc/services.d/mosquitto/finish
@@ -6,7 +6,7 @@
 # ==============================================================================
 
 if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
-  bashio::log.warning "Halt app"
+  bashio::log.warning "Halt add-on"
   exec /run/s6/basedir/bin/halt
 fi
 

--- a/mosquitto/rootfs/etc/services.d/nginx/finish
+++ b/mosquitto/rootfs/etc/services.d/nginx/finish
@@ -6,7 +6,7 @@
 # ==============================================================================
 
 if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
-  bashio::log.warning "Halt app"
+  bashio::log.warning "Halt add-on"
   exec /run/s6/basedir/bin/halt
 fi
 


### PR DESCRIPTION
as per Architecture discussion: Rename “Add-ons” to “Apps” https://github.com/home-assistant/architecture/discussions/1287

related to task: https://github.com/home-assistant/home-assistant.io/issues/43180

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to reflect rebranding terminology from "Add-on" to "App" across installation guides, configuration instructions, and navigation references.

* **Chores**
  * Updated system messages and comments throughout scripts to consistently use "app" terminology instead of "add-on."

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->