### PR TITLE
mosquitto: bump components, remove unsupported archs

### DIFF
--- a/mosquitto/CHANGELOG.md
+++ b/mosquitto/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 7.0.0
+
+- Remove unsupported architectures (armhf, armv7, i386)
+- Update base image to Debian 13 (trixie)
+- Update mosquitto to 2.1.2, see [Mosquitto changelog](https://mosquitto.org/ChangeLog.txt) for the list of changes
+- Update libwebsockets to 4.5.8
+- Update mosquitto-go-auth to 3.0.0
+- Fix Home Assistant mqtt service (de)registration in init scripts
+
 ## 6.5.2
 
 - Update mosquitto to version 2.0.22

--- a/mosquitto/Dockerfile
+++ b/mosquitto/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update \
         libc-ares-dev \
         libcjson1 \
         libcjson-dev \
+        libsqlite3-dev \
         xsltproc \
         docbook-xsl \
         golang-go \
@@ -64,6 +65,7 @@ RUN apt-get update \
         libssl-dev \
         libc-ares-dev \
         libcjson-dev \
+        libsqlite3-dev \
         xsltproc \
         docbook-xsl \
         golang-go \

--- a/mosquitto/Dockerfile
+++ b/mosquitto/Dockerfile
@@ -43,6 +43,10 @@ RUN apt-get update \
        https://github.com/eclipse/mosquitto \
     \
     && cd mosquitto \
+    # Disable editline used by mosquitto_ctrl
+    && sed -i 's/^WITH_EDITLINE=yes/#WITH_EDITLINE=yes/' config.mk \
+    # Disable REST API
+    && sed -i 's/^WITH_HTTP_API=yes/#WITH_HTTP_API=yes/' config.mk \
     && make WITH_WEBSOCKETS=yes WITH_SRV=yes \
     && make install \
     && cd .. \

--- a/mosquitto/README.md
+++ b/mosquitto/README.md
@@ -2,7 +2,7 @@
 
 MQTT broker for Home Assistant.
 
-![Supports aarch64 Architecture][aarch64-shield] ![Supports amd64 Architecture][amd64-shield] ![Supports armhf Architecture][armhf-shield] ![Supports armv7 Architecture][armv7-shield] ![Supports i386 Architecture][i386-shield]
+![Supports aarch64 Architecture][aarch64-shield] ![Supports amd64 Architecture][amd64-shield]
 
 ## About
 
@@ -11,6 +11,4 @@ You can use this app (formerly known as add-on) to install Eclipse Mosquitto, wh
 [mosquitto]: https://mosquitto.org
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
-[armhf-shield]: https://img.shields.io/badge/armhf-yes-green.svg
-[armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
-[i386-shield]: https://img.shields.io/badge/i386-yes-green.svg
+

--- a/mosquitto/build.yaml
+++ b/mosquitto/build.yaml
@@ -3,6 +3,6 @@ build_from:
   aarch64: ghcr.io/home-assistant/aarch64-base-debian:trixie
   amd64: ghcr.io/home-assistant/amd64-base-debian:trixie
 args:
-  LIBWEBSOCKET_VERSION: 4.3.3
-  MOSQUITTO_VERSION: 2.0.22
-  MOSQUITTO_AUTH_VERSION: 2.1.0
+  LIBWEBSOCKET_VERSION: 4.5.8
+  MOSQUITTO_VERSION: 2.1.2
+  MOSQUITTO_AUTH_VERSION: 3.0.0

--- a/mosquitto/build.yaml
+++ b/mosquitto/build.yaml
@@ -1,10 +1,7 @@
 ---
 build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-base-debian:bookworm
-  amd64: ghcr.io/home-assistant/amd64-base-debian:bookworm
-  armhf: ghcr.io/home-assistant/armhf-base-debian:bookworm
-  armv7: ghcr.io/home-assistant/armv7-base-debian:bookworm
-  i386: ghcr.io/home-assistant/i386-base-debian:bookworm
+  aarch64: ghcr.io/home-assistant/aarch64-base-debian:trixie
+  amd64: ghcr.io/home-assistant/amd64-base-debian:trixie
 args:
   LIBWEBSOCKET_VERSION: 4.3.3
   MOSQUITTO_VERSION: 2.0.22

--- a/mosquitto/config.yaml
+++ b/mosquitto/config.yaml
@@ -5,11 +5,8 @@ name: Mosquitto broker
 description: An Open Source MQTT broker
 url: https://github.com/home-assistant/addons/tree/master/mosquitto
 arch:
-  - armhf
-  - armv7
   - aarch64
   - amd64
-  - i386
 auth_api: true
 discovery:
   - mqtt

--- a/mosquitto/config.yaml
+++ b/mosquitto/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 6.5.2
+version: 7.0.0
 slug: mosquitto
 name: Mosquitto broker
 description: An Open Source MQTT broker

--- a/mosquitto/rootfs/etc/services.d/mosquitto/discovery
+++ b/mosquitto/rootfs/etc/services.d/mosquitto/discovery
@@ -10,6 +10,17 @@ declare config
 declare discovery_password
 declare service_password
 
+function execute_without_error_messages() {
+    local current_log_level="${__BASHIO_LOG_LEVELS[${__BASHIO_LOG_LEVEL}]}"
+    bashio::log.level fatal
+    local exit_code=0
+    # shellcheck disable=SC2068
+    $@ || exit_code=$?
+    # shellcheck disable=SC2086
+    bashio::log.level ${current_log_level}
+    return ${exit_code}
+}
+
 # Wait for mosquitto to start before continuing
 bashio::net.wait_for 1883
 
@@ -43,6 +54,9 @@ config=$(bashio::var.json \
     username "addons" \
     password "${service_password}" \
 )
+
+# Remove any stale MQTT service registration left behind by a previous run.
+execute_without_error_messages bashio::services.delete "mqtt" || true
 
 # Send service info
 if bashio::services.publish "mqtt" "${config}" > /dev/null 2>&1; then

--- a/mosquitto/rootfs/etc/services.d/mosquitto/finish
+++ b/mosquitto/rootfs/etc/services.d/mosquitto/finish
@@ -5,11 +5,11 @@
 # s6-overlay docs: https://github.com/just-containers/s6-overlay
 # ==============================================================================
 
+bashio::services.delete "mqtt" || true
+
 if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
-  bashio::log.warning "Halt add-on"
-  bashio::services.delete "mqtt" || true
+  bashio::log.warning "Halt app"
   exec /run/s6/basedir/bin/halt
 fi
 
-bashio::services.delete "mqtt" || true
 bashio::log.info "Service restart after closing"

--- a/mosquitto/rootfs/etc/services.d/mosquitto/finish
+++ b/mosquitto/rootfs/etc/services.d/mosquitto/finish
@@ -1,4 +1,4 @@
-#!/usr/bin/env bashio
+#!/usr/bin/with-contenv bashio
 # vim: ft=bash
 # ==============================================================================
 # Take down the S6 supervision tree when service fails
@@ -7,7 +7,9 @@
 
 if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
   bashio::log.warning "Halt add-on"
+  bashio::services.delete "mqtt" || true
   exec /run/s6/basedir/bin/halt
 fi
 
+bashio::services.delete "mqtt" || true
 bashio::log.info "Service restart after closing"

--- a/mosquitto/rootfs/etc/services.d/nginx/finish
+++ b/mosquitto/rootfs/etc/services.d/nginx/finish
@@ -6,7 +6,7 @@
 # ==============================================================================
 
 if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
-  bashio::log.warning "Halt add-on"
+  bashio::log.warning "Halt app"
   exec /run/s6/basedir/bin/halt
 fi
 

--- a/mosquitto/rootfs/usr/share/tempio/mosquitto.gtpl
+++ b/mosquitto/rootfs/usr/share/tempio/mosquitto.gtpl
@@ -1,4 +1,3 @@
-protocol mqtt
 user root
 log_dest stdout
 {{ if .debug }}


### PR DESCRIPTION
- Remove unsupported architectures (armhf, armv7, i386)
- Update base image to Debian 13 (trixie)
- Update mosquitto to 2.1.2, see [Mosquitto changelog](https://mosquitto.org/ChangeLog.txt) for the list of changes
- Update libwebsockets to 4.5.8
- Update mosquitto-go-auth to 3.0.0
- Fix Home Assistant mqtt service (de)registration in init scripts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Home Assistant MQTT service registration/deregistration

* **Chores**
  * Bumped add-on to 7.0.0
  * Removed support for armhf, armv7, and i386 (retaining aarch64 and amd64)
  * Base image updated to Debian 13 (trixie)
  * Updated core components: mosquitto → 2.1.2, libwebsockets → 4.5.8, mosquitto-go-auth → 3.0.0
  * Disabled embedded HTTP API and interactive editline support in the build
<!-- end of auto-generated comment: release notes by coderabbit.ai -->