### PR TITLE
fix(matter_server): conditionally pass --ota-provider-dir for JS beta server

### DIFF
--- a/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
+++ b/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
@@ -61,6 +61,11 @@ if [[ "${use_js_server}" == "true" ]]; then
   find ./node_modules -type d -name "cjs" -path "*/@project-chip/*" -exec rm -rf {} + 2>/dev/null || true
   rm -rf /tmp/* /var/tmp/* /root/.npm /root/.cache 2>/dev/null || true
 
+  # JS server only uses --ota-provider-dir when --enable-test-net-dcl is also set
+  if bashio::config.true "enable_test_net_dcl"; then
+    extra_args+=('--ota-provider-dir' "/config/updates")
+  fi
+
   if bashio::config.has_value "matter_server_env_vars"; then
     env_vars_count=$(bashio::config 'matter_server_env_vars | length')
     for (( i=0; i < env_vars_count; i++ )); do
@@ -84,6 +89,9 @@ if [[ "${use_js_server}" == "true" ]]; then
 else
   # Non-beta mode: Use Python Matter Server
   bashio::log.info "Using Python Matter Server"
+
+  # Python server uses --ota-provider-dir independently of --enable-test-net-dcl
+  extra_args+=('--ota-provider-dir' "/config/updates")
 
   if bashio::config.has_value "matter_server_version"; then
     matter_server_version=$(bashio::config 'matter_server_version')
@@ -152,7 +160,6 @@ matter_server_args+=(
   '--log-level-sdk' "${log_level_sdk}"
   '--primary-interface' "${primary_interface}"
   '--paa-root-cert-dir' "/data/credentials"
-  '--ota-provider-dir' "/config/updates"
   '--fabricid' 2
   '--vendorid' 4939
   ${extra_args[@]}


### PR DESCRIPTION
## Summary

- Moves `--ota-provider-dir` from the shared argument list into both server-specific code paths via `extra_args`
- **JS beta path**: Only passes `--ota-provider-dir` when `enable_test_net_dcl` is also enabled, since the JS server [requires both flags](https://github.com/matter-js/matterjs-server/blob/a0f7904a01fb7bc34936c2203c21b78ea726fbfd/README.md?plain=1#L165) for custom OTA files to be used
- **Python path**: Continues passing `--ota-provider-dir` unconditionally, as the Python server uses it independently to load local OTA update files

## Test plan

- [ ] Start with `beta: true`, `enable_test_net_dcl: false` — verify no OTA warning in logs, `--ota-provider-dir` is not passed
- [ ] Start with `beta: true`, `enable_test_net_dcl: true` — verify `--ota-provider-dir` is passed alongside `--enable-test-net-dcl`
- [ ] Start with `beta: false` — verify `--ota-provider-dir` is still passed unconditionally to the Python server

Fixes #4520
Related: #4516, #4517, #4518, #4519

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Over-The-Air (OTA) update provider configuration to respect server mode settings. The OTA provider directory is now conditionally applied based on whether the server runs in beta test mode or standard production mode, ensuring consistent update behavior and proper directory handling across all server configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->