### PR TITLE
letsencrypt: fix AWS Route 53 missing region

### DIFF
--- a/letsencrypt/CHANGELOG.md
+++ b/letsencrypt/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 6.0.1
+
+- Fix Route 53 DNS provider failing with "Missing Region" error
+- Add optional `aws_region` configuration option (defaults to `us-east-1`)
+
 ## 6.0.0
 
 This release migrates most DNS challenge providers from individual certbot

--- a/letsencrypt/DOCS.md
+++ b/letsencrypt/DOCS.md
@@ -97,6 +97,7 @@ propagation_seconds: 60
 lego_env: []
 lego_provider: ''
 aws_access_key_id: ''
+aws_region: ''
 aws_secret_access_key: ''
 azure_config: ''
 cloudflare_api_key: ''
@@ -1325,6 +1326,8 @@ An example configuration:
     aws_access_key_id: 0123456789ABCDEF0123
     aws_secret_access_key: 0123456789abcdef0123456789/abcdef0123456
   ```
+
+The configuration also takes `aws_region` which defaults to `us-east-1` (Route 53 is a global AWS service). Set it only if you need to use a different region endpoint.
 
 For security reasons, don't use your main account's credentials. Instead, add a new [AWS user](https://console.aws.amazon.com/iam/home?#/users) with _Access Type: Programmatic access_ and use that user's access key. Assign a minimum [policy](https://console.aws.amazon.com/iam/home?#/policies$new?step=edit) like the following example. Make sure to replace the Resource ARN in the first statement to your domain's hosted zone ARN or use _*_ for all.
 

--- a/letsencrypt/config.yaml
+++ b/letsencrypt/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 6.0.0
+version: 6.0.1
 breaking_versions: [5.3.0, 6.0.0]
 slug: letsencrypt
 name: Let's Encrypt
@@ -34,6 +34,7 @@ schema:
     # "DNS Provider configuration" field. Do NOT include the 'dns:' key itself.
     # Developer note: please add a new plugin alphabetically into all lists
     aws_access_key_id: str?
+    aws_region: str?
     aws_secret_access_key: str?
     azure_config: str?
     cloudflare_api_key: str?

--- a/letsencrypt/rootfs/etc/services.d/lets-encrypt/run
+++ b/letsencrypt/rootfs/etc/services.d/lets-encrypt/run
@@ -471,6 +471,13 @@ if [ "${CHALLENGE}" == "dns" ]; then
             bashio::config.require 'dns.aws_secret_access_key'
             echo "AWS_ACCESS_KEY_ID=$(bashio::config 'dns.aws_access_key_id')" >> "${DNS_MULTI_CREDS}"
             echo "AWS_SECRET_ACCESS_KEY=$(bashio::config 'dns.aws_secret_access_key')" >> "${DNS_MULTI_CREDS}"
+            # Lego's AWS SDK requires a region to resolve the Route53 service endpoint.
+            # Route53 is a global service, so us-east-1 is the standard default.
+            AWS_REGION="us-east-1"
+            if bashio::config.has_value 'dns.aws_region'; then
+                AWS_REGION="$(bashio::config 'dns.aws_region')"
+            fi
+            echo "AWS_REGION=${AWS_REGION}" >> "${DNS_MULTI_CREDS}"
             # Uppercased provider name differs from variable prefix, set propagation timeout here
             echo "AWS_PROPAGATION_TIMEOUT=${PROPAGATION_SECONDS}" >> "${DNS_MULTI_CREDS}"
             PROPAGATION_SECONDS=""


### PR DESCRIPTION
With Python's boto3 library this wasn't needed but Go AWS libs obviously need the region to be specified also for global services. Default to us-east-1 to restore pre-v6.0.0 behavior.

Fixes #4429

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Route 53 DNS provider failing with "Missing Region" error
* **New Features**
  * Added optional aws_region configuration option for custom Route 53 region endpoints (defaults to us-east-1)
* **Documentation**
  * Updated configuration examples and documentation for aws_region setting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->