### PR TITLE
silabs-multiprotocol: disable build, remove unsupported architectures from config

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -42,6 +42,8 @@ jobs:
         run: |
           declare -a changed_addons
           for addon in ${{ steps.addons.outputs.addons }}; do
+            # Skip deprecated add-ons that should no longer be built
+            [[ "$addon" == "silabs-multiprotocol" ]] && continue
             if [[ "${{ steps.changed_files.outputs.all }}" =~ $addon ]]; then
               for file in ${{ env.MONITORED_FILES }}; do
                   if [[ "${{ steps.changed_files.outputs.all }}" =~ $addon/$file ]]; then

--- a/silabs-multiprotocol/README.md
+++ b/silabs-multiprotocol/README.md
@@ -7,7 +7,6 @@
 Zigbee/OpenThread Multiprotocol container for Silicon Labs based radios such as
 Home Assistant Yellow, Home Assistant SkyConnect, and Home Assistant Connect ZBT-1.
 
-![Supports armv7 Architecture][armv7-shield]
 ![Supports aarch64 Architecture][aarch64-shield]
 ![Supports amd64 Architecture][amd64-shield]
 
@@ -18,6 +17,5 @@ single Silicon Labs based radio. The radio needs the RCP Multi-PAN firmware
 installed to support multiple IEEE 802.15.4 Personal Area Networks (PAN). The
 addon has been tested with EFR32 Series 2 based radios.
 
-[armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg

--- a/silabs-multiprotocol/build.yaml
+++ b/silabs-multiprotocol/build.yaml
@@ -1,7 +1,6 @@
 ---
 build_from:
   aarch64: ghcr.io/home-assistant/aarch64-base-debian:bullseye
-  armv7: ghcr.io/home-assistant/armv7-base-debian:bullseye
   amd64: ghcr.io/home-assistant/amd64-base-debian:bullseye
 args:
   CPCD_VERSION: v4.3.1

--- a/silabs-multiprotocol/config.yaml
+++ b/silabs-multiprotocol/config.yaml
@@ -6,7 +6,6 @@ description: Zigbee and OpenThread multiprotocol add-on
 url: >
   https://github.com/home-assistant/addons/tree/master/silabs-multiprotocol
 arch:
-  - armv7
   - aarch64
   - amd64
 homeassistant: 2024.1.0


### PR DESCRIPTION
silabs-multiprotocol still contains armv7 in its build config. Remove it from there, while also adding an exclude condition to the workflow definition so it isn't re-built once the change is merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed `silabs-multiprotocol` add-on from automated build process
  * Removed armv7 architecture support from build configurations

* **Documentation**
  * Updated documentation to reflect removal of armv7 architecture support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->