### PR TITLE
cec_scan: update base image, update libCEC, drop unsupported architectures

### DIFF
--- a/cec_scan/CHANGELOG.md
+++ b/cec_scan/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 4.0
+
+- Remove unsupported architectures (armhf, armv7, i386)
+- Update to Alpine 3.23
+- Update libCEC to 7.1.1
+
 ## 3.0
 
 - Using the Upstream Linux support only

--- a/cec_scan/README.md
+++ b/cec_scan/README.md
@@ -2,13 +2,11 @@
 
 Scan & discover HDMI CEC devices and their addresses.
 
-![Supports aarch64 Architecture][aarch64-shield] ![Supports amd64 Architecture][amd64-shield] ![Supports armhf Architecture][armhf-shield] ![Supports armv7 Architecture][armv7-shield] ![Supports i386 Architecture][i386-shield]
+![Supports aarch64 Architecture][aarch64-shield] ![Supports amd64 Architecture][amd64-shield]
 
 This app (formerly known as add-on) allows for scanning for CEC devices. It is useful for finding
 the CEC address of your devices.
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
-[armhf-shield]: https://img.shields.io/badge/armhf-yes-green.svg
-[armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
-[i386-shield]: https://img.shields.io/badge/i386-yes-green.svg
+

--- a/cec_scan/build.yaml
+++ b/cec_scan/build.yaml
@@ -1,9 +1,6 @@
 ---
 build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-base:3.14
-  amd64: ghcr.io/home-assistant/amd64-base:3.14
-  armhf: ghcr.io/home-assistant/armhf-base:3.14
-  armv7: ghcr.io/home-assistant/armv7-base:3.14
-  i386: ghcr.io/home-assistant/i386-base:3.14
+  aarch64: ghcr.io/home-assistant/aarch64-base:3.23
+  amd64: ghcr.io/home-assistant/amd64-base:3.23
 args:
-  LIBCEC_VERSION: 6.0.2
+  LIBCEC_VERSION: 7.1.1

--- a/cec_scan/config.yaml
+++ b/cec_scan/config.yaml
@@ -1,14 +1,11 @@
 ---
-version: "3.0"
+version: "4.0"
 slug: cec_scan
 name: CEC Scanner
 url: https://github.com/home-assistant/addons/tree/master/cec_scan
 arch:
-  - armhf
-  - armv7
   - aarch64
   - amd64
-  - i386
 boot: manual
 description: Scan for HDMI CEC devices
 image: homeassistant/{arch}-addon-cec_scan


### PR DESCRIPTION
- Remove unsupported architectures (armhf, armv7, i386)
- Update to Alpine 3.23
- Update libCEC to 7.1.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to reflect architecture support changes.

* **Chores**
  * Removed support for armhf, armv7, and i386 architectures; now supports aarch64 and amd64 only.
  * Updated libCEC to 7.1.1 and Alpine Linux to 3.23.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->