### PR TITLE
OpenThread Border Router: Allow network_device without USB device

### DIFF
--- a/openthread_border_router/config.yaml
+++ b/openthread_border_router/config.yaml
@@ -39,7 +39,7 @@ ports_description:
   8080/tcp: OpenThread Web port
   8081/tcp: OpenThread REST API port
 schema:
-  device: device(subsystem=tty)
+  device: device(subsystem=tty)?
   baudrate: list(57600|115200|230400|460800|921600|1000000)
   flow_control: bool
   backbone_interface: str?

--- a/openthread_border_router/rootfs/etc/s6-overlay/s6-rc.d/otbr-agent/run
+++ b/openthread_border_router/rootfs/etc/s6-overlay/s6-rc.d/otbr-agent/run
@@ -42,10 +42,14 @@ if [ "$(cat /proc/sys/net/ipv6/conf/all/forwarding)" != "1" ]; then
     bashio::log.warning "IPv6 routing/forwarding is not enabled! Make sure the Home Assistant host has IPv6 forwarding enabled."
 fi
 
-device=$(bashio::config 'device')
+if ! bashio::config.has_value 'device' && ! bashio::config.has_value 'network_device'; then
+    bashio::exit.nok "No device configured. Set either 'device' (serial port) or 'network_device' (TCP host:port)."
+fi
 
 if bashio::config.has_value 'network_device'; then
     device="/tmp/ttyOTBR"
+else
+    device="$(bashio::config 'device')"
 fi
 
 baudrate=$(bashio::config 'baudrate')


### PR DESCRIPTION
I'm trying to use an SLZB-MR4 (network-connected RCP) on my Raspberry Pi 4B. The add-on requires `device` to be set even though I'm using `network_device` — there's no USB serial device to provide, and setting a dummy value feels wrong.

This makes `device` optional in the schema and adds a check that fails clearly if neither `device` nor `network_device` is configured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Device configuration is now optional, allowing setups without an explicit device entry.

* **Bug Fixes**
  * Startup now validates configuration and exits early with a clear error when neither device nor network device is provided.
  * When a network device is selected, the runtime automatically uses an appropriate virtual device for operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->