### PR TITLE
ssh: fix Dockerfile to use bash

### DIFF
--- a/ssh/CHANGELOG.md
+++ b/ssh/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 10.0.1
+
+- Fix default shell
+
 ## 10.0.0
 
 - Upgrade to Alpine 3.23

--- a/ssh/Dockerfile
+++ b/ssh/Dockerfile
@@ -23,6 +23,9 @@ RUN \
 ADD https://raw.githubusercontent.com/scopatz/nanorc/master/yaml.nanorc /usr/share/nano/yaml.nanorc
 RUN sed -i 's/^#[[:space:]]*\(include "\/usr\/share\/nano\/\*\.nanorc".*\)/\1/' /etc/nanorc
 
+# Use bash as default shell
+RUN sed -i "s|/bin/sh|/bin/bash|" /etc/passwd
+
 # Home Assistant CLI
 ARG BUILD_ARCH
 ARG CLI_VERSION

--- a/ssh/config.yaml
+++ b/ssh/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 10.0.0
+version: 10.0.1
 slug: ssh
 name: Terminal & SSH
 description: Allow logging in remotely to Home Assistant using SSH


### PR DESCRIPTION
Reimplement #4165

Fixes #4393

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated default shell in the SSH container from /bin/sh to /bin/bash.
  * Bumped version to 10.0.1.
* **Documentation**
  * Added a changelog entry for version 10.0.1 noting the default shell fix.

No other runtime behavior, configurations, or public interfaces were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->