### PR TITLE
mariadb: Properly close s6 notification file descriptors

### DIFF
--- a/mariadb/rootfs/etc/s6-overlay/s6-rc.d/mariadb-lock-core/run
+++ b/mariadb/rootfs/etc/s6-overlay/s6-rc.d/mariadb-lock-core/run
@@ -12,4 +12,5 @@ exec 4> >(mariadb)
 
 # We need to delay the starting of the dependent services until mysql is started
 echo "" >&3
+exec 3>&-
 wait


### PR DESCRIPTION
Note: Marking it as draft, becasue it can be merged later when a new version is released, this PR is just a minor refactor, doesn't worth a release.

s6 docs says: "daemons can simply write a line to a file descriptor of their choice, **then close that file descriptor**" https://skarnet.org/software/s6/notifywhenup.html

Checked the whole repo, no similar issues elsewhere (OTBR apps use ./data/check scripts)