### PR TITLE
Fix OTBR migration script hanging when no settings to migrate

### DIFF
--- a/openthread_border_router/rootfs/usr/local/bin/migrate_otbr_settings.py
+++ b/openthread_border_router/rootfs/usr/local/bin/migrate_otbr_settings.py
@@ -152,14 +152,10 @@ async def main() -> None:
     if flow_control == "none":
         flow_control = None
 
-    # First, read the hardware address of the new adapter
-    hwaddr = await get_adapter_hardware_addr(
-        port=args.adapter,
-        baudrate=args.baudrate,
-        flow_control=flow_control,
-    )
-
-    # Then, look at existing settings
+    # First, look at existing settings before touching the adapter.
+    # If there is nothing to migrate, skip the adapter connection entirely.
+    # This avoids a TimeoutError / AssertionError on dongles that reset their
+    # USB connection in response to a Spinel RESET (issue #4475).
     all_settings = []
 
     for settings_path in args.data_dir.glob("*.data"):
@@ -183,6 +179,13 @@ async def main() -> None:
     if not all_settings:
         print("No existing settings files found, skipping")
         return
+
+    # Only connect to the adapter if there are settings files that need migrating
+    hwaddr = await get_adapter_hardware_addr(
+        port=args.adapter,
+        baudrate=args.baudrate,
+        flow_control=flow_control,
+    )
 
     most_recent_settings_info = sorted(all_settings, reverse=True)[0]
     most_recent_settings_path = most_recent_settings_info[1]


### PR DESCRIPTION
## Problem

`migrate_otbr_settings.py` unconditionally calls `get_adapter_hardware_addr()` before checking whether any `.data` files exist that actually need migrating.

On certain dongles (ZBT-1 with firmware 2.7.2.0, Sonoff Dongle Lite MG21, and others), this causes a `TimeoutError` or `AssertionError` because the adapter drops or resets its USB connection in response to the Spinel RESET command. The script exits with code 1 even though there is nothing to migrate, preventing `otbr-agent` from starting.

Affected scenarios:
- Fresh installs with no prior OTBR configuration
- Reinstalls where the data directory has been cleared
- Any restart where the adapter is in a recently-initialized state

Fixes #4475

## Fix

Scan the data directory for `.data` files **first**. If none are found, exit cleanly without opening a serial connection to the adapter at all. Only connect to the adapter if there are settings that actually need migrating.

The logic change is minimal — the `.data` scanning loop and early-exit are simply moved before the `get_adapter_hardware_addr()` call.

## Testing

Verified on a ZBT-1 (serial `20b518d285...`, firmware `SL-OPENTHREAD/2.7.2.0`):
- Empty data dir → script exits cleanly without touching the adapter → `otbr-agent` starts normally
- Existing `.data` files present → adapter connection proceeds as before → migration completes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized settings migration to defer adapter initialization and skip migration when no settings exist, preventing timeout issues on certain dongles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->