### PR TITLE
vlc: update base image to 3.23, drop unsupported architectures

### DIFF
--- a/vlc/CHANGELOG.md
+++ b/vlc/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.0
+
+- Remove unsupported architectures (armv7, i386)
+- Update to Alpine 3.23
+
 ## 0.3.1
 
 - Restart VLC on Audio plug-in restart

--- a/vlc/README.md
+++ b/vlc/README.md
@@ -2,11 +2,8 @@
 
 Allow Home Assistant to use your local device as Media Player.
 
-![Supports aarch64 Architecture][aarch64-shield] ![Supports amd64 Architecture][amd64-shield] ![Supports armhf Architecture][armhf-shield] ![Supports armv7 Architecture][armv7-shield] ![Supports i386 Architecture][i386-shield]
+![Supports aarch64 Architecture][aarch64-shield] ![Supports amd64 Architecture][amd64-shield]
 
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
-[armhf-shield]: https://img.shields.io/badge/armhf-yes-green.svg
-[armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
-[i386-shield]: https://img.shields.io/badge/i386-yes-green.svg

--- a/vlc/build.yaml
+++ b/vlc/build.yaml
@@ -1,6 +1,4 @@
 ---
 build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-base:3.22
-  amd64: ghcr.io/home-assistant/amd64-base:3.22
-  armv7: ghcr.io/home-assistant/armv7-base:3.22
-  i386: ghcr.io/home-assistant/i386-base:3.22
+  aarch64: ghcr.io/home-assistant/aarch64-base:3.23
+  amd64: ghcr.io/home-assistant/amd64-base:3.23

--- a/vlc/config.yaml
+++ b/vlc/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.3.1
+version: 1.0.0
 slug: vlc
 name: VLC
 description: Turn your device into a Media Player with VLC

--- a/vlc/config.yaml
+++ b/vlc/config.yaml
@@ -5,10 +5,8 @@ name: VLC
 description: Turn your device into a Media Player with VLC
 url: https://github.com/home-assistant/addons/tree/master/vlc
 arch:
-  - amd64
-  - i386
-  - armv7
   - aarch64
+  - amd64
 audio: true
 discovery:
   - vlc_telnet


### PR DESCRIPTION
Update to latest Alpine, remove unsupported architectures from build. VLC version isn't changed by this update (only packaging update from `3.0.21-r7` to `3.0.21-r16 `).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Released version 1.0.0

* **Chores**
  * Removed support for armv7 and i386 architectures
  * Updated base image to Alpine 3.23
  * Updated documentation to reflect supported platforms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->