### PR TITLE
Bump Z-Wave JS UI to 11.16.0

### DIFF
--- a/zwave_js/CHANGELOG.md
+++ b/zwave_js/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 1.2.0
+
+This release corrects the Z-Wave logfile path to be consistent with the defaults used by Z-Wave JS UI.
+
+### Z-Wave JS 15.23.0
+
+#### Bugfixes
+
+- Fixed an issue where Z-Wave.me UZB controllers could hang during NVM backup
+
+#### Config file changes
+
+- Add configuration for Inovelli VZW30-SN
+- Improve configuration files for Inovelli VZW30-SN, VZW31-SN, and VZW32-SN
+- Standardize **Control Associated Device** triggers across 7x series Zooz switches
+
+### Detailed changelogs
+
+- [Z-Wave JS 15.23.0](https://github.com/zwave-js/zwave-js/releases/tag/v15.23.0)
+
 ## 1.1.0
 
 This release includes an improvement to how Window/Door sensors are represented. Previously exposed as several binary sensors, which did not all work for all devices, they are now exposed as a single **Opening state** sensor with three states: Closed/Open/Tilted. The Tilted state is only exposed after a device has reported this.

--- a/zwave_js/build.yaml
+++ b/zwave_js/build.yaml
@@ -3,4 +3,4 @@ build_from:
   aarch64: ghcr.io/home-assistant/aarch64-base:3.23
   amd64: ghcr.io/home-assistant/amd64-base:3.23
 args:
-  ZWAVEJS_UI_VERSION: 11.15.1
+  ZWAVEJS_UI_VERSION: 11.16.0

--- a/zwave_js/config.yaml
+++ b/zwave_js/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 1.1.0
+version: 1.2.0
 slug: zwave_js
 name: Z-Wave JS
 description: Control a Z-Wave network with Home Assistant Z-Wave JS

--- a/zwave_js/rootfs/usr/share/tempio/zwave_config.conf
+++ b/zwave_js/rootfs/usr/share/tempio/zwave_config.conf
@@ -3,7 +3,7 @@
     "logLevel": "{{ .log_level }}",
     "logToFile": {{ .log_to_file }},
     "maxFiles": {{ .log_max_files }},
-    "logFilename": "/config/zwave",
+    "logFilename": "/config/logs/zwavejs",
     "forceConsole": true,
     "rf": {{ .rf_json }},
     "storage": {


### PR DESCRIPTION
Built and tested locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed UZB controllers hanging during NVM backup.

* **Updates**
  * Upgraded Z-Wave JS UI to version 11.16.0.
  * Added support for Inovelli VZW30-SN and improved configurations for multiple Inovelli and Zooz Z-Wave switches.
  * Updated logging output path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->