### PR TITLE
Fix undefined OLD_COMMIT after fresh clone in git_pull

### DIFF
--- a/git_pull/CHANGELOG.md
+++ b/git_pull/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 8.0.2
+- Fix undefined OLD_COMMIT variable after fresh clone
+
 ## 8.0.1
 - Fix bashio warn(ing) logger usage breaking deployment keys
 


### PR DESCRIPTION
## Summary
- Initialize `OLD_COMMIT` with fallback to empty string when `git rev-parse HEAD` fails (e.g., fresh clone)
- Handle fresh clone case in `validate-config` by still running config validation but skipping restart logic
- Prevents undefined variable errors when comparing commits after initial clone

Previously, if `/config` wasn't a git repo and a clone was triggered, `OLD_COMMIT` would be undefined when `validate-config` tried to compare commits.

## Test plan
- [ ] Test fresh clone scenario - should validate config without errors
- [ ] Test normal pull scenario - should still compare commits and restart if needed
- [ ] Test reset scenario - should still compare commits correctly
- [ ] Verify no undefined variable warnings in logs

🤖 Generated with [Claude Code](https://claude.ai/code)