### PR TITLE
Remove old architecture shields

### DIFF
--- a/assist_microphone/README.md
+++ b/assist_microphone/README.md
@@ -8,6 +8,3 @@ Part of the [Year of Voice](https://www.home-assistant.io/blog/2022/12/20/year-o
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
-[armhf-shield]: https://img.shields.io/badge/armhf-no-red.svg
-[armv7-shield]: https://img.shields.io/badge/armv7-no-red.svg
-[i386-shield]: https://img.shields.io/badge/i386-no-red.svg

--- a/configurator/README.md
+++ b/configurator/README.md
@@ -2,7 +2,7 @@
 
 Browser-based configuration file editor for Home Assistant.
 
-![Supports aarch64 Architecture][aarch64-shield] ![Supports amd64 Architecture][amd64-shield] ![Supports armhf Architecture][armhf-shield] ![Supports armv7 Architecture][armv7-shield] ![Supports i386 Architecture][i386-shield]
+![Supports aarch64 Architecture][aarch64-shield] ![Supports amd64 Architecture][amd64-shield]
 
 ![Configurator in the Home Assistant Frontend][screenshot]
 
@@ -32,7 +32,4 @@ configuration files) will be automatically checked for syntax errors while editi
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
-[armhf-shield]: https://img.shields.io/badge/armhf-yes-green.svg
-[armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
-[i386-shield]: https://img.shields.io/badge/i386-yes-green.svg
 [screenshot]: https://github.com/home-assistant/hassio-addons/raw/master/configurator/images/screenshot.png

--- a/mariadb/DOCS.md
+++ b/mariadb/DOCS.md
@@ -112,7 +112,6 @@ In case you've found a bug, please [open an issue on our GitHub][issue].
 [mariadb-ha-recorder]: https://www.home-assistant.io/integrations/recorder/
 [discord]: https://www.home-assistant.io/join-chat
 [forum]: https://community.home-assistant.io
-[i386-shield]: https://img.shields.io/badge/i386-yes-green.svg
 [issue]: https://github.com/home-assistant/addons/issues
 [reddit]: https://reddit.com/r/homeassistant
 [repository]: https://github.com/hassio-addons/repository

--- a/piper/README.md
+++ b/piper/README.md
@@ -8,6 +8,3 @@ Part of the [Year of Voice](https://www.home-assistant.io/blog/2022/12/20/year-o
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
-[armhf-shield]: https://img.shields.io/badge/armhf-no-red.svg
-[armv7-shield]: https://img.shields.io/badge/armv7-no-red.svg
-[i386-shield]: https://img.shields.io/badge/i386-no-red.svg

--- a/speech_to_phrase/README.md
+++ b/speech_to_phrase/README.md
@@ -13,6 +13,3 @@ Requires Home Assistant 2023.11 or later.
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
-[armv7-shield]: https://img.shields.io/badge/armv7-no-red.svg
-[armhf-shield]: https://img.shields.io/badge/armhf-no-red.svg
-[i386-shield]: https://img.shields.io/badge/i386-no-red.svg


### PR DESCRIPTION
Several README.md files still had architecture shields in their references list or even in actual text part (configurator). Drop all references for this already unsupported architectures from README.md files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Removed legacy architecture badges (armhf, armv7, i386) from assist_microphone, configurator, piper, and speech_to_phrase docs; mariadb docs no longer show the i386 badge.
  * Updated visible shields to show aarch64 and amd64 where applicable, clarifying supported architectures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->