### PR TITLE
Add pre-flight repository validation to git_pull

### DIFF
--- a/git_pull/CHANGELOG.md
+++ b/git_pull/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 8.0.2
+- Add pre-flight repository validation to catch auth failures before destructive operations
+
 ## 8.0.1
 - Fix bashio warn(ing) logger usage breaking deployment keys
 

--- a/git_pull/data/run.sh
+++ b/git_pull/data/run.sh
@@ -41,7 +41,17 @@ function add-ssh-key {
     chmod 600 "${HOME}/.ssh/id_${DEPLOYMENT_KEY_PROTOCOL}"
 }
 
+function validate-repository {
+    bashio::log.info "[Info] Validating repository access..."
+    if ! git ls-remote --exit-code "$REPOSITORY" HEAD &>/dev/null; then
+        bashio::exit.nok "[Error] Cannot access repository: $REPOSITORY. Check URL and credentials."
+    fi
+    bashio::log.info "[Info] Repository access validated"
+}
+
 function git-clone {
+    # Validate we can access the repo before doing anything destructive
+    validate-repository
     # create backup
     BACKUP_LOCATION="/tmp/config-$(date +%Y-%m-%d_%H-%M-%S)"
     bashio::log.info "[Info] Backup configuration to $BACKUP_LOCATION"


### PR DESCRIPTION
## Summary
- Add `validate-repository` function that verifies repository accessibility before any destructive operations
- Uses `git ls-remote` to check if the repository can be reached with current credentials
- Called before `git-clone` to fail fast if repository is inaccessible
- Prevents wiping `/config` only to discover the clone will fail

## Test plan
- [ ] Test with valid repository URL - should proceed normally
- [ ] Test with invalid repository URL - should fail early with clear error
- [ ] Test with SSH repository and invalid key - should fail at validation
- [ ] Test with HTTPS repository and invalid credentials - should fail at validation

🤖 Generated with [Claude Code](https://claude.ai/code)