### PR TITLE
otbr: improve validation of OTBR settings file

### DIFF
--- a/openthread_border_router/rootfs/usr/local/bin/migrate_otbr_settings.py
+++ b/openthread_border_router/rootfs/usr/local/bin/migrate_otbr_settings.py
@@ -72,7 +72,14 @@ def serialize_otbr_settings(settings: list[tuple[OtbrSettingsKey, bytes]]) -> by
 
 def is_valid_otbr_settings_file(settings: list[tuple[OtbrSettingsKey, bytes]]) -> bool:
     """Check if parsed settings represent a valid OTBR settings file."""
-    return {OtbrSettingsKey.ACTIVE_DATASET} <= {key for key, _ in settings}
+    for key, value in settings:
+        if key == OtbrSettingsKey.ACTIVE_DATASET:
+            # A real Active Dataset contains Thread TLVs (Network Key, Channel,
+            # etc.) and is typically 80+ bytes. Reject tiny values which are
+            # likely key-ID collisions with the tmp_storage boot-time entry
+            # (time_t of 8 bytes on 64bit systems)
+            return len(value) > 8
+    return False
 
 
 async def get_adapter_hardware_addr(


### PR DESCRIPTION
The current validation only checks if ACTIVE_DATASET (0x1) is present in the settings files. However, this can incorrectly match on data that doesn't contain Thread TLVs, but also for ephemeral data (boot time marker) created by OpenThread's TmpStorage [1], as seen in this hexdump of the file:

```
00000000: 0100 0800 b477 8b69 0000 0000 0200 1000  .....w.i........
```

To make the check more robust, check not only for the key, but also for value length, which should normally be larger than time_t.

[1] https://github.com/openthread/openthread/blob/thread-reference-20250612/src/posix/platform/tmp_storage.cpp#L75