### PR TITLE
[openthread_border_router] Fix TREL being disabled by default in beta mode

### DIFF
--- a/openthread_border_router/CHANGELOG.md
+++ b/openthread_border_router/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.16.2
+- Fix TREL being disabled by default in beta mode
+
 ## 2.16.1
 - Fix listen address of OTBR Web UI
 

--- a/openthread_border_router/config.yaml
+++ b/openthread_border_router/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 2.16.1
+version: 2.16.2
 slug: openthread_border_router
 name: OpenThread Border Router
 description: OpenThread Border Router add-on

--- a/openthread_border_router/rootfs/etc/s6-overlay/scripts/otbr-agent-configure.sh
+++ b/openthread_border_router/rootfs/etc/s6-overlay/scripts/otbr-agent-configure.sh
@@ -4,6 +4,8 @@
 # Configure OTBR depending on add-on settings
 # ==============================================================================
 
+ot-ctl trel enable
+
 if bashio::config.true 'nat64'; then
     bashio::log.info "Enabling NAT64."
     ot-ctl nat64 enable


### PR DESCRIPTION
OpenThread refactored internally and TREL is now a runtime-controllable flag, same as all the others. We should explicitly enable TREL on startup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * TREL (Thread Relay) is no longer disabled by default in beta mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->