### PR TITLE
Add configuration options for TXT and PTR records

### DIFF
--- a/dnsmasq/CHANGELOG.md
+++ b/dnsmasq/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.1.0
+
+- Added option for configuring TXT and PTR records
+
 ## 2.0.0
 
 - Update base image to Alpine 3.23 (with dnsmasq v2.91)

--- a/dnsmasq/DOCS.md
+++ b/dnsmasq/DOCS.md
@@ -119,6 +119,31 @@ The name to resolve.
 
 The target name. Note that this only works for targets which are names from DHCP or /etc/hosts. Give host "bert" another name, bertrand cname=bertand,bert
 
+### Option: `txts` (optional)
+
+This option allows you to provide txt records.
+
+#### Option: `txts.name`
+
+The name to resolve.
+
+#### Option: `txts.value`
+
+The resulting txt string.
+
+### Option: `ptrs` (optional)
+
+This option allows you to provide ptr records.
+
+#### Option: `ptrs.ip`
+
+The ip to resolve as reverse-mapping domain name (IP 1.2.3.4 → 4.3.2.1.in-addr.arpa).
+
+#### Option: `ptrs.name`
+
+The resulting name.
+
+
 ### Option: `log_queries` (required) 
 
 Log all DNS requests. Defaults to `false`.

--- a/dnsmasq/DOCS.md
+++ b/dnsmasq/DOCS.md
@@ -137,7 +137,7 @@ This option allows you to provide ptr records.
 
 #### Option: `ptrs.ip`
 
-The ip to resolve as reverse-mapping domain name (IP 1.2.3.4 → 4.3.2.1.in-addr.arpa).
+The IP address to resolve as reverse-mapping domain name. Use reversed IP address with ".in-addr.arpa" added, for example for IP address "1.2.3.4" use "4.3.2.1.in-addr.arpa".
 
 #### Option: `ptrs.name`
 

--- a/dnsmasq/config.yaml
+++ b/dnsmasq/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 2.0.0
+version: 2.1.0
 slug: dnsmasq
 name: Dnsmasq
 description: A simple DNS server

--- a/dnsmasq/config.yaml
+++ b/dnsmasq/config.yaml
@@ -17,6 +17,8 @@ options:
   hosts: []
   services: []
   cnames: []
+  txts: []
+  ptrs: []
   log_queries: false
   cache_size: 150
 ports:
@@ -40,6 +42,12 @@ schema:
   cnames:
     - name: str
       target: str
+  txts:
+    - name: str
+      value: str
+  ptrs:
+    - ip: str
+      name: str
   log_queries: bool
   cache_size: int
 startup: system

--- a/dnsmasq/rootfs/usr/share/tempio/dnsmasq.config
+++ b/dnsmasq/rootfs/usr/share/tempio/dnsmasq.config
@@ -35,3 +35,13 @@ srv-host={{ .srv }},{{ .host }},{{ .port }},{{ .priority }},{{ .weight }}
 {{ range .cnames }}
 cname={{ .name }},{{ .target }}
 {{ end }}
+
+# Static txt
+{{ range .txts }}
+txt-record={{ .name }},"{{ .value }}"
+{{ end }}
+
+# Static ptr
+{{ range .ptrs }}
+ptr-record={{ .ip }},"{{ .name }}"
+{{ end }}

--- a/dnsmasq/translations/en.yaml
+++ b/dnsmasq/translations/en.yaml
@@ -24,7 +24,7 @@ configuration:
   ptrs:
     name: PTR records
     description: >-
-      Reversed IP address with ".in-addr.arpa" suffix 
+      Reversed IP address with ".in-addr.arpa" suffix
       (IP 1.2.3.4 → 4.3.2.1.in-addr.arpa)
   log_queries:
     name: Log Queries

--- a/dnsmasq/translations/en.yaml
+++ b/dnsmasq/translations/en.yaml
@@ -19,11 +19,11 @@ configuration:
     name: Cnames
     description: Provide cname records for DNSMasq to resolve.
   txts:
-    name: TXT-records
+    name: TXT records
     description: Provide txt records for DNSMasq to resolve.
   ptrs:
-    name: PTR-records
-    description: For IP 1.2.3.4, specify 4.3.2.1.in-addr.arpa.
+    name: PTR records
+    description: Reversed IP address with ".in-addr.arpa" suffix (IP 1.2.3.4 → 4.3.2.1.in-addr.arpa)
   log_queries:
     name: Log Queries
     description: Log all DNS requests.

--- a/dnsmasq/translations/en.yaml
+++ b/dnsmasq/translations/en.yaml
@@ -23,7 +23,9 @@ configuration:
     description: Provide txt records for DNSMasq to resolve.
   ptrs:
     name: PTR records
-    description: Reversed IP address with ".in-addr.arpa" suffix (IP 1.2.3.4 → 4.3.2.1.in-addr.arpa)
+    description: >-
+      Reversed IP address with ".in-addr.arpa" suffix 
+      (IP 1.2.3.4 → 4.3.2.1.in-addr.arpa)
   log_queries:
     name: Log Queries
     description: Log all DNS requests.

--- a/dnsmasq/translations/en.yaml
+++ b/dnsmasq/translations/en.yaml
@@ -18,6 +18,12 @@ configuration:
   cnames:
     name: Cnames
     description: Provide cname records for DNSMasq to resolve.
+  txts:
+    name: TXT-records
+    description: Provide txt records for DNSMasq to resolve.
+  ptrs:
+    name: PTR-records
+    description: For IP 1.2.3.4, specify 4.3.2.1.in-addr.arpa.
   log_queries:
     name: Log Queries
     description: Log all DNS requests.


### PR DESCRIPTION
Extends schema in `config.yaml` to show options for TXT and PTR records.
Extends `dnsmasq.config` to format these two records in the way Dnsmasq expects.
Also updates `DOCS.md`, among others to show how to write the PTR record.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for TXT records — add DNS text records with name and value for custom responses.
  * Support for PTR records — add reverse-DNS entries by providing an IP and target name.

* **Configuration**
  * Configuration schema/version updated to include new txts and ptrs lists with validation.

* **Documentation**
  * Docs, UI translations, and changelog updated to describe formats, examples, and the new options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->