### PR TITLE
fix(docs): Update DOCS.md with Thread creds sync instructions

### DIFF
--- a/openthread_border_router/DOCS.md
+++ b/openthread_border_router/DOCS.md
@@ -46,6 +46,19 @@ create a new integration named "Open Thread Border Router". With Home Assistant
 Core 2023.3 and newer the OTBR will get configured automatically. The Thread
 integration allows to inspect the network configuration.
 
+You will still need to go to the Thread settings page and select your preferred
+network, choose the option for **Use router for Android and iOS credentials**, 
+and then you can add devices using your mobile via the Home-Assistant companion
+app. **Don't forget to sync the credentials** for the Thread network with your
+companion app.
+
+On an Android phone in the HA app go to **Settings** > **Companion App** >
+**Troubleshooting** > **Sync Thread credentials**.
+
+Or for an iPhone, go to **Settings** > **Devices & services**, select the
+Thread integration, select **Configure** under Services. At the bottom of the
+preferred network box, select **Send credentials to phone**.
+
 ### Web interface (advanced)
 
 There is also a web interface provided by the OTBR. However, the web


### PR DESCRIPTION
Hey, I wasted a lot of time on setup today, because everything was fine except the credentials sync in the android companion app [hidden in troubleshooting].
That piece of information is available on the thread integration's docs page, but not the open thread border router, which is where the matter signup process fails [android says you need a thread border router - which you have already setup via HA].
Adding to the docs page of the OTBR app is the first place people will look.
It might make more sense to have the how-to-use section containing the OTBR/mobile  guidance, at least until the home assistant companion app can do the sync automatically as you add your network/HA-instance in the mobile app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guidance for synchronizing Thread network credentials across Android and iOS mobile devices. New documentation provides detailed step-by-step in-app navigation instructions specific to both platforms, helping users successfully configure Thread integration and transfer network credentials to their Android smartphones and iPhones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->