### PR TITLE
matter_server: add ble_proxy option

### DIFF
--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 8.5.0
 
-- Add `ble_proxy` option to expose the Matter Server's BLE proxy endpoint, so the Home Assistant Matter integration can drive BLE commissioning through Home Assistant's bluetooth stack (including ESPHome BLE proxies). Requires Home Assistant 2026.06 or later and the Beta Matter Server (>= 0.7.1, JavaScript-based); mutually exclusive with `bluetooth_adapter_id` (the local adapter is ignored with a warning when `ble_proxy` is enabled).
+- Add `ble_proxy` option to expose the Matter Server's BLE proxy endpoint, so the Home Assistant Matter integration can drive BLE commissioning through Home Assistant's bluetooth stack (including ESPHome BLE proxies). To actually use this BLE proxy you need Home Assistant 2026.06 or later (the Matter integration support landed there) and the Beta Matter Server (>= 0.7.1, JavaScript-based); mutually exclusive with `bluetooth_adapter_id` (the local adapter is ignored with a warning when `ble_proxy` is enabled).
 
 ## 8.4.0
 

--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 8.5.0
+
+- Add `ble_proxy` option to expose the Matter Server's BLE proxy endpoint, so the Home Assistant Matter integration can drive BLE commissioning through Home Assistant's bluetooth stack (including ESPHome BLE proxies). Only available with the Beta Matter Server (>= 0.7.1, JavaScript-based) and mutually exclusive with `bluetooth_adapter_id`.
+
 ## 8.4.0
 
 - Skip `--log-level-sdk` for JavaScript Matter Server (beta mode); it is now only passed to the Python server

--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 8.5.0
 
-- Add `ble_proxy` option to expose the Matter Server's BLE proxy endpoint, so the Home Assistant Matter integration can drive BLE commissioning through Home Assistant's bluetooth stack (including ESPHome BLE proxies). Only available with the Beta Matter Server (>= 0.7.1, JavaScript-based) and mutually exclusive with `bluetooth_adapter_id`.
+- Add `ble_proxy` option to expose the Matter Server's BLE proxy endpoint, so the Home Assistant Matter integration can drive BLE commissioning through Home Assistant's bluetooth stack (including ESPHome BLE proxies). Requires Home Assistant 2026.06 or later and the Beta Matter Server (>= 0.7.1, JavaScript-based); mutually exclusive with `bluetooth_adapter_id` (the local adapter is ignored with a warning when `ble_proxy` is enabled).
 
 ## 8.4.0
 

--- a/matter_server/config.yaml
+++ b/matter_server/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 8.4.0
+version: 8.5.0
 slug: matter_server
 name: Matter Server
 description: Matter WebSocket Server for Home Assistant Matter support.

--- a/matter_server/config.yaml
+++ b/matter_server/config.yaml
@@ -33,6 +33,7 @@ schema:
   log_level_sdk: list(automation|detail|progress|error|none)?
   beta: bool?
   enable_test_net_dcl: bool?
+  ble_proxy: bool?
   bluetooth_adapter_id: int?
   matter_server_args:
     - str?

--- a/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
+++ b/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
@@ -138,9 +138,10 @@ fi
 
 if bashio::config.true "ble_proxy"; then
     extra_args+=('--ble-proxy')
-fi
-
-if bashio::config.has_value "bluetooth_adapter_id"; then
+    if bashio::config.has_value "bluetooth_adapter_id"; then
+        bashio::log.warning "Ignoring 'bluetooth_adapter_id' option: 'ble_proxy' is enabled (mutually exclusive)."
+    fi
+elif bashio::config.has_value "bluetooth_adapter_id"; then
   # shellcheck disable=SC2207
   extra_args+=('--bluetooth-adapter' $(bashio::config 'bluetooth_adapter_id'))
 fi

--- a/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
+++ b/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
@@ -136,6 +136,10 @@ if [ -z ${primary_interface} ] || [ ${primary_interface} == "null" ]; then
     bashio::exit.nok "No primary network interface found!"
 fi
 
+if bashio::config.true "ble_proxy"; then
+    extra_args+=('--ble-proxy')
+fi
+
 if bashio::config.has_value "bluetooth_adapter_id"; then
   # shellcheck disable=SC2207
   extra_args+=('--bluetooth-adapter' $(bashio::config 'bluetooth_adapter_id'))

--- a/matter_server/translations/en.yaml
+++ b/matter_server/translations/en.yaml
@@ -31,9 +31,10 @@ configuration:
     description: >-
       Expose the Matter Server's BLE proxy endpoint so the Home Assistant
       Matter integration can drive BLE commissioning through Home Assistant's
-      own bluetooth stack (including ESPHome BLE proxies). Only available with
-      the Beta Matter Server (>= 0.7.1, JavaScript-based). Mutually exclusive
-      with the local `Bluetooth Adapter ID` option.
+      own bluetooth stack (including ESPHome BLE proxies). Requires Home
+      Assistant 2026.06 or later and the Beta Matter Server (>= 0.7.1,
+      JavaScript-based). Mutually exclusive with `Bluetooth Adapter ID` —
+      the local adapter option is ignored with a warning when this is on.
   matter_server_env_vars:
     name: Matter Server environment variables
     description: >-

--- a/matter_server/translations/en.yaml
+++ b/matter_server/translations/en.yaml
@@ -31,10 +31,12 @@ configuration:
     description: >-
       Expose the Matter Server's BLE proxy endpoint so the Home Assistant
       Matter integration can drive BLE commissioning through Home Assistant's
-      own bluetooth stack (including ESPHome BLE proxies). Requires Home
-      Assistant 2026.06 or later and the Beta Matter Server (>= 0.7.1,
-      JavaScript-based). Mutually exclusive with `Bluetooth Adapter ID` —
-      the local adapter option is ignored with a warning when this is on.
+      own bluetooth stack (including ESPHome BLE proxies). To actually use
+      the BLE proxy you need Home Assistant 2026.06 or later (where the
+      Matter integration's proxy support landed) and the Beta Matter Server
+      (>= 0.7.1, JavaScript-based). Mutually exclusive with `Bluetooth
+      Adapter ID` — the local adapter option is ignored with a warning when
+      this is on.
   matter_server_env_vars:
     name: Matter Server environment variables
     description: >-

--- a/matter_server/translations/en.yaml
+++ b/matter_server/translations/en.yaml
@@ -26,6 +26,14 @@ configuration:
       Home Assistant Companion app commissioning method is recommended as it is
       better tested and allows to commission directly in proximity of the
       device itself.
+  ble_proxy:
+    name: Enable BLE proxy
+    description: >-
+      Expose the Matter Server's BLE proxy endpoint so the Home Assistant
+      Matter integration can drive BLE commissioning through Home Assistant's
+      own bluetooth stack (including ESPHome BLE proxies). Only available with
+      the Beta Matter Server (>= 0.7.1, JavaScript-based). Mutually exclusive
+      with the local `Bluetooth Adapter ID` option.
   matter_server_env_vars:
     name: Matter Server environment variables
     description: >-


### PR DESCRIPTION
## Proposed change

Add a \`ble_proxy\` boolean option to the Matter Server add-on. When
enabled, the add-on starts the matter-server with \`--ble-proxy\`
instead of the local-adapter \`--bluetooth-adapter\` flag. The
matter-server then exposes a \`/ble\` WebSocket endpoint that Home
Assistant's Matter integration connects to and bridges through HA's
bluetooth component (including ESPHome BLE proxies).

This is the add-on side of a three-repo change:
- matter-server: https://github.com/matter-js/matterjs-server/pull/662
- HA core Matter integration:
  https://github.com/home-assistant/core/pull/171384
- (this PR) matter-server add-on

The two BLE-related options are mutually exclusive at the
matter-server level — \`--ble-proxy\` takes precedence if both are
set, with a warning logged. The add-on docs note the conflict.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing add-on)
- [ ] Breaking change

## Test plan

- [x] Add-on builds successfully with the new \`ble_proxy\` option.
- [x] Setting \`ble_proxy: true\` passes \`--ble-proxy\` to the
      matter-server start command (verified in \`s6-rc.d/.../run\`).
- [x] End-to-end commissioning of a Matter device over BLE through
      HA's bluetooth integration, with matter-server in \`--ble-proxy\`
      mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ble_proxy` configuration option (v8.5.0) to expose Matter Server's BLE proxy endpoint for Home Assistant's Matter integration. Requires Home Assistant 2026.06+ and Beta Matter Server ≥ 0.7.1. This setting is mutually exclusive with Bluetooth Adapter ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->