### PR TITLE
nginx: Update SSL configuration and add PQC key exchange

### DIFF
--- a/nginx_proxy/CHANGELOG.md
+++ b/nginx_proxy/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.2.0
+
+- update SSL/TLS configuration and add PQC key exchange following Mozilla guidelines
+
 ## 4.1.0
 
 - add use_ssl_backend option to support cases where the http section is using the ssl_certificate, ssl_key options

--- a/nginx_proxy/config.yaml
+++ b/nginx_proxy/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 4.1.0
+version: 4.2.0
 hassio_api: true
 slug: nginx_proxy
 name: NGINX Home Assistant SSL proxy

--- a/nginx_proxy/rootfs/etc/nginx/nginx.conf.gtpl
+++ b/nginx_proxy/rootfs/etc/nginx/nginx.conf.gtpl
@@ -25,8 +25,8 @@ http {
     # intermediate configuration
     # https://ssl-config.mozilla.org/#server=nginx&version=1.28.0&config=intermediate&openssl=3.5.0
     ssl_protocols TLSv1.2 TLSv1.3;
-    ssl_ecdh_curve X25519:prime256v1:secp384r1;
-    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305;
+    ssl_ecdh_curve X25519MLKEM768:X25519:prime256v1:secp384r1;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305;
     ssl_prefer_server_ciphers off;
 
     {{- if .options.cloudflare }}

--- a/nginx_proxy/rootfs/etc/nginx/nginx.conf.gtpl
+++ b/nginx_proxy/rootfs/etc/nginx/nginx.conf.gtpl
@@ -23,7 +23,7 @@ http {
     server_names_hash_bucket_size 128;
 
     # intermediate configuration
-    # https://ssl-config.mozilla.org/#server=nginx&version=1.28.0&config=intermediate&openssl=3.5.0
+    # https://ssl-config.mozilla.org/#server=nginx&version=1.28.3&config=intermediate&openssl=3.5.6
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_ecdh_curve X25519MLKEM768:X25519:prime256v1:secp384r1;
     ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305;


### PR DESCRIPTION
Updated SSL configuration following Mozilla guidelines. 

- Add Post-Quantum Cryptography (PQC) key exchange
- Remove classic Diffie-Hellman Ephemeral (DHE) ciphersuites for TLS 1.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated nginx proxy SSL/TLS configuration to follow newer recommendations, refining enabled key exchange curves and cipher suites.
  * Bumped add-on manifest version to 4.2.0.

* **Documentation**
  * Added changelog entry noting the TLS configuration and post-quantum key-exchange update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->