### PR TITLE
rpc_shutdown: update base image to 3.23, drop unsupported architectures

### DIFF
--- a/rpc_shutdown/CHANGELOG.md
+++ b/rpc_shutdown/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.0
+
+- Remove unsupported architectures (armhf, armv7, i386)
+- Update to Alpine 3.23 (updates samba to 4.22.8)
+
 ## 2.5
 
 - Update to Alpine 3.19

--- a/rpc_shutdown/README.md
+++ b/rpc_shutdown/README.md
@@ -2,7 +2,7 @@
 
 Shutdown Windows machines remotely.
 
-![Supports aarch64 Architecture][aarch64-shield] ![Supports amd64 Architecture][amd64-shield] ![Supports armhf Architecture][armhf-shield] ![Supports armv7 Architecture][armv7-shield] ![Supports i386 Architecture][i386-shield]
+![Supports aarch64 Architecture][aarch64-shield] ![Supports amd64 Architecture][amd64-shield]
 
 ## About
 
@@ -10,7 +10,4 @@ Allows you to shut down Windows Computers with a service call from Home Assistan
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
-[armhf-shield]: https://img.shields.io/badge/armhf-yes-green.svg
-[armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
-[i386-shield]: https://img.shields.io/badge/i386-yes-green.svg
 [discord]: https://www.home-assistant.io/join-chat

--- a/rpc_shutdown/build.yaml
+++ b/rpc_shutdown/build.yaml
@@ -1,7 +1,4 @@
 ---
 build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-base:3.19
-  amd64: ghcr.io/home-assistant/amd64-base:3.19
-  armhf: ghcr.io/home-assistant/armhf-base:3.19
-  armv7: ghcr.io/home-assistant/armv7-base:3.19
-  i386: ghcr.io/home-assistant/i386-base:3.19
+  aarch64: ghcr.io/home-assistant/aarch64-base:3.23
+  amd64: ghcr.io/home-assistant/amd64-base:3.23

--- a/rpc_shutdown/config.yaml
+++ b/rpc_shutdown/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: "2.5"
+version: "3.0"
 slug: rpc_shutdown
 name: RPC Shutdown
 description: Shutdown Windows machines remotely

--- a/rpc_shutdown/config.yaml
+++ b/rpc_shutdown/config.yaml
@@ -5,11 +5,8 @@ name: RPC Shutdown
 description: Shutdown Windows machines remotely
 url: https://github.com/home-assistant/addons/tree/master/rpc_shutdown
 arch:
-  - armhf
-  - armv7
   - aarch64
   - amd64
-  - i386
 host_network: true
 image: homeassistant/{arch}-addon-rpc_shutdown
 options:


### PR DESCRIPTION
Update to latest Alpine from EOL version, remove unsupported architectures from build. Base update pulls in samba `4.22.8-r0` to replace `4.18.9-r0` in version 2.5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated supported platforms to aarch64 and amd64.

* **Chores**
  * Version bumped to 3.0.
  * Removed support for armhf, armv7, and i386 architectures.
  * Upgraded base environment to Alpine 3.23.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->