### PR TITLE
mosquitto: add log_type and log_dest options

### DIFF
--- a/mosquitto/CHANGELOG.md
+++ b/mosquitto/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 7.1.0
+
+- Add `log_dest` and `log_type` configuration options
+
 ## 7.0.1
 
 - Fix regression where clients with `/` in their client id (e.g. `govee2mqtt`) were rejected with "ACL denying access to client with dangerous client id" after the mosquitto 2.1 upgrade ([#4564](https://github.com/home-assistant/addons/issues/4564))

--- a/mosquitto/DOCS.md
+++ b/mosquitto/DOCS.md
@@ -36,6 +36,8 @@ App configuration:
 
 ```yaml
 logins: []
+log_dest: []
+log_type: []
 customize:
   active: false
   folder: mosquitto
@@ -67,6 +69,26 @@ logins:
     password: "PBKDF2$sha512$100000$qsU7xQ8YCV/9nRuBBJVTxA==$jqw94Ej3aEr97UofY6rClmVCRkTdDiubQW0A6ZYmUI+pZjW9Hax+2w2FeYB3y5ut1SliB7+HAwIl2iONLKkohw=="
     password_pre_hashed: true
 ```
+
+### Option: `log_dest` (optional)
+
+A list of Mosquitto logging destinations.
+
+Allowed values: `none`, `stdout`, `stderr`, `syslog`, `topic`
+
+If left empty, the default is `stdout`.
+
+**Note:** `file` is not available via this option - if needed, use `none` combined with `customize` options.
+
+### Option: `log_type` (optional)
+
+A list of Mosquitto logging types.
+
+Allowed values: `none`, `debug`, `error`, `warning`, `notice`, `information`, `subscribe`, `unsubscribe`, `websockets`, `all`
+
+If left empty, defaults to `error`, `warning`, `notice`, and `information`.
+
+If `debug` is enabled, the option is ignored and `log_type all` is used.
 
 **Note:** This app does not support anonymous logins; all connections must use a username/password to connect. `allow_anonymous true` nor any anonymous ACLs will not work with this app.
 

--- a/mosquitto/DOCS.md
+++ b/mosquitto/DOCS.md
@@ -74,7 +74,7 @@ logins:
 
 A list of Mosquitto logging destinations.
 
-Allowed values: `none`, `stdout`, `stderr`, `syslog`, `topic`
+Allowed values: `none`, `stdout`, `stderr`, `topic`
 
 If left empty, the default is `stdout`.
 

--- a/mosquitto/config.yaml
+++ b/mosquitto/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 7.0.1
+version: 7.1.0
 slug: mosquitto
 name: Mosquitto broker
 description: An Open Source MQTT broker
@@ -16,6 +16,8 @@ map:
   - share
 options:
   logins: []
+  log_dest: []
+  log_type: []
   require_certificate: false
   certfile: fullchain.pem
   keyfile: privkey.pem
@@ -32,6 +34,10 @@ schema:
     - username: str
       password: password
       password_pre_hashed: "bool?"
+  log_dest:
+    - list(none|stdout|stderr|topic)?
+  log_type:
+    - list(none|debug|error|warning|notice|information|subscribe|unsubscribe|websockets|all)?
   require_certificate: bool
   certfile: str
   cafile: str?

--- a/mosquitto/rootfs/etc/cont-init.d/mosquitto.sh
+++ b/mosquitto/rootfs/etc/cont-init.d/mosquitto.sh
@@ -10,6 +10,8 @@ declare cafile
 declare certfile
 declare discovery_password
 declare keyfile
+declare log_dest
+declare log_type
 declare password
 declare service_password
 declare ssl
@@ -76,6 +78,11 @@ else
   ssl="false"
 fi
 
+# Get log options as raw JSON types for tempio
+options=$(bashio::addon.config)
+log_dest=$(jq -c ".log_dest" <<<"$options")
+log_type=$(jq -c ".log_type" <<<"$options")
+
 # Generate mosquitto configuration.
 bashio::var.json \
   cafile "${cafile}" \
@@ -83,6 +90,8 @@ bashio::var.json \
   customize "^$(bashio::config 'customize.active')" \
   customize_folder "$(bashio::config 'customize.folder')" \
   keyfile "${keyfile}" \
+  log_dest "^${log_dest}" \
+  log_type "^${log_type}" \
   require_certificate "^$(bashio::config 'require_certificate')" \
   ssl "^${ssl}" \
   debug "^$(bashio::config 'debug')" \

--- a/mosquitto/rootfs/etc/services.d/mosquitto/discovery
+++ b/mosquitto/rootfs/etc/services.d/mosquitto/discovery
@@ -10,17 +10,6 @@ declare config
 declare discovery_password
 declare service_password
 
-function execute_without_error_messages() {
-    local current_log_level="${__BASHIO_LOG_LEVELS[${__BASHIO_LOG_LEVEL}]}"
-    bashio::log.level fatal
-    local exit_code=0
-    # shellcheck disable=SC2068
-    $@ || exit_code=$?
-    # shellcheck disable=SC2086
-    bashio::log.level ${current_log_level}
-    return ${exit_code}
-}
-
 # Wait for mosquitto to start before continuing
 bashio::net.wait_for 1883
 
@@ -56,7 +45,8 @@ config=$(bashio::var.json \
 )
 
 # Remove any stale MQTT service registration left behind by a previous run.
-execute_without_error_messages bashio::services.delete "mqtt" || true
+# Note: you can't redirect LOG_FD without eval
+eval "bashio::services.delete mqtt &> /dev/null ${LOG_FD}> /dev/null" || true
 
 # Send service info
 if bashio::services.publish "mqtt" "${config}" > /dev/null 2>&1; then

--- a/mosquitto/rootfs/usr/share/tempio/mosquitto.gtpl
+++ b/mosquitto/rootfs/usr/share/tempio/mosquitto.gtpl
@@ -1,7 +1,16 @@
 user root
+{{ if .log_dest }}
+# custom log_dest
+{{ range .log_dest }}log_dest {{ . }}
+{{ end }}
+{{ else }}
 log_dest stdout
+{{ end }}
 {{ if .debug }}
 log_type all
+{{ else if .log_type }}
+{{ range .log_type }}log_type {{ . }}
+{{ end }}
 {{ else }}
 log_type error
 log_type warning

--- a/mosquitto/translations/en.yaml
+++ b/mosquitto/translations/en.yaml
@@ -12,14 +12,13 @@ configuration:
     name: Log Destinations
     description: >-
       Optional list of Mosquitto log destinations. Allowed values are `none`,
-      `stdout`, `stderr`, `syslog`, and `topic`. If empty, defaults to
-      `stdout`.
+      `stdout`, `stderr` and `topic`. If empty, defaults to `stdout`.
   log_type:
     name: Log Types
     description: >-
       Optional list of Mosquitto log types. If empty, defaults to `error`,
       `warning`, `notice`, and `information`. Ignored and defaults to `all`
-      when Debug is enabled).
+      when Debug is enabled.
   require_certificate:
     name: Require Client Certificate
     description: >-

--- a/mosquitto/translations/en.yaml
+++ b/mosquitto/translations/en.yaml
@@ -8,6 +8,18 @@ configuration:
       without any configuration. You can also specify
       `password_pre_hashed: true` to utilize a pre-hashed password from the
       output of the `pw` command (which is present inside the container).
+  log_dest:
+    name: Log Destinations
+    description: >-
+      Optional list of Mosquitto log destinations. Allowed values are `none`,
+      `stdout`, `stderr`, `syslog`, and `topic`. If empty, defaults to
+      `stdout`.
+  log_type:
+    name: Log Types
+    description: >-
+      Optional list of Mosquitto log types. If empty, defaults to `error`,
+      `warning`, `notice`, and `information`. Ignored and defaults to `all`
+      when Debug is enabled).
   require_certificate:
     name: Require Client Certificate
     description: >-


### PR DESCRIPTION
Since log_type and log_dest options can be combined and are defined before the custom config include, it's not possible to fully customize them. Add app configuration options that allows to override the previously hardcoded default.

Closes #4531, closes #4574

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added log_dest (none, stdout, stderr, topic) and log_type (none, debug, error, warning, notice, information, subscribe, unsubscribe, websockets, all). Debug forces full logging; defaults apply when lists are empty.

* **Documentation**
  * Docs and UI text updated with new options, behavior notes, and example configuration.

* **Chore**
  * Add-on version bumped to 7.1.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->