### PR TITLE
mosquitto: disable auth_plugin_deny_special_chars to allow '/' in client ids (#4564)

### DIFF
--- a/mosquitto/CHANGELOG.md
+++ b/mosquitto/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 7.0.1
+
+- Fix regression where clients with `/` in their client id (e.g. `govee2mqtt`) were rejected with "ACL denying access to client with dangerous client id" after the mosquitto 2.1 upgrade ([#4564](https://github.com/home-assistant/addons/issues/4564))
+
 ## 7.0.0
 
 - Remove unsupported architectures (armhf, armv7, i386)

--- a/mosquitto/config.yaml
+++ b/mosquitto/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 7.0.0
+version: 7.0.1
 slug: mosquitto
 name: Mosquitto broker
 description: An Open Source MQTT broker

--- a/mosquitto/rootfs/usr/share/tempio/mosquitto.gtpl
+++ b/mosquitto/rootfs/usr/share/tempio/mosquitto.gtpl
@@ -20,6 +20,10 @@ max_queued_messages 8192
 
 # Authentication plugin
 auth_plugin /usr/share/mosquitto/go-auth.so
+# Restore pre-7.0 behaviour: allow '/' in client ids and usernames.
+# The addon's ACL file does not use pattern substitution (%c/%u), so
+# mosquitto 2.1's broker-side rejection of +, #, / is not needed here.
+auth_plugin_deny_special_chars false
 auth_opt_backends files,http
 auth_opt_hasher pbkdf2
 auth_opt_cache true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed regression where clients whose IDs contain forward slashes (e.g., `govee2mqtt`) were incorrectly rejected with "ACL denying access to client with dangerous client id" error following the Mosquitto 2.1 upgrade.
  * Restored support for special characters in client IDs and usernames with authentication plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->