### PR TITLE
Clarify using the latest voices with Wyoming Piper

### DIFF
--- a/piper/DOCS.md
+++ b/piper/DOCS.md
@@ -27,7 +27,8 @@ for more information.
 [Listen to voice samples](https://rhasspy.github.io/piper-samples/)
 
 Name of the Piper voice to use, such as `en_US-lessac-medium` (the default).
-Voice models are automatically downloaded from https://huggingface.co/rhasspy/piper-voices/tree/v1.0.0
+Voice models are automatically downloaded from <https://huggingface.co/rhasspy/piper-voices/tree/main>.
+To use the latest voices, you may need to use the `update_voices` option.
 
 Voices are named according to the following scheme: `<language>_<REGION>-<name>-<quality>`
 The `<name>` portion comes from the dataset used to train the voice or the speaker's name if it was provided.


### PR DESCRIPTION
The Wyoming Piper code fetches from the main Huggingface "branch", not
v1.0.0. Though in order to use newly available voices, one might need to
update the voices list - clarify this in the docs.

SEE: https://github.com/rhasspy/wyoming-piper/issues/49


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated voice model setup guidance to reference the latest available voices from the rolling main branch.
  * Added note about using the `update_voices` option to fetch the most recent voice models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->