### PR TITLE
Change Discord join link

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ repository can be a great source of inspiration. For more information
 about developing an app, please see our
 [documentation for developers][dev-docs].
 
-[discord]: https://discord.gg/c5DvZ4e
+[discord]: https://www.home-assistant.io/join-chat
 [forum]: https://community.home-assistant.io
 [i386-shield]: https://img.shields.io/badge/i386-no-red.svg
 [issue]: https://github.com/home-assistant/addons/issues

--- a/assist_microphone/DOCS.md
+++ b/assist_microphone/DOCS.md
@@ -72,7 +72,7 @@ You have several options to get them answered:
 
 In case you've found an bug, please [open an issue on our GitHub][issue].
 
-[discord]: https://discord.gg/c5DvZ4e
+[discord]: https://www.home-assistant.io/join-chat
 [forum]: https://community.home-assistant.io
 [issue]: https://github.com/home-assistant/addons/issues
 [reddit]: https://reddit.com/r/homeassistant

--- a/cec_scan/DOCS.md
+++ b/cec_scan/DOCS.md
@@ -27,7 +27,7 @@ You have several options to get them answered:
 
 In case you've found a bug, please [open an issue on our GitHub][issue].
 
-[discord]: https://discord.gg/c5DvZ4e
+[discord]: https://www.home-assistant.io/join-chat
 [forum]: https://community.home-assistant.io
 [issue]: https://github.com/home-assistant/hassio-addons/issues
 [reddit]: https://reddit.com/r/homeassistant

--- a/configurator/DOCS.md
+++ b/configurator/DOCS.md
@@ -70,7 +70,7 @@ You have several options to get them answered:
 
 In case you've found a bug, please [open an issue on our GitHub][issue].
 
-[discord]: https://discord.gg/c5DvZ4e
+[discord]: https://www.home-assistant.io/join-chat
 [forum]: https://community.home-assistant.io
 [issue]: https://github.com/home-assistant/addons/issues
 [reddit]: https://reddit.com/r/homeassistant

--- a/deconz/DOCS.md
+++ b/deconz/DOCS.md
@@ -232,7 +232,7 @@ You have several options to get them answered:
 
 In case you've found a bug, please [open an issue on our GitHub][issue].
 
-[discord]: https://discord.gg/c5DvZ4e
+[discord]: https://www.home-assistant.io/join-chat
 [forum]: https://community.home-assistant.io
 [issue]: https://github.com/home-assistant/addons/issues
 [manual-upgrade]: https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Update-deCONZ-manually

--- a/dnsmasq/DOCS.md
+++ b/dnsmasq/DOCS.md
@@ -139,7 +139,7 @@ You have several options to get them answered:
 
 In case you've found a bug, please [open an issue on our GitHub][issue].
 
-[discord]: https://discord.gg/c5DvZ4e
+[discord]: https://www.home-assistant.io/join-chat
 [forum]: https://community.home-assistant.io
 [issue]: https://github.com/home-assistant/addons/issues
 [reddit]: https://reddit.com/r/homeassistant

--- a/duckdns/DOCS.md
+++ b/duckdns/DOCS.md
@@ -150,7 +150,7 @@ You have several options to get them answered:
 
 In case you've found a bug, please [open an issue on our GitHub][issue].
 
-[discord]: https://discord.gg/c5DvZ4e
+[discord]: https://www.home-assistant.io/join-chat
 [forum]: https://community.home-assistant.io
 [issue]: https://github.com/home-assistant/addons/issues
 [reddit]: https://reddit.com/r/homeassistant

--- a/git_pull/DOCS.md
+++ b/git_pull/DOCS.md
@@ -148,7 +148,7 @@ You have several options to get them answered:
 
 In case you've found a bug, please [open an issue on our GitHub][issue].
 
-[discord]: https://discord.gg/c5DvZ4e
+[discord]: https://www.home-assistant.io/join-chat
 [forum]: https://community.home-assistant.io
 [issue]: https://github.com/home-assistant/addons/issues
 [reddit]: https://reddit.com/r/homeassistant

--- a/letsencrypt/DOCS.md
+++ b/letsencrypt/DOCS.md
@@ -1549,7 +1549,7 @@ You have several options to get them answered:
 
 In case you've found a bug, please [open an issue on our GitHub][issue].
 
-[discord]: https://discord.gg/c5DvZ4e
+[discord]: https://www.home-assistant.io/join-chat
 [forum]: https://community.home-assistant.io
 [issue]: https://github.com/home-assistant/addons/issues
 [certbot]: https://certbot.eff.org

--- a/mariadb/DOCS.md
+++ b/mariadb/DOCS.md
@@ -110,7 +110,7 @@ In case you've found a bug, please [open an issue on our GitHub][issue].
 [grant]: https://mariadb.com/kb/en/grant/
 [migration-issues]: https://github.com/home-assistant/core/issues/125339
 [mariadb-ha-recorder]: https://www.home-assistant.io/integrations/recorder/
-[discord]: https://discord.gg/c5DvZ4e
+[discord]: https://www.home-assistant.io/join-chat
 [forum]: https://community.home-assistant.io
 [i386-shield]: https://img.shields.io/badge/i386-yes-green.svg
 [issue]: https://github.com/home-assistant/addons/issues

--- a/matter_server/DOCS.md
+++ b/matter_server/DOCS.md
@@ -78,7 +78,7 @@ In case you've found a bug, please [open an issue on our GitHub][issue].
 
 [addon]: https://my.home-assistant.io/redirect/supervisor_addon/?addon=core_matter_server
 [addon-badge]: https://my.home-assistant.io/badges/supervisor_addon.svg
-[discord]: https://discord.gg/c5DvZ4e
+[discord]: https://www.home-assistant.io/join-chat
 [forum]: https://community.home-assistant.io
 [reddit]: https://reddit.com/r/homeassistant
 [issue]: https://github.com/home-assistant/addons/issues

--- a/mosquitto/DOCS.md
+++ b/mosquitto/DOCS.md
@@ -185,7 +185,7 @@ You have several options to get them answered:
 
 In case you've found a bug, please [open an issue on our GitHub][issue].
 
-[discord]: https://discord.gg/c5DvZ4e
+[discord]: https://www.home-assistant.io/join-chat
 [forum]: https://community.home-assistant.io
 [issue]: https://github.com/home-assistant/addons/issues
 [reddit]: https://reddit.com/r/homeassistant

--- a/nginx_proxy/DOCS.md
+++ b/nginx_proxy/DOCS.md
@@ -112,7 +112,7 @@ You have several options to get them answered:
 
 In case you've found a bug, please [open an issue on our GitHub][issue].
 
-[discord]: https://discord.gg/c5DvZ4e
+[discord]: https://www.home-assistant.io/join-chat
 [forum]: https://community.home-assistant.io
 [hsts]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
 [issue]: https://github.com/home-assistant/addons/issues

--- a/openthread_border_router/DOCS.md
+++ b/openthread_border_router/DOCS.md
@@ -101,7 +101,7 @@ You have several options to get them answered:
 
 In case you've found a bug, please [open an issue on our GitHub][issue].
 
-[discord]: https://discord.gg/c5DvZ4e
+[discord]: https://www.home-assistant.io/join-chat
 [forum]: https://community.home-assistant.io
 [reddit]: https://reddit.com/r/homeassistant
 [issue]: https://github.com/home-assistant/addons/issues

--- a/openwakeword/DOCS.md
+++ b/openwakeword/DOCS.md
@@ -54,7 +54,7 @@ You have several options to get them answered:
 
 In case you've found an bug, please [open an issue on our GitHub][issue].
 
-[discord]: https://discord.gg/c5DvZ4e
+[discord]: https://www.home-assistant.io/join-chat
 [forum]: https://community.home-assistant.io
 [issue]: https://github.com/home-assistant/addons/issues
 [reddit]: https://reddit.com/r/homeassistant

--- a/piper/DOCS.md
+++ b/piper/DOCS.md
@@ -84,7 +84,7 @@ You have several options to get them answered:
 
 In case you've found an bug, please [open an issue on our GitHub][issue].
 
-[discord]: https://discord.gg/c5DvZ4e
+[discord]: https://www.home-assistant.io/join-chat
 [forum]: https://community.home-assistant.io
 [issue]: https://github.com/home-assistant/addons/issues
 [reddit]: https://reddit.com/r/homeassistant

--- a/rpc_shutdown/README.md
+++ b/rpc_shutdown/README.md
@@ -13,4 +13,4 @@ Allows you to shut down Windows Computers with a service call from Home Assistan
 [armhf-shield]: https://img.shields.io/badge/armhf-yes-green.svg
 [armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
 [i386-shield]: https://img.shields.io/badge/i386-yes-green.svg
-[discord]: https://discord.gg/c5DvZ4e
+[discord]: https://www.home-assistant.io/join-chat

--- a/samba/DOCS.md
+++ b/samba/DOCS.md
@@ -126,7 +126,7 @@ You have several options to get them answered:
 
 In case you've found a bug, please [open an issue on our GitHub][issue].
 
-[discord]: https://discord.gg/c5DvZ4e
+[discord]: https://www.home-assistant.io/join-chat
 [forum]: https://community.home-assistant.io
 [issue]: https://github.com/home-assistant/addons/issues
 [reddit]: https://reddit.com/r/homeassistant

--- a/silabs-multiprotocol/DOCS.md
+++ b/silabs-multiprotocol/DOCS.md
@@ -103,7 +103,7 @@ You have several options to get them answered:
 
 In case you've found a bug, please [open an issue on our GitHub][issue].
 
-[discord]: https://discord.gg/c5DvZ4e
+[discord]: https://www.home-assistant.io/join-chat
 [forum]: https://community.home-assistant.io
 [reddit]: https://reddit.com/r/homeassistant
 [issue]: https://github.com/home-assistant/addons/issues

--- a/silabs_flasher/DOCS.md
+++ b/silabs_flasher/DOCS.md
@@ -41,7 +41,7 @@ You have several options to get them answered:
 
 In case you've found a bug, please [open an issue on our GitHub][issue].
 
-[discord]: https://discord.gg/c5DvZ4e
+[discord]: https://www.home-assistant.io/join-chat
 [forum]: https://community.home-assistant.io
 [reddit]: https://reddit.com/r/homeassistant
 [issue]: https://github.com/home-assistant/addons/issues

--- a/speech_to_phrase/DOCS.md
+++ b/speech_to_phrase/DOCS.md
@@ -63,7 +63,7 @@ You have several options to get them answered:
 
 In case you've found an bug, please [open an issue on our GitHub][issue].
 
-[discord]: https://discord.gg/c5DvZ4e
+[discord]: https://www.home-assistant.io/join-chat
 [forum]: https://community.home-assistant.io
 [issue]: https://github.com/home-assistant/addons/issues
 [reddit]: https://reddit.com/r/homeassistant

--- a/ssh/DOCS.md
+++ b/ssh/DOCS.md
@@ -112,7 +112,7 @@ You have several options to get them answered:
 
 In case you've found a bug, please [open an issue on our GitHub][issue].
 
-[discord]: https://discord.gg/c5DvZ4e
+[discord]: https://www.home-assistant.io/join-chat
 [forum]: https://community.home-assistant.io
 [issue]: https://github.com/home-assistant/addons/issues
 [keygen-windows]: https://www.digitalocean.com/community/tutorials/how-to-create-ssh-keys-with-putty-to-connect-to-a-vps

--- a/vlc/DOCS.md
+++ b/vlc/DOCS.md
@@ -31,7 +31,7 @@ You have several options to get them answered:
 
 In case you've found a bug, please [open an issue on our GitHub][issue].
 
-[discord]: https://discord.gg/c5DvZ4e
+[discord]: https://www.home-assistant.io/join-chat
 [forum]: https://community.home-assistant.io
 [issue]: https://github.com/home-assistant/addons/issues
 [reddit]: https://reddit.com/r/homeassistant

--- a/whisper/DOCS.md
+++ b/whisper/DOCS.md
@@ -124,7 +124,7 @@ You have several options to get them answered:
 
 In case you've found an bug, please [open an issue on our GitHub][issue].
 
-[discord]: https://discord.gg/c5DvZ4e
+[discord]: https://www.home-assistant.io/join-chat
 [forum]: https://community.home-assistant.io
 [issue]: https://github.com/home-assistant/addons/issues
 [reddit]: https://reddit.com/r/homeassistant

--- a/zwave_js/DOCS.md
+++ b/zwave_js/DOCS.md
@@ -252,7 +252,7 @@ You have several options to get them answered:
 
 In case you've found a bug, please [open an issue on our GitHub][issue].
 
-[discord]: https://discord.gg/c5DvZ4e
+[discord]: https://www.home-assistant.io/join-chat
 [forum]: https://community.home-assistant.io
 [issue]: https://github.com/home-assistant/addons/issues
 [reddit]: https://reddit.com/r/homeassistant


### PR DESCRIPTION
Change Discord join link

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated community support links across documentation to point to the official Home Assistant chat join page, replacing the previous Discord invite reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->