### PR TITLE
fix(matter_server): skip --paa-root-cert-dir for JS beta server

### DIFF
--- a/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
+++ b/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
@@ -85,6 +85,9 @@ else
   # Non-beta mode: Use Python Matter Server
   bashio::log.info "Using Python Matter Server"
 
+  # PAA root cert dir is only supported by the Python server
+  extra_args+=('--paa-root-cert-dir' "/data/credentials")
+
   if bashio::config.has_value "matter_server_version"; then
     matter_server_version=$(bashio::config 'matter_server_version')
     bashio::log.info "Installing Python Matter Server ${matter_server_version}"
@@ -151,7 +154,6 @@ matter_server_args+=(
   '--log-level' "${log_level}"
   '--log-level-sdk' "${log_level_sdk}"
   '--primary-interface' "${primary_interface}"
-  '--paa-root-cert-dir' "/data/credentials"
   '--ota-provider-dir' "/config/updates"
   '--fabricid' 2
   '--vendorid' 4939


### PR DESCRIPTION
## Summary

- Moves `--paa-root-cert-dir` from the shared argument list into the Python-only (non-beta) code path via `extra_args`, matching the existing pattern for server-specific options
- The JavaScript Matter Server does not support `--paa-root-cert-dir` and emits `Warning: --paa-root-cert-dir is deprecated and no longer supported. This option will be ignored.` on every startup

## Test plan

- [ ] Start Matter Server add-on with `beta: true` — verify no `--paa-root-cert-dir` deprecation warning in logs
- [ ] Start Matter Server add-on with `beta: false` — verify `--paa-root-cert-dir` is still passed correctly to the Python server

Fixes #4518
Related: #4516, #4517

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Matter Server startup configuration to conditionally apply root certificate directory settings based on the execution environment, preventing potential compatibility issues and ensuring stable operation across different deployment modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->