### PR TITLE
[openthread_border_router] Migrate OpenThread settings when switching between beta/stable

### DIFF
--- a/openthread_border_router/CHANGELOG.md
+++ b/openthread_border_router/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.16.1
+- Preserve Thread network identity when switching between stable and beta mode
+
 ## 2.16.0
 - Add beta toggle to switch between Thread 1.3 (stable) and Thread 1.4 (beta)
 - Beta mode uses OpenThread's built-in mDNS instead of mDNSResponder

--- a/openthread_border_router/config.yaml
+++ b/openthread_border_router/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 2.16.0
+version: 2.16.1
 slug: openthread_border_router
 name: OpenThread Border Router
 description: OpenThread Border Router add-on

--- a/openthread_border_router/rootfs/etc/s6-overlay/s6-rc.d/otbr-agent/run
+++ b/openthread_border_router/rootfs/etc/s6-overlay/s6-rc.d/otbr-agent/run
@@ -148,10 +148,18 @@ echo "${otbr_rest_listen_port}" >> /tmp/otbr-agent-rest-api
 
 # Migrate OTBR settings to new adapter if needed
 bashio::log.info "Migrating OTBR settings if needed..."
+
+if bashio::config.true 'beta'; then
+    thread_version=5
+else
+    thread_version=4
+fi
+
 python3 /usr/local/bin/migrate_otbr_settings.py \
     --adapter "${device}" \
     --baudrate "${baudrate}" \
     --flow-control "${migrate_flow_control}" \
+    --thread-version "${thread_version}" \
     --data-dir /data/thread/
 
 bashio::log.info "Starting otbr-agent..."

--- a/openthread_border_router/rootfs/usr/local/bin/migrate_otbr_settings.py
+++ b/openthread_border_router/rootfs/usr/local/bin/migrate_otbr_settings.py
@@ -242,16 +242,28 @@ async def main() -> None:
 
     if expected_settings_path.exists():
         if most_recent_settings_path == expected_settings_path:
-            print(
-                f"Adapter settings file {expected_settings_path} is the most recently used, skipping"
-            )
-            return
+            # Check if thread version needs updating
+            current_version = None
+            for key, value in most_recent_settings:
+                if key == OtbrSettingsKey.NETWORK_INFO:
+                    current_version = NetworkInfo.from_bytes(value).version
+                    break
 
-        # If the settings file is old, we should "delete" it
-        print(
-            f"Settings file for adapter {hwaddr} already exists at {expected_settings_path} but appears to be old, archiving"
-        )
-        backup_file(expected_settings_path)
+            if args.thread_version is None or current_version == args.thread_version:
+                print(
+                    f"Adapter settings file {expected_settings_path} is the most recently used, skipping"
+                )
+                return
+
+            print(
+                f"Updating thread version from {current_version} to {args.thread_version}"
+            )
+        else:
+            # If the settings file is old, we should "delete" it
+            print(
+                f"Settings file for adapter {hwaddr} already exists at {expected_settings_path} but appears to be old, archiving"
+            )
+            backup_file(expected_settings_path)
 
     # Write back a new settings file that keeps only a few keys
     new_settings = []


### PR DESCRIPTION
I noticed that the binary format has not actually changed for OpenThread itself: no new fields have been added, just the internal version has bumped from `4` to `5`. We theoretically can just tweak this value to keep OpenThread from regenerating Thread network information.

Note that the active dataset isn't changed in the current addon state, just the Thread network information. This will result in devices rerouting a little since your border router effectively disconnects and another fresh one re-connects.