### PR TITLE
openthread_border_router: Print a warning if IPv6 routing is disabled

### DIFF
--- a/openthread_border_router/CHANGELOG.md
+++ b/openthread_border_router/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.16.7
+
+- Print a warning if IPv6 routing is not enabled
+
 ## 2.16.6
 
 - Fix and improve NAT64 firewall rules

--- a/openthread_border_router/config.yaml
+++ b/openthread_border_router/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 2.16.6
+version: 2.16.7
 slug: openthread_border_router
 name: OpenThread Border Router
 description: OpenThread Border Router add-on

--- a/openthread_border_router/rootfs/etc/s6-overlay/s6-rc.d/otbr-agent/run
+++ b/openthread_border_router/rootfs/etc/s6-overlay/s6-rc.d/otbr-agent/run
@@ -37,6 +37,11 @@ else
     fi
 fi
 
+# Check if IPv6 forwarding is enabled
+if [ "$(cat /proc/sys/net/ipv6/conf/all/forwarding)" != "1" ]; then
+    bashio::log.warning "IPv6 routing/forwarding is not enabled! Make sure the Home Assistant host has IPv6 forwarding enabled."
+fi
+
 device=$(bashio::config 'device')
 
 if bashio::config.has_value 'network_device'; then


### PR DESCRIPTION
Print a warning if IPv6 is disabled. This is the case on Home Assistant OS 17.2 if IPv6 is not enabled on the hassio network. Enabling IPv6 on hassio network can be achived by using:

```
ha docker options --enable-ipv6=true
```

When IPv6 is enabled on the IPv6 network, Docker automatically enabled IPv6 routing as well. This then makes the Thread devices accessible for other ecosystems and make features like NAT64 work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added startup warning when IPv6 routing is not enabled.

* **Chores**
  * Version bump to 2.16.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->