### PR TITLE
mariadb: update base image (incl. mariadb upgrade), remove unsupported archs

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,6 @@ about developing an app, please see our
 
 [discord]: https://www.home-assistant.io/join-chat
 [forum]: https://community.home-assistant.io
-[i386-shield]: https://img.shields.io/badge/i386-no-red.svg
 [issue]: https://github.com/home-assistant/addons/issues
 [reddit]: https://reddit.com/r/homeassistant
 [dev-docs]: https://developers.home-assistant.io/docs/add-ons/

--- a/mariadb/CHANGELOG.md
+++ b/mariadb/CHANGELOG.md
@@ -2,8 +2,13 @@
 
 ## 3.0.0
 
+**Note:** This update upgrades MariaDB from 10.11 to 11.4. The database
+migration will be performed automatically on the first startup after the
+app is updated. Make a backup of the MariaDB app before installing this
+update.
+
 - Remove unsupported architectures (armhf, armv7, i386)
-- Update to Alpine 3.23
+- Update to Alpine 3.23 (updates MariaDB 10.11.6 to 11.4.9)
 
 ## 2.7.2
 

--- a/mariadb/CHANGELOG.md
+++ b/mariadb/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.0.0
+
+- Remove unsupported architectures (armhf, armv7, i386)
+- Update to Alpine 3.23
+
 ## 2.7.2
 
 - Add option to configure MariaDB server parameters (see also [home-assistant/addons#3754](https://github.com/home-assistant/addons/issues/3754))

--- a/mariadb/README.md
+++ b/mariadb/README.md
@@ -2,7 +2,7 @@
 
 MariaDB database for Home Assistant.
 
-![Supports aarch64 Architecture][aarch64-shield] ![Supports amd64 Architecture][amd64-shield] ![Supports armhf Architecture][armhf-shield] ![Supports armv7 Architecture][armv7-shield] ![Supports i386 Architecture][i386-shield]
+![Supports aarch64 Architecture][aarch64-shield] ![Supports amd64 Architecture][amd64-shield]
 
 ## About
 
@@ -10,7 +10,4 @@ You can use this app (formerly known as add-on) to install MariaDB, which is an 
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
-[armhf-shield]: https://img.shields.io/badge/armhf-yes-green.svg
-[armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
 [mariadb]: https://mariadb.com
-[i386-shield]: https://img.shields.io/badge/i386-yes-green.svg

--- a/mariadb/build.yaml
+++ b/mariadb/build.yaml
@@ -1,7 +1,4 @@
 ---
 build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-base:3.19
-  amd64: ghcr.io/home-assistant/amd64-base:3.19
-  armhf: ghcr.io/home-assistant/armhf-base:3.19
-  armv7: ghcr.io/home-assistant/armv7-base:3.19
-  i386: ghcr.io/home-assistant/i386-base:3.19
+  aarch64: ghcr.io/home-assistant/aarch64-base:3.23
+  amd64: ghcr.io/home-assistant/amd64-base:3.23

--- a/mariadb/config.yaml
+++ b/mariadb/config.yaml
@@ -1,5 +1,6 @@
 ---
 version: 3.0.0
+breaking_versions: [3.0.0]
 slug: mariadb
 name: MariaDB
 description: A SQL database server

--- a/mariadb/config.yaml
+++ b/mariadb/config.yaml
@@ -5,11 +5,8 @@ name: MariaDB
 description: A SQL database server
 url: https://github.com/home-assistant/addons/tree/master/mariadb
 arch:
-  - armhf
-  - armv7
   - aarch64
   - amd64
-  - i386
 backup_post: unlock-tables-for-backup
 backup_pre: lock-tables-for-backup
 image: homeassistant/{arch}-addon-mariadb

--- a/mariadb/config.yaml
+++ b/mariadb/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 2.7.2
+version: 3.0.0
 slug: mariadb
 name: MariaDB
 description: A SQL database server

--- a/mariadb/rootfs/etc/s6-overlay/s6-rc.d/mariadb-core/run
+++ b/mariadb/rootfs/etc/s6-overlay/s6-rc.d/mariadb-core/run
@@ -16,7 +16,7 @@ fi
 mkdir -p /run/mysqld
 
 if [ -z "${extra_args+x}" ] || [ ${#extra_args[@]} -eq 0 ]; then
-  exec mysqld --datadir="${MARIADB_DATA}" --user=root < /dev/null
+  exec mariadbd --datadir="${MARIADB_DATA}" --user=root < /dev/null
 else
-  exec mysqld --datadir="${MARIADB_DATA}" --user=root "${extra_args[@]}" < /dev/null
+  exec mariadbd --datadir="${MARIADB_DATA}" --user=root "${extra_args[@]}" < /dev/null
 fi

--- a/mariadb/rootfs/etc/s6-overlay/s6-rc.d/mariadb-lock-core/run
+++ b/mariadb/rootfs/etc/s6-overlay/s6-rc.d/mariadb-lock-core/run
@@ -8,7 +8,7 @@
 bashio::log.info "Start MariaDB client (to lock tables for backups)"
 
 # File descriptor &4 is used as stdin for mysql, because &0 is closed after the mariadb-lock-core service is started
-exec 4> >(mysql)
+exec 4> >(mariadb)
 
 # We need to delay the starting of the dependent services until mysql is started
 echo "" >&3

--- a/mariadb/rootfs/etc/s6-overlay/s6-rc.d/mariadb-post/run
+++ b/mariadb/rootfs/etc/s6-overlay/s6-rc.d/mariadb-post/run
@@ -17,7 +17,7 @@ function execute_without_error_messages() {
 }
 
 # Wait until DB is running
-while ! mysql -e "" 2> /dev/null; do
+while ! mariadb -e "" 2> /dev/null; do
     sleep 1
 done
 bashio::log.info "MariaDB started"
@@ -26,18 +26,18 @@ bashio::log.info "MariaDB started"
 execute_without_error_messages bashio::services.delete "mysql" || true
 
 bashio::log.info "Check data integrity and fix corruptions"
-mysqlcheck --no-defaults --databases mysql --fix-db-names --fix-table-names || true
-mysqlcheck --no-defaults --databases mysql --check --check-upgrade --auto-repair || true
-mysqlcheck --no-defaults --all-databases --skip-database=mysql --fix-db-names --fix-table-names || true
-mysqlcheck --no-defaults --all-databases --skip-database=mysql --check --check-upgrade --auto-repair || true
+mariadb-check --no-defaults --databases mysql --fix-db-names --fix-table-names || true
+mariadb-check --no-defaults --databases mysql --check --check-upgrade --auto-repair || true
+mariadb-check --no-defaults --all-databases --skip-database=mysql --fix-db-names --fix-table-names || true
+mariadb-check --no-defaults --all-databases --skip-database=mysql --check --check-upgrade --auto-repair || true
 
 bashio::log.info "Ensuring internal database upgrades are performed"
-mysql_upgrade --silent
+mariadb-upgrade --silent
 
 # Set default secure values after initial setup
 if bashio::var.true "${NEW_INSTALL}"; then
     # Secure the installation.
-    mysql <<-EOSQL
+    mariadb <<-EOSQL
         SET @@SESSION.SQL_LOG_BIN=0;
         DELETE FROM
             mysql.user
@@ -58,7 +58,7 @@ fi
 bashio::log.info "Ensure databases exists"
 for database in $(bashio::config "databases"); do
     bashio::log.info "Create database ${database}"
-    mysql -e "CREATE DATABASE ${database};" 2> /dev/null || true
+    mariadb -e "CREATE DATABASE ${database};" 2> /dev/null || true
 done
 
 # Init logins
@@ -67,11 +67,11 @@ for login in $(bashio::config "logins|keys"); do
     USERNAME=$(bashio::config "logins[${login}].username")
     PASSWORD=$(bashio::config "logins[${login}].password")
 
-    if mysql -e "SET PASSWORD FOR '${USERNAME}'@'%' = PASSWORD('${PASSWORD}');" 2> /dev/null; then
+    if mariadb -e "SET PASSWORD FOR '${USERNAME}'@'%' = PASSWORD('${PASSWORD}');" 2> /dev/null; then
         bashio::log.info "Update user ${USERNAME}"
     else
         bashio::log.info "Create user ${USERNAME}"
-        mysql -e "CREATE USER '${USERNAME}'@'%' IDENTIFIED BY '${PASSWORD}';" 2> /dev/null || true
+        mariadb -e "CREATE USER '${USERNAME}'@'%' IDENTIFIED BY '${PASSWORD}';" 2> /dev/null || true
     fi
 done
 
@@ -84,11 +84,11 @@ for right in $(bashio::config "rights|keys"); do
     if bashio::config.exists "rights[${right}].privileges"; then
         PRIVILEGES=$(bashio::config "rights[${right}].privileges")
         bashio::log.info "Granting ${PRIVILEGES} to ${USERNAME} on ${DATABASE}"
-        mysql -e "REVOKE ALL PRIVILEGES ON ${DATABASE}.* FROM '${USERNAME}'@'%';" || true
-        mysql -e "GRANT ${PRIVILEGES} ON ${DATABASE}.* TO '${USERNAME}'@'%';" || true
+        mariadb -e "REVOKE ALL PRIVILEGES ON ${DATABASE}.* FROM '${USERNAME}'@'%';" || true
+        mariadb -e "GRANT ${PRIVILEGES} ON ${DATABASE}.* TO '${USERNAME}'@'%';" || true
     else
         bashio::log.info "Granting all privileges to ${USERNAME} on ${DATABASE}"
-        mysql -e "GRANT ALL PRIVILEGES ON ${DATABASE}.* TO '${USERNAME}'@'%';" 2> /dev/null || true
+        mariadb -e "GRANT ALL PRIVILEGES ON ${DATABASE}.* TO '${USERNAME}'@'%';" 2> /dev/null || true
     fi
 done
 
@@ -97,13 +97,13 @@ if ! bashio::fs.file_exists "/data/secret"; then
     pwgen 64 1 > /data/secret
 fi
 SECRET=$(</data/secret)
-mysql -e "CREATE USER 'service'@'172.30.32.%' IDENTIFIED BY '${SECRET}';" 2> /dev/null || true
-mysql -e "CREATE USER 'service'@'172.30.33.%' IDENTIFIED BY '${SECRET}';" 2> /dev/null || true
-mysql -e "GRANT ALL PRIVILEGES ON *.* TO 'service'@'172.30.32.%' WITH GRANT OPTION;" 2> /dev/null || true
-mysql -e "GRANT ALL PRIVILEGES ON *.* TO 'service'@'172.30.33.%' WITH GRANT OPTION;" 2> /dev/null || true
+mariadb -e "CREATE USER 'service'@'172.30.32.%' IDENTIFIED BY '${SECRET}';" 2> /dev/null || true
+mariadb -e "CREATE USER 'service'@'172.30.33.%' IDENTIFIED BY '${SECRET}';" 2> /dev/null || true
+mariadb -e "GRANT ALL PRIVILEGES ON *.* TO 'service'@'172.30.32.%' WITH GRANT OPTION;" 2> /dev/null || true
+mariadb -e "GRANT ALL PRIVILEGES ON *.* TO 'service'@'172.30.33.%' WITH GRANT OPTION;" 2> /dev/null || true
 
 # Flush privileges
-mysql -e "FLUSH PRIVILEGES;" 2> /dev/null || true
+mariadb -e "FLUSH PRIVILEGES;" 2> /dev/null || true
 
 # Send service information to the Supervisor
 PAYLOAD=$(\

--- a/mariadb/rootfs/etc/s6-overlay/s6-rc.d/mariadb-post/run
+++ b/mariadb/rootfs/etc/s6-overlay/s6-rc.d/mariadb-post/run
@@ -5,17 +5,6 @@
 # Post-start initialization of MariaDB service
 # ==============================================================================
 
-function execute_without_error_messages() {
-    local current_log_level="${__BASHIO_LOG_LEVELS[${__BASHIO_LOG_LEVEL}]}"
-    bashio::log.level fatal
-    local exit_code=0
-    # shellcheck disable=SC2068
-    $@ || exit_code=$?
-    # shellcheck disable=SC2086
-    bashio::log.level ${current_log_level}
-    return ${exit_code}
-}
-
 # Wait until DB is running
 while ! mariadb -e "" 2> /dev/null; do
     sleep 1
@@ -23,7 +12,8 @@ done
 bashio::log.info "MariaDB started"
 
 # Delete service information, just in case the previous instance somehow did not cleanup
-execute_without_error_messages bashio::services.delete "mysql" || true
+# Note: you can't redirect LOG_FD without eval
+eval "bashio::services.delete mysql &> /dev/null ${LOG_FD}> /dev/null" || true
 
 bashio::log.info "Check data integrity and fix corruptions"
 mariadb-check --no-defaults --databases mysql --fix-db-names --fix-table-names || true

--- a/mariadb/rootfs/etc/s6-overlay/s6-rc.d/mariadb-pre/run
+++ b/mariadb/rootfs/etc/s6-overlay/s6-rc.d/mariadb-pre/run
@@ -23,7 +23,7 @@ ln -s /proc/1/fd/1 "${MARIADB_DATA}/mariadb.err"
 # Init mariadb
 if bashio::var.true "${NEW_INSTALL}"; then
     bashio::log.info "Create a new mariadb"
-    mysql_install_db --user=root --datadir="${MARIADB_DATA}" --skip-name-resolve --skip-test-db > /dev/null
+    mariadb-install-db --user=root --datadir="${MARIADB_DATA}" --skip-name-resolve --skip-test-db > /dev/null
 else
     bashio::log.info "Using existing mariadb"
 fi


### PR DESCRIPTION
- Remove unsupported architectures (armhf, armv7, i386)
- Update to Alpine 3.23 (updates MariaDB 10.11.6 to 11.4.9)

Marked as breaking version to avoid automatic updates, as `mariadb-upgrade` will be performed on the next startup and it's advised to make a backup before doing that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded MariaDB from 10.11.6 to 11.4.9
  * Updated base image to Alpine 3.23
  * Removed support for armhf, armv7, and i386 (aarch64 and amd64 remain)
  * Bumped add-on to version 3.0.0 and marked as a breaking release

* **Documentation**
  * Added changelog note: automatic database migration occurs on first startup after update; backup recommended
  * Updated architecture badges and README links to reflect supported platforms
<!-- end of auto-generated comment: release notes by coderabbit.ai -->