### PR TITLE
openthread_border_router: customize mDNS hostname in beta mode

### DIFF
--- a/openthread_border_router/CHANGELOG.md
+++ b/openthread_border_router/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.16.8
 
-- Use regular hostname with "-br" suffix in beta mode to make OTBR recognizable
+- Use regular hostname with "-otbr" suffix in beta mode to make OTBR recognizable
 
 ## 2.16.7
 

--- a/openthread_border_router/CHANGELOG.md
+++ b/openthread_border_router/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.16.8
+
+- Use regular hostname with "-br" suffix in beta mode to make OTBR recognizable
+
 ## 2.16.7
 
 - Print a warning if IPv6 routing is not enabled

--- a/openthread_border_router/config.yaml
+++ b/openthread_border_router/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 2.16.7
+version: 2.16.8
 slug: openthread_border_router
 name: OpenThread Border Router
 description: OpenThread Border Router add-on

--- a/openthread_border_router/openthread-core-ha-config-posix.h
+++ b/openthread_border_router/openthread-core-ha-config-posix.h
@@ -73,4 +73,14 @@
  */
 #define OPENTHREAD_CONFIG_BORDER_AGENT_MESHCOP_SERVICE_BASE_NAME "Home Assistant OpenThread Border Router "
 
+/**
+ * @def OPENTHREAD_CONFIG_MULTICAST_DNS_AUTO_ENABLE_ON_INFRA_IF
+ *
+ * Define to 1 for mDNS module to be automatically enabled/disabled on the same infra-if used for border routing
+ * based on infra-if state.
+ *
+ * Set to 0 so the app can customize the mDNS hostname before starting in our startup script.
+ */
+#define OPENTHREAD_CONFIG_MULTICAST_DNS_AUTO_ENABLE_ON_INFRA_IF 0
+
 #endif /* OPENTHREAD_CORE_HA_CONFIG_POSIX_H_ */

--- a/openthread_border_router/rootfs/etc/s6-overlay/scripts/otbr-agent-configure.sh
+++ b/openthread_border_router/rootfs/etc/s6-overlay/scripts/otbr-agent-configure.sh
@@ -12,6 +12,13 @@ if bashio::config.true 'nat64'; then
     ot-ctl dns server upstream enable
 fi
 
+if bashio::config.true 'beta'; then
+    mdns_localhostname="$(hostname)-br"
+    bashio::log.info "Setting OpenThread mDNS local hostname to ${mdns_localhostname}."
+    ot-ctl mdns localhostname "${mdns_localhostname}"
+    ot-ctl mdns enable
+fi
+
 # To avoid asymmetric link quality the TX power from the controller should not
 # exceed that of what other Thread routers devices typically use.
 ot-ctl txpower 6

--- a/openthread_border_router/rootfs/etc/s6-overlay/scripts/otbr-agent-configure.sh
+++ b/openthread_border_router/rootfs/etc/s6-overlay/scripts/otbr-agent-configure.sh
@@ -13,7 +13,7 @@ if bashio::config.true 'nat64'; then
 fi
 
 if bashio::config.true 'beta'; then
-    mdns_localhostname="$(hostname)-br"
+    mdns_localhostname="$(hostname)-otbr"
     bashio::log.info "Setting OpenThread mDNS local hostname to ${mdns_localhostname}."
     ot-ctl mdns localhostname "${mdns_localhostname}"
     ot-ctl mdns enable


### PR DESCRIPTION
Set the OpenThread built-in mDNS local hostname to "<hostname>-br" so the border router is recognizable on the network. Disable the auto- enable on infra-if so the startup script can set the hostname before mDNS is brought up (avoids announcing as `ot<extmac>.local` just before switching to our custom hostname). Drop the unused mdnsresponder s6 service in beta mode so no supervisor is spawned for it.

The `-br` suffix avoids any unwanted conflicts with other mDNS responder running on the same system.

Fixes: #4383

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Beta mode now appends a "-otbr" suffix to the system hostname for OpenThread Border Router discovery.
  * Added a toggle to control automatic mDNS enablement on the infrastructure interface.

* **Chores**
  * Bumped release to version 2.16.8 and added a changelog entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->