### PR TITLE
Update wyoming-piper to 2.2.2

### DIFF
--- a/piper/CHANGELOG.md
+++ b/piper/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.2.2
+
+- Upgrade to `wyoming-piper` 2.2.2 (wheel fix)
+
 ## 2.2.1
 
 - Upgrade to `wyoming-piper` 2.2.1

--- a/piper/build.yaml
+++ b/piper/build.yaml
@@ -3,4 +3,4 @@ build_from:
   amd64: ghcr.io/home-assistant/amd64-base-debian:bookworm
   aarch64: ghcr.io/home-assistant/aarch64-base-debian:bookworm
 args:
-  WYOMING_PIPER_VERSION: 2.2.1
+  WYOMING_PIPER_VERSION: 2.2.2

--- a/piper/config.yaml
+++ b/piper/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 2.2.1
+version: 2.2.2
 slug: piper
 name: Piper
 description: Text-to-speech with Piper


### PR DESCRIPTION
Fixes problem with missing wheel dependencies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 2.2.2
  * Upgraded wyoming-piper dependency to 2.2.2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->