### PR TITLE
Move git_pull backups to persistent /data/backups/

### DIFF
--- a/git_pull/CHANGELOG.md
+++ b/git_pull/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 8.0.2
+- Move backups from volatile /tmp to persistent /data/backups/
+
 ## 8.0.1
 - Fix bashio warn(ing) logger usage breaking deployment keys
 

--- a/git_pull/data/run.sh
+++ b/git_pull/data/run.sh
@@ -42,8 +42,10 @@ function add-ssh-key {
 }
 
 function git-clone {
-    # create backup
-    BACKUP_LOCATION="/tmp/config-$(date +%Y-%m-%d_%H-%M-%S)"
+    # create backup in persistent storage (survives add-on restarts)
+    BACKUP_DIR="/data/backups"
+    mkdir -p "$BACKUP_DIR"
+    BACKUP_LOCATION="${BACKUP_DIR}/config-$(date +%Y-%m-%d_%H-%M-%S)"
     bashio::log.info "[Info] Backup configuration to $BACKUP_LOCATION"
 
     mkdir "${BACKUP_LOCATION}" || bashio::exit.nok "[Error] Creation of backup directory failed"


### PR DESCRIPTION
## Summary
- Move backup directory from volatile `/tmp` to persistent `/data/backups/`
- Backups now survive add-on restarts and can be used for manual recovery
- `/tmp` is cleared on container restart, making backups useless when most needed

## Test plan
- [ ] Test git_pull add-on backup creation
- [ ] Verify backups are created in `/data/backups/` directory
- [ ] Verify backups persist after add-on restart
- [ ] Verify old backup location `/tmp` is no longer used

🤖 Generated with [Claude Code](https://claude.ai/code)