### PR TITLE
git_pull: update base to Alpine 3.23, drop unsupported archs and advaced flag

### DIFF
--- a/git_pull/CHANGELOG.md
+++ b/git_pull/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 9.0.0
+
+- Update base image to Alpine 3.23
+- Drop unsupported architectures
+- Remove advanced flag in the app config
+
 ## 8.0.1
 - Fix bashio warn(ing) logger usage breaking deployment keys
 

--- a/git_pull/README.md
+++ b/git_pull/README.md
@@ -2,13 +2,10 @@
 
 Load and update configuration files for Home Assistant from a Git repository.
 
-![Supports aarch64 Architecture][aarch64-shield] ![Supports amd64 Architecture][amd64-shield] ![Supports armhf Architecture][armhf-shield] ![Supports armv7 Architecture][armv7-shield] ![Supports i386 Architecture][i386-shield]
+![Supports aarch64 Architecture][aarch64-shield] ![Supports amd64 Architecture][amd64-shield]
 
 You can use this app (formerly known as add-on) to `git pull` updates to your Home Assistant configuration files from a Git
 repository.
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
-[armhf-shield]: https://img.shields.io/badge/armhf-yes-green.svg
-[armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
-[i386-shield]: https://img.shields.io/badge/i386-yes-green.svg

--- a/git_pull/build.yaml
+++ b/git_pull/build.yaml
@@ -1,7 +1,4 @@
 ---
 build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-base:3.21
-  amd64: ghcr.io/home-assistant/amd64-base:3.21
-  armhf: ghcr.io/home-assistant/armhf-base:3.21
-  armv7: ghcr.io/home-assistant/armv7-base:3.21
-  i386: ghcr.io/home-assistant/i386-base:3.21
+  aarch64: ghcr.io/home-assistant/aarch64-base:3.23
+  amd64: ghcr.io/home-assistant/amd64-base:3.23

--- a/git_pull/config.yaml
+++ b/git_pull/config.yaml
@@ -1,16 +1,12 @@
 ---
-version: 8.0.1
+version: 9.0.0
 slug: git_pull
 name: Git pull
 description: Simple git pull to update the local configuration
 url: https://github.com/home-assistant/addons/tree/master/git_pull
-advanced: true
 arch:
-  - armhf
-  - armv7
   - aarch64
   - amd64
-  - i386
 boot: manual
 hassio_api: true
 hassio_role: homeassistant


### PR DESCRIPTION
Refs #4455

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Base image upgraded to Alpine 3.23 for improved security and reliability
  * Architecture support streamlined to aarch64 and amd64 only; armhf, armv7, and i386 support discontinued
  * Advanced configuration flag removed to simplify configuration

* **Documentation**
  * README updated to reflect supported architectures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->