### PR TITLE
mosquitto: ensure custom config takes precedence over defaults

### DIFF
--- a/mosquitto/rootfs/usr/share/tempio/mosquitto.gtpl
+++ b/mosquitto/rootfs/usr/share/tempio/mosquitto.gtpl
@@ -1,4 +1,7 @@
 user root
+{{ if .customize }}
+include_dir /share/{{ .customize_folder }}
+{{ else }}
 log_dest stdout
 {{ if .debug }}
 log_type all
@@ -7,6 +10,7 @@ log_type error
 log_type warning
 log_type notice
 log_type information
+{{ end }}
 {{ end }}
 log_timestamp_format %Y-%m-%d %H:%M:%S
 persistence true
@@ -43,10 +47,6 @@ auth_opt_http_port 80
 auth_opt_http_getuser_uri /authentication
 auth_opt_http_superuser_uri /superuser
 auth_opt_http_aclcheck_uri /acl
-
-{{ if .customize }}
-include_dir /share/{{ .customize_folder }}
-{{ end }}
 
 listener 1883
 protocol mqtt


### PR DESCRIPTION
## Problem

When users configure a custom config file (`/share/mosquitto/mosquitto.conf`), settings are silently ignored. For example, setting `log_dest topic` and `log_type debug` has no effect and all output still goes to the add-on log.

Upstream issue: https://github.com/home-assistant/addons/issues/4531

## Root cause

The cause is that `log_dest` and `log_type` directives in Mosquitto's config parser are accumulated additively using bitwise OR. Once `log_dest stdout` is set in the default config, no subsequent directive can remove it. The user's custom settings are simply added on top, never replacing the defaults.

The problem cannot be solved by reordering directives in the config file, because once a `log_dest` bit is set it cannot be unset by any subsequent directive. The fix must be applied in `mosquitto.gtpl`: when `customize` is active, the default `log_dest` and `log_type` directives are never used.

## Fix

When `customize` is active, skip the entire `log_dest stdout` and `log_type` block in `mosquitto.gtpl` and load `include_dir` instead. The user's custom config then becomes the sole source of logging configuration. When `customize` is not active, behaviour is identical to today.

## Effect on users

Users can now control logging fully via `/share/mosquitto/mosquitto.conf`. Two verified examples:

Log everything to file, including `MOSQ_LOG_DEBUG` and `MOSQ_LOG_INTERNAL`:

```
#
# Log to file
#
log_dest file /share/mosquitto/mosquitto.log
log_type all
log_timestamp true
log_timestamp_format [%H:%M:%S]
```

Log to topic. Note: `MOSQ_LOG_DEBUG` and `MOSQ_LOG_INTERNAL` are excluded by Mosquitto at the source level ([src/logging.c line 388](https://github.com/eclipse-mosquitto/mosquitto/blob/master/src/logging.c#L388)):

```
#
# Log to topic
# Note: excludes MOSQ_LOG_DEBUG & MOSQ_LOG_INTERNAL.
#
log_dest topic
log_type all
log_timestamp true
log_timestamp_format [%H:%M:%S]
```

## Risk

When `customize` is not active, behaviour is completely unchanged. When `customize` is active, `log_dest stdout` is no longer set by default, meaning the add-on log will be silent unless the user's custom config explicitly sets a `log_dest`. This is intentional and expected — the user has opted in to full control by enabling `customize`. Users who enable `customize` without configuring any `log_dest` will see no log output, which is consistent with how Mosquitto behaves when no logging is configured.

## Changed file

`mosquitto/rootfs/usr/share/tempio/mosquitto.gtpl`

## Deep analysis

Examination of [`src/conf.c`](https://github.com/eclipse-mosquitto/mosquitto/blob/master/src/conf.c) shows that each `log_dest` line is OR-combined into a bitmask using `|=`:

```c
cr->log_dest |= MQTT3_LOG_STDOUT;
cr->log_dest |= MQTT3_LOG_TOPIC;
cr->log_dest |= MQTT3_LOG_FILE;
```

Once a destination bit is set, it cannot be unset by a subsequent `log_dest` line. The only escape is `log_dest none` which resets the entire bitmask. This means that even if `include_dir` were moved to the very end of the generated config, the `log_dest stdout` set in the first line of the template would remain permanently active in the final bitmask — making a position change alone insufficient to fix the problem.

The same additive behaviour applies to `log_type`.

At the end of `config__read()` the accumulated value is applied once:

```c
if(cr.log_dest_set){
    config->log_dest = cr.log_dest;
}
```

There is no mechanism for a later config line to remove an earlier destination.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized configuration template structure for improved clarity. Customization folder includes and debug logging directives are now conditionally placed based on configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->