### PR TITLE
silabs_flasher: update flasher and base image/remove archs

### DIFF
--- a/silabs_flasher/CHANGELOG.md
+++ b/silabs_flasher/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.5.0
+
+- Detect Home Assistant Yellow correctly on latest HAOS versions
+- Add additional log messages for download and flashing
+- Update universal-silabs-flasher to 0.0.37
+- Upgrade to Alpine 3.23
+- Remove unsupported architectures (armhf, armv7, i386)
+
 ## 0.4.0
 
 - Upgrade to Alpine 3.22

--- a/silabs_flasher/README.md
+++ b/silabs_flasher/README.md
@@ -11,9 +11,6 @@ Multiprotocol app.
 
 ![Supports aarch64 Architecture][aarch64-shield]
 ![Supports amd64 Architecture][amd64-shield]
-![Supports armhf Architecture][armhf-shield]
-![Supports armv7 Architecture][armv7-shield]
-![Supports i386 Architecture][i386-shield]
 
 ## About
 
@@ -23,6 +20,3 @@ Home Assistant Yellow to flash Zigbee.
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
-[armhf-shield]: https://img.shields.io/badge/armhf-yes-green.svg
-[armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
-[i386-shield]: https://img.shields.io/badge/i386-yes-green.svg

--- a/silabs_flasher/build.yaml
+++ b/silabs_flasher/build.yaml
@@ -1,9 +1,6 @@
 ---
 build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-base-python:3.13-alpine3.22
-  amd64: ghcr.io/home-assistant/amd64-base-python:3.13-alpine3.22
-  armhf: ghcr.io/home-assistant/armhf-base-python:3.13-alpine3.22
-  armv7: ghcr.io/home-assistant/armv7-base-python:3.13-alpine3.22
-  i386: ghcr.io/home-assistant/i386-base-python:3.13-alpine3.22
+  aarch64: ghcr.io/home-assistant/aarch64-base-python:3.13-alpine3.23
+  amd64: ghcr.io/home-assistant/amd64-base-python:3.13-alpine3.23
 args:
-  UNIVERSAL_SILABS_FLASHER: 0.0.36
+  UNIVERSAL_SILABS_FLASHER: 0.0.37

--- a/silabs_flasher/config.yaml
+++ b/silabs_flasher/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.4.0
+version: 0.5.0
 slug: silabs_flasher
 name: Silicon Labs Flasher
 description: Silicon Labs firmware flasher add-on
@@ -8,9 +8,6 @@ url: >
 arch:
   - aarch64
   - amd64
-  - armhf
-  - armv7
-  - i386
 gpio: true
 hassio_api: true
 image: homeassistant/{arch}-addon-silabs-flasher

--- a/silabs_flasher/rootfs/etc/s6-overlay/scripts/universal-silabs-flasher-up
+++ b/silabs_flasher/rootfs/etc/s6-overlay/scripts/universal-silabs-flasher-up
@@ -12,6 +12,7 @@ declare autoflash_firmware
 declare device
 declare bootloader_baudrate
 declare firmware
+declare firmware_url
 declare verbose
 declare usb_device_path
 declare usb_manufacturer
@@ -43,7 +44,9 @@ function is_home_assistant_yellow {
     # Check the known paths for Home Assistant Yellow
     local paths=(
         "/sys/devices/platform/soc/fe201800.serial/tty/ttyAMA1"
+        "/sys/devices/platform/soc/fe201800.serial/fe201800.serial:0/fe201800.serial:0.0/tty/ttyAMA1"
         "/sys/devices/platform/axi/1000120000.pcie/1f0003c000.serial/tty/ttyAMA1"
+        "/sys/devices/platform/axi/1000120000.pcie/1f0003c000.serial/1f0003c000.serial:0/1f0003c000.serial:0.0/tty/ttyAMA1"
     )
     for path in "${paths[@]}"; do
         if [ -d "${path}" ]; then
@@ -64,7 +67,9 @@ else
 fi
 
 if bashio::config.has_value 'firmware_url'; then
-    curl --silent -L -o "/root/firmware.gbl" "$(bashio::config 'firmware_url')"
+    firmware_url="$(bashio::config 'firmware_url')"
+    bashio::log.info "Downloading firmware from ${firmware_url}"
+    curl --silent -L -o "/root/firmware.gbl" "${firmware_url}"
     if [ ! -f "/root/firmware.gbl" ]; then
         bashio::log.warning "Downloading firmware failed"
         exit 0
@@ -124,3 +129,4 @@ universal-silabs-flasher \
     "${ezsp_baudrate_arg[@]}" \
     ${gpio_reset_flag} \
     flash --force --firmware "/root/${firmware}"
+bashio::log.info "Flashing completed successfully"


### PR DESCRIPTION
Update the universal silabs flasher to 0.0.37. This is the last version which supports the old CLI arguments. Moving to newer version will require a bigger rework of the app, along with removing (and potentially adding) options.

Update the Yellow detection to work with the latest HAOS versions.

Update Alpine base image to 3.23 with Python 3.13. Also remove unsupported architectures (i386/armhf/armv7).

Note: Since the current app is still used by Home Assistant Core (multiprotocol migration logic), I'd prefer to keep the changes minimal for now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes: Version 0.5.0

* **New Features**
  * Improved detection for Home Assistant Yellow on latest HAOS versions.
  * Enhanced logging for download and flashing operations.

* **Chores**
  * Updated universal-silabs-flasher dependency.
  * Upgraded base environment to Alpine 3.23.
  * Removed support for armhf, armv7, and i386 architectures; now supporting aarch64 and amd64 only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->