### PR TITLE
duckdns: update base image to 3.23, drop unsupported architectures

### DIFF
--- a/duckdns/CHANGELOG.md
+++ b/duckdns/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.0.0
+
+- Remove unsupported architectures (armhf, armv7, i386)
+- Update to Alpine 3.23
+
 ## 1.26.0
 
 - Updated dehydrated fork with support for single-txt domains

--- a/duckdns/README.md
+++ b/duckdns/README.md
@@ -2,7 +2,7 @@
 
 Automatically update your Duck DNS IP address with integrated HTTPS support via Let's Encrypt.
 
-![Supports aarch64 Architecture][aarch64-shield] ![Supports amd64 Architecture][amd64-shield] ![Supports armhf Architecture][armhf-shield] ![Supports armv7 Architecture][armv7-shield] ![Supports i386 Architecture][i386-shield]
+![Supports aarch64 Architecture][aarch64-shield] ![Supports amd64 Architecture][amd64-shield]
 
 ## About
 
@@ -10,7 +10,4 @@ Automatically update your Duck DNS IP address with integrated HTTPS support via 
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
-[armhf-shield]: https://img.shields.io/badge/armhf-yes-green.svg
-[armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
-[i386-shield]: https://img.shields.io/badge/i386-yes-green.svg
 [duckdns]: https://www.duckdns.org

--- a/duckdns/build.yaml
+++ b/duckdns/build.yaml
@@ -1,9 +1,6 @@
 ---
 build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-base:3.20
-  amd64: ghcr.io/home-assistant/amd64-base:3.20
-  armhf: ghcr.io/home-assistant/armhf-base:3.20
-  armv7: ghcr.io/home-assistant/armv7-base:3.20
-  i386: ghcr.io/home-assistant/i386-base:3.20
+  aarch64: ghcr.io/home-assistant/aarch64-base:3.23
+  amd64: ghcr.io/home-assistant/amd64-base:3.23
 args:
   DEHYDRATED_VERSION: 0.8.0

--- a/duckdns/config.yaml
+++ b/duckdns/config.yaml
@@ -6,11 +6,8 @@ description: >-
   Free Dynamic DNS (DynDNS or DDNS) service with Let's Encrypt support
 url: https://github.com/home-assistant/addons/tree/master/duckdns
 arch:
-  - armhf
-  - armv7
   - aarch64
   - amd64
-  - i386
 hassio_api: true
 init: false
 image: homeassistant/{arch}-addon-duckdns

--- a/duckdns/config.yaml
+++ b/duckdns/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 1.26.0
+version: 2.0.0
 slug: duckdns
 name: Duck DNS
 description: >-


### PR DESCRIPTION
Update to latest Alpine from EOL version, remove unsupported architectures from build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Dropped support for armhf, armv7, and i386 architectures. Only aarch64 and amd64 are now supported.
* **Updates**
  * Base environment updated to Alpine 3.23.
* **Documentation**
  * Updated changelog and architecture support badges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->