### PR TITLE
mariadb: fix GRANT syntax for multiple `rights.privileges`

### DIFF
--- a/mariadb/CHANGELOG.md
+++ b/mariadb/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.0.1
+
+- Fix GRANT statement generation for multiple `privileges`
+
 ## 3.0.0
 
 **Note:** This update upgrades MariaDB from 10.11 to 11.4. The database

--- a/mariadb/config.yaml
+++ b/mariadb/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 3.0.0
+version: 3.0.1
 breaking_versions: [3.0.0]
 slug: mariadb
 name: MariaDB

--- a/mariadb/rootfs/etc/s6-overlay/s6-rc.d/mariadb-post/run
+++ b/mariadb/rootfs/etc/s6-overlay/s6-rc.d/mariadb-post/run
@@ -72,7 +72,7 @@ for right in $(bashio::config "rights|keys"); do
     DATABASE=$(bashio::config "rights[${right}].database")
 
     if bashio::config.exists "rights[${right}].privileges"; then
-        PRIVILEGES=$(bashio::config "rights[${right}].privileges")
+        PRIVILEGES=$(bashio::config "rights[${right}].privileges | (if type == \"array\" then join(\", \") else . end)")
         bashio::log.info "Granting ${PRIVILEGES} to ${USERNAME} on ${DATABASE}"
         mariadb -e "REVOKE ALL PRIVILEGES ON ${DATABASE}.* FROM '${USERNAME}'@'%';" || true
         mariadb -e "GRANT ${PRIVILEGES} ON ${DATABASE}.* TO '${USERNAME}'@'%';" || true


### PR DESCRIPTION
The `privileges` option only worked for a single or no (= all) privilege, otherwise the option was serialized into list delimited by newlines, resulting in invalid syntax error. Since errors for this command are ignored, this mistake went unnoticed. With this change the config should be serialized into a correct SQL.

Fixes #4577

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed MariaDB GRANT statement generation when handling multiple privileges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->