### PR TITLE
Fix broken extglob copy syntax in git_pull

### DIFF
--- a/git_pull/CHANGELOG.md
+++ b/git_pull/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 8.0.2
+- Fix broken extglob pattern for restoring non-YAML files after clone
+
 ## 8.0.1
 - Fix bashio warn(ing) logger usage breaking deployment keys
 

--- a/git_pull/data/run.sh
+++ b/git_pull/data/run.sh
@@ -56,8 +56,10 @@ function git-clone {
     bashio::log.info "[Info] Start git clone"
     git clone "$REPOSITORY" /config || bashio::exit.nok "[Error] Git clone failed"
 
-    # try to copy non yml files back
-    cp "${BACKUP_LOCATION}" "!(*.yaml)" /config 2>/dev/null
+    # try to copy non-yaml files back (extglob pattern matches all except *.yaml)
+    shopt -s extglob
+    cp "${BACKUP_LOCATION}"/!(*.yaml) /config 2>/dev/null || true
+    shopt -u extglob
 
     # try to copy secrets file back
     cp "${BACKUP_LOCATION}/secrets.yaml" /config 2>/dev/null


### PR DESCRIPTION
## Summary
- Fix broken extglob copy syntax that prevented non-YAML files from being restored after git clone
- Enable extglob before pattern matching and disable after
- Add `|| true` to prevent script failure when no matching files exist

The original code `cp "${BACKUP_LOCATION}" "!(*.yaml)" /config` was incorrect - it passed the pattern as a literal string argument instead of expanding it.

## Test plan
- [ ] Test git_pull add-on with a fresh clone scenario
- [ ] Verify non-YAML files from backup are copied to /config after clone
- [ ] Verify script doesn't fail when backup has no non-YAML files

🤖 Generated with [Claude Code](https://claude.ai/code)