### PR TITLE
Clone to /data/repo and sync to /config for safer git_pull operations

### DIFF
--- a/git_pull/CHANGELOG.md
+++ b/git_pull/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 8.1.0
+- **BREAKING**: Repository is now cloned to `/data/repo` instead of `/config`
+- Add `config_folder` option to specify which repo subfolder syncs to `/config`
+- Add `sync_exclude` option to protect files from being overwritten (default: `secrets.yaml`)
+- Backups are now stored persistently in `/data/backups/`
+- Clone failures no longer destroy existing configuration
+- Add rsync for efficient file synchronization
+
 ## 8.0.1
 - Fix bashio warn(ing) logger usage breaking deployment keys
 

--- a/git_pull/DOCS.md
+++ b/git_pull/DOCS.md
@@ -8,12 +8,20 @@ Follow these steps to get the add-on installed on your system:
 2. Find the "Git pull" add-on and click it.
 3. Click on the "INSTALL" button.
 
-## WARNING
+## How It Works
 
-The risk of complete loss is possible. Prior to starting this add-on, ensure a copy
-of your Home Assistant configuration files exists in the Github repository. Otherwise, 
-your local machine configuration folder will be overwritten with an empty configuration 
-folder and you will need to restore from a backup.
+The add-on clones your repository to a persistent location (`/data/repo`) and then
+syncs the appropriate folder to `/config`. This architecture provides several safety
+benefits:
+
+- **Clone failures don't destroy your config**: The repository is cloned to isolated
+  storage first, so network or authentication failures won't affect your existing config.
+- **Protected files**: Files listed in `sync_exclude` (like `secrets.yaml`) are never
+  overwritten during sync.
+- **Persistent backups**: Before each sync, your config is backed up to `/data/backups/`
+  for manual recovery if needed.
+- **Subfolder support**: Use `config_folder` to sync only a specific folder from your
+  repository to `/config`.
 
 ## How to use
 
@@ -49,6 +57,9 @@ restart_ignore:
   - ui-lovelace.yaml
   - ".gitignore"
   - exampledirectory/
+config_folder: "."
+sync_exclude:
+  - secrets.yaml
 repeat:
   active: false
   interval: 300
@@ -100,6 +111,31 @@ Git URL to your repository (make sure to use double quotes).
 ### Option: `restart_ignore` (optional)
 
 When `auto_restart` is enabled, changes to these files will not make HA restart. Full directories to ignore can be specified.
+
+### Option: `config_folder` (optional)
+
+The folder within your repository that contains the Home Assistant configuration files. This folder will be synced to `/config`. Default is `.` (repository root).
+
+Example use cases:
+- Your HA config is in a `homeassistant/` subfolder: set `config_folder: homeassistant`
+- Your repo has multiple configs for different environments: set `config_folder: production`
+
+### Option: `sync_exclude` (optional)
+
+List of files and folders that should never be overwritten when syncing from the repository. Default is `["secrets.yaml"]`.
+
+This is useful for:
+- Protecting `secrets.yaml` from being overwritten (default behavior)
+- Protecting local-only configuration files
+- Excluding the `.storage/` directory if you don't want to sync Home Assistant's internal state
+
+Example:
+```yaml
+sync_exclude:
+  - secrets.yaml
+  - .storage/
+  - local_config.yaml
+```
 
 ### Option group: `repeat`
 

--- a/git_pull/Dockerfile
+++ b/git_pull/Dockerfile
@@ -2,7 +2,7 @@ ARG BUILD_FROM
 FROM $BUILD_FROM
 
 # Setup base
-RUN apk add --no-cache jq curl git openssh-client
+RUN apk add --no-cache jq curl git openssh-client rsync
 
 # Copy data
 COPY data/run.sh /

--- a/git_pull/config.yaml
+++ b/git_pull/config.yaml
@@ -32,6 +32,9 @@ options:
   deployment_user: ""
   deployment_password: ""
   deployment_key_protocol: rsa
+  config_folder: "."
+  sync_exclude:
+    - secrets.yaml
   repeat:
     active: false
     interval: 300
@@ -49,6 +52,9 @@ schema:
   deployment_user: str
   deployment_password: password
   deployment_key_protocol: match(rsa|dsa|ecdsa|ed25519|rsa)
+  config_folder: str
+  sync_exclude:
+    - str
   repeat:
     active: bool
     interval: int


### PR DESCRIPTION
## Summary
This is a significant architectural change that eliminates the most critical data loss risks in the git_pull add-on.

**Current behavior:** Clone directly into `/config`, deleting all existing files first. If clone fails, data is lost.

**New behavior:** Clone to `/data/repo/` (add-on's persistent storage), then rsync to `/config` with configurable exclusions.

### Key improvements:
1. **Clone isolation**: Git operations happen in `/data/repo/`, not in the live `/config` directory
2. **Configurable sync**: New `config_folder` option to specify which repo subfolder maps to `/config`
3. **Protected files**: New `sync_exclude` option to protect files like `secrets.yaml` from being overwritten
4. **Path traversal protection**: Validates `config_folder` can't escape the repository directory
5. **Proper backup handling**: Creates backups with correct directory structure

### New configuration options:
```yaml
config_folder: "."          # Subfolder in repo to sync (default: repo root)
sync_exclude:               # Files/folders to never overwrite
  - secrets.yaml
```

### Migration notes:
- Existing users: No action needed. Defaults match current behavior.
- Users with monorepos: Can now set `config_folder: "home-assistant"` to sync only that subfolder
- Users wanting to protect secrets: Add files to `sync_exclude` list

## Test plan
- [ ] Test fresh clone - should clone to /data/repo/ and sync to /config
- [ ] Test with config_folder pointing to subfolder - should only sync that folder
- [ ] Test sync_exclude with secrets.yaml - should not overwrite existing secrets
- [ ] Test path traversal attempt (config_folder: "../../../etc") - should fail safely
- [ ] Test normal pull/reset operations - should sync changes correctly
- [ ] Verify backups are created with correct structure

🤖 Generated with [Claude Code](https://claude.ai/code)