### PR TITLE
Make SSH validation fail-fast in git_pull

### DIFF
--- a/git_pull/CHANGELOG.md
+++ b/git_pull/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 8.0.2
+- Make SSH validation fail-fast instead of continuing on auth failure
+
 ## 8.0.1
 - Fix bashio warn(ing) logger usage breaking deployment keys
 


### PR DESCRIPTION
## Summary
- Always set up SSH key first before attempting validation (previously only set up on failure)
- Properly detect HTTPS URLs and skip SSH verification for them (with informative warning)
- Make SSH authentication failures fatal instead of continuing to destructive operations
- Improve domain extraction for SSH URLs

The previous behavior would continue to clone operations even when SSH authentication failed, potentially leading to failed clones after config was already cleared.

## Changes
- Restructured `check-ssh-key` to always call `add-ssh-key` when deployment key is configured
- Added HTTPS URL detection to skip SSH-specific verification
- Changed from warning to fatal error on SSH auth failure

## Test plan
- [ ] Test with valid SSH key - should proceed normally
- [ ] Test with invalid SSH key - should fail with clear error before any clone
- [ ] Test with HTTPS URL and deployment key - should warn and skip SSH check
- [ ] Test GitHub SSH specifically - should handle "successfully authenticated" message

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SSH validation now fails immediately on authentication errors instead of continuing, providing clear error messages and preventing connection timeouts.
  * Improved SSH key handling for HTTPS repositories when deployment keys are configured.
  * Added timeout protection to SSH authentication connectivity checks to prevent indefinite hanging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->