### PR TITLE
otbr: ignore temporary settings files in migration script

### DIFF
--- a/openthread_border_router/CHANGELOG.md
+++ b/openthread_border_router/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.16.3
+- Ignore ephemeral temporary settings files in migration
+
 ## 2.16.2
 - Fix TREL being disabled by default in beta mode
 

--- a/openthread_border_router/config.yaml
+++ b/openthread_border_router/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 2.16.2
+version: 2.16.3
 slug: openthread_border_router
 name: OpenThread Border Router
 description: OpenThread Border Router add-on

--- a/openthread_border_router/rootfs/usr/local/bin/migrate_otbr_settings.py
+++ b/openthread_border_router/rootfs/usr/local/bin/migrate_otbr_settings.py
@@ -1,6 +1,7 @@
 import asyncio
 import argparse
 import datetime
+import re
 import zigpy.serial
 from pathlib import Path
 from serialx import PinState
@@ -15,6 +16,7 @@ from universal_silabs_flasher.spinel import (
 
 CONNECT_TIMEOUT = 10
 AFTER_DISCONNECT_DELAY = 1
+SETTINGS_FILE_PATTERN = re.compile(r"^\d+_[0-9a-f]+\.data$")
 
 
 class OtbrSettingsKey(Enum):
@@ -161,6 +163,9 @@ async def main() -> None:
     all_settings = []
 
     for settings_path in args.data_dir.glob("*.data"):
+        if not SETTINGS_FILE_PATTERN.match(settings_path.name):
+            continue
+
         mod_time = settings_path.stat().st_mtime
         otbr_settings = parse_otbr_settings(settings_path.read_bytes())
 


### PR DESCRIPTION
In some cases, OTBR creates temporary settings files [1]. If the RCP becomes unavailable (seems to happen particularly for network connected adapters), file with a newer timestamp containing ephemeral data is created and incorrectly migrated as configuration for the reconnected adapter later:

```
Settings file for adapter 187a3efffe0182dd already exists at /data/thread/0_187a3efffe0182dd.data but appears to be old, archiving
Wrote new settings file to /data/thread/0_187a3efffe0182dd.data
```

This is how the thread folder looks like after the migration:

```
-rw------- 1 kpt kpt  32 Feb 11 09:57 0_0-tmp.data
-rw------- 1 kpt kpt  73 Feb 11 09:58 0_187a3efffe0182dd.data
-rw------- 1 kpt kpt 278 Feb 11 09:47 0_187a3efffe0182dd.data.backup-20260211095840
```

The new data file is clearly migrated from the 0_0-tmp.data, creating a new configuration out of ephemeral data which is invalid and prevents correct initialization of the OTBR app.

This change adds a check that the file to be migrated is matching a valid name created by [2], effectively ignoring the temporary files.

[1] https://github.com/openthread/openthread/blob/thread-reference-20250612/src/posix/platform/tmp_storage.cpp
[2] https://github.com/openthread/openthread/blob/thread-reference-20250612/src/posix/platform/settings.cpp#L93

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Migration now properly ignores ephemeral temporary settings files, improving reliability and preventing potential issues during the settings migration process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->