### PR TITLE
otbr: Only explicitly enable TREL when on beta

### DIFF
--- a/openthread_border_router/CHANGELOG.md
+++ b/openthread_border_router/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.16.4
+- Only explicitly enable TREL in beta mode to avoid startup issues on stable
+
 ## 2.16.3
 - Ignore ephemeral temporary settings files in migration
 

--- a/openthread_border_router/config.yaml
+++ b/openthread_border_router/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 2.16.3
+version: 2.16.4
 slug: openthread_border_router
 name: OpenThread Border Router
 description: OpenThread Border Router add-on

--- a/openthread_border_router/rootfs/etc/s6-overlay/scripts/otbr-agent-configure.sh
+++ b/openthread_border_router/rootfs/etc/s6-overlay/scripts/otbr-agent-configure.sh
@@ -4,7 +4,10 @@
 # Configure OTBR depending on add-on settings
 # ==============================================================================
 
-ot-ctl trel enable
+if bashio::config.true 'beta'; then
+    bashio::log.info "Enabling TREL."
+    ot-ctl trel enable
+fi
 
 if bashio::config.true 'nat64'; then
     bashio::log.info "Enabling NAT64."


### PR DESCRIPTION
https://github.com/home-assistant/addons/issues/4409 seems to indicate that running `ot-cli trel enable` during startup actually causes issues for stable users, presumably because the "feature" refactor in ot-br-posix changed how things started/stopped. To maintain the old behavior exactly, we should start TREL only on the beta.