### PR TITLE
Configure Z-Wave device config priority dir correctly

### DIFF
--- a/zwave_js/rootfs/usr/share/tempio/zwave_config.conf
+++ b/zwave_js/rootfs/usr/share/tempio/zwave_config.conf
@@ -8,6 +8,7 @@
     "rf": {{ .rf_json }},
     "storage": {
         "cacheDir": "/config/cache",
+        "deviceConfigPriorityDir": "/config/config",
         "throttle": "slow"
     },
     "securityKeys": {


### PR DESCRIPTION
When migrating from the Z-Wave JS UI community addon, the path to the device config priority dir was configured to be `/app/store/config`, which does not exist in the `zwave_js` addon. This PR updates the configuration to point to the correct path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated storage configuration to improve device configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->