### PR TITLE
Add HTTPS credential validation to git_pull

### DIFF
--- a/git_pull/CHANGELOG.md
+++ b/git_pull/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 8.0.2
+- Add HTTPS credential validation before clone operations
+
 ## 8.0.1
 - Fix bashio warn(ing) logger usage breaking deployment keys
 

--- a/git_pull/data/run.sh
+++ b/git_pull/data/run.sh
@@ -112,6 +112,13 @@ password=${DEPLOYMENT_PASSWORD}
     bashio::log.info "[Info] Saving git credentials to /tmp/git-credentials"
     # shellcheck disable=SC2259
     git credential fill | git credential approve <<< "$cred_data"
+
+    # Verify credentials work by testing repository access
+    bashio::log.info "[Info] Verifying HTTPS credentials..."
+    if ! git ls-remote --exit-code "$REPOSITORY" HEAD &>/dev/null; then
+        bashio::exit.nok "[Error] HTTPS authentication failed for $REPOSITORY. Check username and password."
+    fi
+    bashio::log.info "[Info] HTTPS authentication successful"
 fi
 }
 


### PR DESCRIPTION
## Summary
- Add validation of HTTPS credentials after they are configured
- Uses `git ls-remote` to verify credentials work before any destructive operations
- Mirrors the SSH validation pattern for consistent behavior
- Prevents proceeding to clone/sync when HTTPS auth is broken

## Test plan
- [ ] Test with valid HTTPS credentials - should proceed normally
- [ ] Test with invalid HTTPS credentials - should fail with clear error
- [ ] Test without HTTPS credentials configured - should skip validation
- [ ] Verify credentials file is properly created before validation

🤖 Generated with [Claude Code](https://claude.ai/code)