### PR TITLE
letsencrypt: add note about Hetzner changes in v6.0.0, adjust docs

### DIFF
--- a/letsencrypt/CHANGELOG.md
+++ b/letsencrypt/CHANGELOG.md
@@ -19,6 +19,7 @@ breaking changes below.
 - Remove `linode_version` option: only Linode API v4 is supported
 - Ignore `dreamhost_baseurl` option (not supported by lego, default URL is used)
 - Ignore `gandi_sharing_id`, `ionos_endpoint`, `joker_domain` options (not supported by lego)
+- Hetzner option `hetzner_api_token` now requires Hetzner Cloud API token, old Hetzner DNS token is no longer supported
 - Drop unsupported armhf, armv7, and i386 architectures
 
 ### Other changes

--- a/letsencrypt/DOCS.md
+++ b/letsencrypt/DOCS.md
@@ -858,7 +858,7 @@ You will need to create the dynamic TXT record from within the dns.he.net interf
 <details>
   <summary>Hetzner</summary>
 
-Use of this plugin requires a Hetzner DNS API personal access token. You can create one on the Hetzner [DNS website](https://dns.hetzner.com/settings/api-token).
+Use of this plugin requires a Hetzner Cloud API token. See the Hetzner Docs on [Generating an API token](https://docs.hetzner.com/cloud/api/getting-started/generating-api-token/).
 
   ```yaml
   email: your.email@example.com
@@ -869,7 +869,7 @@ Use of this plugin requires a Hetzner DNS API personal access token. You can cre
   challenge: dns
   dns:
     provider: dns-hetzner
-    hetzner_api_token: hetzner-personal-access-token
+    hetzner_api_token: hetzner-api-token
   ```
 
 [Full Documentation](https://github.com/ctrlaltcoop/certbot-dns-hetzner)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Hetzner API token handling has changed; the `hetzner_api_token` option now requires a Hetzner Cloud API token instead of the previous Hetzner DNS token.

* **Documentation**
  * Updated documentation to reflect new Hetzner Cloud API token requirements and configuration examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->