### PR TITLE
Migrate Z-Wave network keys from the OZW format to the Z-Wave JS format

### DIFF
--- a/zwave_js/rootfs/etc/cont-init.d/config.sh
+++ b/zwave_js/rootfs/etc/cont-init.d/config.sh
@@ -307,6 +307,14 @@ for config_key in "network_key" "s0_legacy_key" "s2_access_control_key" "s2_auth
     fi
 done
 
+# Flush any migrated keys immediately so that bashio::config below reads the
+# migrated values rather than stale on-disk legacy values.
+if [[ ${flush_to_disk:+x} ]]; then
+    bashio::log.info "Flushing config to disk due to legacy key migration..."
+    bashio::addon.options >"/data/options.json"
+    flush_to_disk=
+fi
+
 if bashio::config.has_value 'network_key'; then
     # If both 'network_key' and 's0_legacy_key' are set and keys don't match,
     # we don't know which one to pick so we have to exit. If they are both set


### PR DESCRIPTION
fixes: https://github.com/home-assistant/addons/issues/4447

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Z-Wave network keys are automatically migrated at startup from legacy formats to the new compact hex format and persisted.
  * Migration runs before key validation/generation to ensure correct handling of existing keys.
  * Startup logging now reports when keys are migrated or created and indicates when changes are flushed to disk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->