### PR TITLE
letsencrypt: don't override lego's DNS propagation timeout with propagation_seconds

### DIFF
--- a/letsencrypt/CHANGELOG.md
+++ b/letsencrypt/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 6.3.2
 
-- No longer override lego's DNS propagation timeout with `propagation_seconds`.  Allows lego configuration and defaults.
+- No longer override lego's DNS propagation timeout with `propagation_seconds`. Allows lego configuration and defaults.
 
 ## 6.3.1
 

--- a/letsencrypt/CHANGELOG.md
+++ b/letsencrypt/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.3.2
+
+- No longer override lego's DNS propagation timeout with `propagation_seconds`.  Allows lego configuration and defaults.
+
 ## 6.3.1
 
 - Add HTTP request DNS provider support

--- a/letsencrypt/config.yaml
+++ b/letsencrypt/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 6.3.1
+version: 6.3.2
 breaking_versions: [5.3.0, 6.0.0]
 slug: letsencrypt
 name: Let's Encrypt

--- a/letsencrypt/rootfs/etc/services.d/lets-encrypt/run
+++ b/letsencrypt/rootfs/etc/services.d/lets-encrypt/run
@@ -109,9 +109,6 @@ if [ "${CHALLENGE}" == "dns" ]; then
         # Use certbot-dns-multi for all other providers
         bashio::log.info "Using certbot-dns-multi for ${DNS_PROVIDER}"
 
-        # Some providers use a different env var prefix than the uppercased provider name
-        PROVIDER_ENV_PREFIX=""
-
         # Map config provider names to lego provider names
         declare -A LEGO_PROVIDERS=(
             ["dns-bunny"]="bunny"
@@ -233,8 +230,6 @@ if [ "${CHALLENGE}" == "dns" ]; then
         'dns-digitalocean')
             bashio::config.require 'dns.digitalocean_token'
             echo "DO_AUTH_TOKEN=$(bashio::config 'dns.digitalocean_token')" >> "${DNS_MULTI_CREDS}"
-            # Uppercased provider name differs from variable prefix
-            PROVIDER_ENV_PREFIX="DO"
             ;;
 
         # DirectAdmin
@@ -320,8 +315,6 @@ if [ "${CHALLENGE}" == "dns" ]; then
             bashio::config.require 'dns.google_creds'
             # File is copied during container init by file-structure.sh
             echo "GCE_SERVICE_ACCOUNT_FILE=/data/google.json" >> "${DNS_MULTI_CREDS}"
-            # Uppercased provider name differs from variable prefix
-            PROVIDER_ENV_PREFIX="GCE"
             ;;
 
         # Hetzner
@@ -502,8 +495,6 @@ if [ "${CHALLENGE}" == "dns" ]; then
                 AWS_REGION="$(bashio::config 'dns.aws_region')"
             fi
             echo "AWS_REGION=${AWS_REGION}" >> "${DNS_MULTI_CREDS}"
-            # Uppercased provider name differs from variable prefix
-            PROVIDER_ENV_PREFIX="AWS"
             ;;
 
         # SakuraCloud
@@ -552,12 +543,6 @@ if [ "${CHALLENGE}" == "dns" ]; then
             echo "WEBSUPPORT_SECRET=$(bashio::config 'dns.websupport_secret_key')" >> "${DNS_MULTI_CREDS}"
             ;;
         esac
-
-        # Set propagation timeout env var
-        if [ -z "${PROVIDER_ENV_PREFIX}" ]; then
-            PROVIDER_ENV_PREFIX=$(echo "${LEGO_PROVIDER}" | tr '[:lower:]-' '[:upper:]_')
-        fi
-        echo "${PROVIDER_ENV_PREFIX}_PROPAGATION_TIMEOUT=${PROPAGATION_SECONDS}" >> "${DNS_MULTI_CREDS}"
 
         ACME_ARGUMENTS+=("--authenticator" "dns-multi" "--dns-multi-credentials" "${DNS_MULTI_CREDS}" "--dns-multi-propagation-seconds" "${PROPAGATION_SECONDS}")
         if bashio::config.has_value 'dns.dns_multi_nameservers'; then


### PR DESCRIPTION
Removes the `${PROVIDER_ENV_PREFIX}_PROPAGATION_TIMEOUT` line written into the dns-multi credentials file, and the now-dead `PROVIDER_ENV_PREFIX` variable and all its assignments.

`propagation_seconds` and lego's `*_PROPAGATION_TIMEOUT` are distinct settings at different layers:

- `*_PROPAGATION_TIMEOUT` — lego's internal polling timeout for waiting on the DNS provider's nameservers to confirm a newly created TXT record has propagated
 - `propagation_seconds` — a certbot-level sleep after lego confirms propagation, before notifying the ACME server to verify

The run script was writing `propagation_seconds` (default: 60s) as lego's internal timeout, silently overriding provider-specific defaults. For example, lego's built-in default for ClouDNS is 120s — the script was cutting that in half, causing renewal failures before lego even finished polling.

`propagation_seconds` is already correctly passed to certbot via `--dns-multi-propagation-seconds`. Lego's internal timeouts should be left to their provider-specific defaults.

This issue was introduced in 6.3.0 when `certbot-dns-multi` replaced individual certbot DNS plugins.

resolves #4549 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified DNS handling for Let's Encrypt: provider-specific timeout override removed so DNS propagation timeout now follows the underlying ACME tool's configured values and defaults.
* **Chores**
  * Bumped package version to 6.3.2 and added a changelog entry describing the DNS propagation behavior change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->