### PR TITLE
Harden workflows based on Zizmor check results

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,4 +6,6 @@ updates:
     schedule:
       interval: weekly
       time: "06:00"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 10

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -12,6 +12,9 @@ on:
   push:
     branches: ["master"]
 
+permissions:
+  contents: read
+
 jobs:
   init:
     runs-on: ubuntu-latest
@@ -22,11 +25,13 @@ jobs:
       changed: ${{ steps.changed_addons.outputs.changed }}
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Get changed files
         id: changed_files
-        uses: masesgroup/retrieve-changed-files@v4.0.0
+        uses: masesgroup/retrieve-changed-files@45a8b3b496d2d6037cbd553e8a3450989b9384a2 # v4.0.0
 
       - name: Get apps
         id: addons
@@ -39,14 +44,17 @@ jobs:
 
       - name: Get changed apps
         id: changed_addons
+        env:
+          ADDONS: ${{ steps.addons.outputs.addons }}
+          CHANGED_FILES: ${{ steps.changed_files.outputs.all }}
         run: |
           declare -a changed_addons
-          for addon in ${{ steps.addons.outputs.addons }}; do
+          for addon in ${ADDONS}; do
             # Skip deprecated add-ons that should no longer be built
             [[ "$addon" == "silabs-multiprotocol" ]] && continue
-            if [[ "${{ steps.changed_files.outputs.all }}" =~ $addon ]]; then
+            if [[ "${CHANGED_FILES}" =~ $addon ]]; then
               for file in ${{ env.MONITORED_FILES }}; do
-                  if [[ "${{ steps.changed_files.outputs.all }}" =~ $addon/$file ]]; then
+                  if [[ "${CHANGED_FILES}" =~ $addon/$file ]]; then
                     if [[ ! "${changed_addons[@]}" =~ $addon ]]; then
                       changed_addons+=("\"${addon}\",");
                     fi
@@ -80,40 +88,43 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Get information
         id: info
-        uses: home-assistant/actions/helpers/info@master
+        uses: home-assistant/actions/helpers/info@master # zizmor: ignore[unpinned-uses] master
         with:
           path: "./${{ matrix.addon }}"
 
       - name: Check app
         id: check
+        env:
+          ADDON: ${{ matrix.addon }}
+          ARCH: ${{ matrix.arch }}
+          ARCHITECTURES: ${{ steps.info.outputs.architectures }}
         run: |
-          if [[ "${{ steps.info.outputs.architectures }}" =~ ${{ matrix.arch }} ]]; then
-             echo "build_arch=true" >> "$GITHUB_OUTPUT";
-           else
-             echo "${{ matrix.arch }} is not a valid arch for ${{ matrix.addon }}, skipping build";
+          if [[ "${ARCHITECTURES}" =~ ${ARCH} ]]; then
+            echo "build_arch=true" >> "$GITHUB_OUTPUT";
+          else
+            echo "${ARCH} is not a valid arch for ${ADDON}, skipping build";
           fi
 
       - name: Set build arguments
-        if: steps.check.outputs.build_arch == 'true'
-        run: |
-          if [[ -z "${{ github.head_ref }}" ]] && [[ "${{ github.event_name }}" == "push" ]]; then
-              echo "BUILD_ARGS=--docker-hub-check" >> $GITHUB_ENV;
-          fi
+        if: steps.check.outputs.build_arch == 'true' && github.head_ref == '' && github.event_name == 'push'
+        run: echo "BUILD_ARGS=--docker-hub-check" >> "$GITHUB_ENV"
 
       - name: Login to DockerHub
         if: env.BUILD_ARGS == '--docker-hub-check'
-        uses: docker/login-action@v4.1.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build ${{ matrix.addon }} app
         if: steps.check.outputs.build_arch == 'true'
-        uses: home-assistant/builder@2026.02.1
+        uses: home-assistant/builder@6cb4fd3d1338b6e22d0958a4bcb53e0965ea63b4 # 2026.02.1
         with:
           image: ${{ matrix.arch }}
           args: |

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Get information
         id: info
-        uses: home-assistant/actions/helpers/info@master # zizmor: ignore[unpinned-uses] master
+        uses: home-assistant/actions/helpers/info@master # zizmor: ignore[unpinned-uses]
         with:
           path: "./${{ matrix.addon }}"
 

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -1,5 +1,5 @@
 ---
-# yamllint disable rule:line-length rule:truthy
+# yamllint disable rule:comments rule:line-length rule:truthy
 name: Build app
 
 env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,5 @@
 ---
-# yamllint disable rule:truthy
+# yamllint disable rule:comments rule:line-length rule:truthy
 name: Lint
 
 env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,13 +11,18 @@ on:
   push:
     branches: ["master"]
 
+permissions:
+  contents: read
+
 jobs:
   hadolint:
     runs-on: ubuntu-latest
     name: hadolint
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Run linter
         id: changed_files
@@ -35,20 +40,24 @@ jobs:
     name: YAMLLint
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Run YAMLLint
-        uses: frenck/action-yamllint@v1.5
+        uses: frenck/action-yamllint@34b4bbcaeabedcfefad6adea8c5bbc42af0e2d47 # v1.5
 
   shellcheck:
     runs-on: ubuntu-latest
     name: ShellCheck
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Run linter
-        uses: ludeeus/action-shellcheck@2.0.0
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0
         env:
           SHELLCHECK_OPTS: -e SC1008 -s bash -x
         with:

--- a/.github/workflows/restrict-task-creation.yml
+++ b/.github/workflows/restrict-task-creation.yml
@@ -6,6 +6,9 @@ on:
   issues:
     types: [opened]
 
+permissions:
+  issues: write
+
 jobs:
   check-authorization:
     runs-on: ubuntu-latest
@@ -13,7 +16,7 @@ jobs:
     if: github.event.issue.type.name == 'Task'
     steps:
       - name: Check if user is authorized
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const issueAuthor = context.payload.issue.user.login;

--- a/.github/workflows/restrict-task-creation.yml
+++ b/.github/workflows/restrict-task-creation.yml
@@ -1,7 +1,7 @@
 ---
+# yamllint disable rule:comments rule:line-length rule:truthy
 name: Restrict task creation
 
-# yamllint disable-line rule:truthy
 on:
   issues:
     types: [opened]

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,12 +7,15 @@ on:
     - cron: "0 * * * *"
   workflow_dispatch:
 
+permissions:
+  issues: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
       - name: 30 days stale issues
-        uses: actions/stale@v10.2.0
+        uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-issue-stale: 30

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,5 +1,5 @@
 ---
-# yamllint disable rule:truthy
+# yamllint disable rule:comments rule:truthy
 name: Stale
 
 on:


### PR DESCRIPTION
Make Zizmor happy by addressing all unpinned actions and potential injections. Dependabot cooldown uses the default of 7 days, this can be lowered later along with added custom Zizmor config.

Refs home-assistant/epics#29

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned GitHub Actions to specific commits across workflows for greater consistency and security.
  * Added explicit workflow permission declarations to limit access (contents read, issues write where applicable).
  * Configured Dependabot with a 7-day cooldown between update attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->