### PR TITLE
letsencrypt: add httpreq provider support

### DIFF
--- a/letsencrypt/CHANGELOG.md
+++ b/letsencrypt/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.3.1
+
+- Add HTTP request DNS provider support
+
 ## 6.3.0
 
 - Update certbot-dns-multi to 4.33.0, adding several DNS providers (see [lego's changelog](https://github.com/go-acme/lego/blob/v4.33.0/CHANGELOG.md) for details).

--- a/letsencrypt/DOCS.md
+++ b/letsencrypt/DOCS.md
@@ -64,6 +64,7 @@ dns-godaddy
 dns-google
 dns-he
 dns-hetzner
+dns-httpreq
 dns-infomaniak
 dns-inwx
 dns-ionos
@@ -136,6 +137,9 @@ google_creds: ''
 he_pass: ''
 he_user: ''
 hetzner_api_token: ''
+httpreq_endpoint: ''
+httpreq_password: ''
+httpreq_username: ''
 infomaniak_api_token: ''
 inwx_password: ''
 inwx_shared_secret: ''
@@ -923,6 +927,30 @@ Use of this plugin requires a Hetzner Cloud API token. See the Hetzner Docs on [
 </details>
 
 <details>
+  <summary>HTTP request</summary>
+
+The `dns-httpreq` provider uses lego's [HTTP request provider](https://go-acme.github.io/lego/dns/httpreq/).
+Your HTTP service must accept `POST` requests on `/present` and `/cleanup`.
+
+  ```yaml
+  email: your.email@example.com
+  domains:
+    - your.domain.tld
+  certfile: fullchain.pem
+  keyfile: privkey.pem
+  challenge: dns
+  dns:
+    provider: dns-httpreq
+    httpreq_endpoint: http://my.server.com:9090
+    httpreq_username: your-username
+    httpreq_password: your-password
+  ```
+
+The `httpreq_username` and `httpreq_password` values are optional, but they must either both be set or both be omitted.
+
+</details>
+
+<details>
   <summary>Infomaniak</summary>
 
   ```yaml
@@ -1527,6 +1555,7 @@ dns-godaddy
 dns-google
 dns-he
 dns-hetzner
+dns-httpreq
 dns-infomaniak
 dns-inwx
 dns-ionos

--- a/letsencrypt/config.yaml
+++ b/letsencrypt/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 6.3.0
+version: 6.3.1
 breaking_versions: [5.3.0, 6.0.0]
 slug: letsencrypt
 name: Let's Encrypt
@@ -78,6 +78,9 @@ schema:
     he_pass: str?
     he_user: str?
     hetzner_api_token: str?
+    httpreq_endpoint: url?
+    httpreq_password: str?
+    httpreq_username: str?
     infomaniak_api_token: str?
     inwx_password: str?
     inwx_shared_secret: str?
@@ -141,6 +144,7 @@ schema:
         dns-google|\
         dns-he|\
         dns-hetzner|\
+        dns-httpreq|\
         dns-infomaniak|\
         dns-inwx|\
         dns-ionos|\

--- a/letsencrypt/rootfs/etc/services.d/lets-encrypt/run
+++ b/letsencrypt/rootfs/etc/services.d/lets-encrypt/run
@@ -131,6 +131,7 @@ if [ "${CHALLENGE}" == "dns" ]; then
             ["dns-godaddy"]="godaddy"
             ["dns-google"]="gcloud"
             ["dns-hetzner"]="hetzner"
+            ["dns-httpreq"]="httpreq"
             ["dns-infomaniak"]="infomaniak"
             ["dns-inwx"]="inwx"
             ["dns-ionos"]="ionos"
@@ -327,6 +328,18 @@ if [ "${CHALLENGE}" == "dns" ]; then
         'dns-hetzner')
             bashio::config.require 'dns.hetzner_api_token'
             echo "HETZNER_API_TOKEN=$(bashio::config 'dns.hetzner_api_token')" >> "${DNS_MULTI_CREDS}"
+            ;;
+
+        # HTTP request
+        'dns-httpreq')
+            bashio::config.require 'dns.httpreq_endpoint'
+            echo "HTTPREQ_ENDPOINT=$(bashio::config 'dns.httpreq_endpoint')" >> "${DNS_MULTI_CREDS}"
+            if bashio::config.exists 'dns.httpreq_username' || bashio::config.exists 'dns.httpreq_password'; then
+                bashio::config.require 'dns.httpreq_username'
+                bashio::config.require 'dns.httpreq_password'
+                echo "HTTPREQ_USERNAME=$(bashio::config 'dns.httpreq_username')" >> "${DNS_MULTI_CREDS}"
+                echo "HTTPREQ_PASSWORD=$(bashio::config 'dns.httpreq_password')" >> "${DNS_MULTI_CREDS}"
+            fi
             ;;
 
         # Infomaniak


### PR DESCRIPTION
Adds the `httpreq` lego provider using the certbot multi provider. Modeled after the #4467 PR which does roughly the same.

The setup has been tested locally and succesfully issued a certificate via a local dns01proxy host.

Fixes https://github.com/orgs/home-assistant/discussions/3458

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added HTTP request DNS provider as a certificate validation option.

* **Documentation**
  * Updated configuration guide with HTTP request DNS provider setup details and credential requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->