### PR TITLE
fix(matter_server): skip --log-level-sdk for JS beta server

### DIFF
--- a/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
+++ b/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
@@ -8,7 +8,6 @@ bashio::log.info "Starting Matter Server..."
 
 declare server_port
 declare log_level
-declare log_level_sdk
 declare primary_interface
 declare matter_server_version
 declare npm_package
@@ -25,9 +24,6 @@ if ! bashio::config.exists log_level; then
   bashio::log.magenta 'No log_level set in config, fallback to info'
 fi
 log_level=$(bashio::string.lower "$(bashio::config log_level info)")
-
-# Make Matter SDK log level currently default to error
-log_level_sdk=$(bashio::string.lower "$(bashio::config log_level_sdk error)")
 
 # Determine server type based on beta flag
 use_js_server=$(bashio::config "beta")
@@ -84,6 +80,9 @@ if [[ "${use_js_server}" == "true" ]]; then
 else
   # Non-beta mode: Use Python Matter Server
   bashio::log.info "Using Python Matter Server"
+
+  # SDK log level is only supported by the Python server
+  extra_args+=('--log-level-sdk' "$(bashio::string.lower "$(bashio::config log_level_sdk error)")")
 
   if bashio::config.has_value "matter_server_version"; then
     matter_server_version=$(bashio::config 'matter_server_version')
@@ -149,7 +148,6 @@ matter_server_args+=(
   '--storage-path' "/data"
   '--port' "${server_port}"
   '--log-level' "${log_level}"
-  '--log-level-sdk' "${log_level_sdk}"
   '--primary-interface' "${primary_interface}"
   '--paa-root-cert-dir' "/data/credentials"
   '--ota-provider-dir' "/config/updates"


### PR DESCRIPTION
## Summary

- Moves `--log-level-sdk` from the shared argument list into the Python-only (non-beta) code path via `extra_args`, matching the existing pattern for server-specific options
- Removes the now-unused `declare log_level_sdk` and top-level config read
- The JavaScript Matter Server does not support `--log-level-sdk` and emits `Warning: --log-level-sdk is deprecated and no longer supported. This option will be ignored.` on every startup

## Note on configuration UI

Ideally the `log_level_sdk` configuration option would be hidden or disabled in the UI when `beta: true` is set, since it has no effect on the JS server. However, the Home Assistant add-on schema system does not currently support conditional field visibility based on other option values, so this is not possible without upstream changes to the add-on config framework. The option is harmless when present — it is simply not read or passed through.

## Test plan

- [ ] Start Matter Server add-on with `beta: true` — verify no `--log-level-sdk` deprecation warning in logs
- [ ] Start Matter Server add-on with `beta: false` and a non-default `log_level_sdk` value — verify `--log-level-sdk` is still passed correctly to the Python server

Fixes #4516

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted SDK logging configuration handling to provide improved flexibility and cleaner default settings across different server modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->