### PR TITLE
feat(matter_server): allow configuring custom primary network interface

### DIFF
--- a/matter_server/config.yaml
+++ b/matter_server/config.yaml
@@ -35,6 +35,7 @@ schema:
   enable_test_net_dcl: bool?
   ble_proxy: bool?
   bluetooth_adapter_id: int?
+  matter_server_primary_interface: str?
   matter_server_args:
     - str?
   matter_server_env_vars:

--- a/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
+++ b/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
@@ -122,18 +122,35 @@ if bashio::config.true "enable_test_net_dcl"; then
     extra_args+=('--enable-test-net-dcl')
 fi
 
-primary_interface="$(bashio::api.supervisor 'GET' '/network/info' '' 'first(.interfaces[] | select (.primary == true)) .interface')"
-
-# Try fallback method (e.g. in case NetworkManager is not available)
-# shellcheck disable=SC2086
-if [ -z ${primary_interface} ]; then
-  bashio::log.warning 'Trying fallback method to determine primary interface'
-  primary_interface="$(ip --json route show default | jq --raw-output '.[0].dev')"
+# Check if the user configured a custom primary interface
+if bashio::config.has_value 'matter_server_primary_interface'; then
+    custom_interface=$(bashio::config 'matter_server_primary_interface')
+    
+    # Check if the configured interface actually exists in the system
+    if ip link show "$custom_interface" > /dev/null 2>&1; then
+        bashio::log.info "Using manually configured network interface: ${custom_interface}"
+        primary_interface="$custom_interface"
+    else
+        bashio::log.error "The configured network interface '${custom_interface}' was not found on the host!"
+        bashio::log.warning "Falling back to automatic interface detection."
+    fi
 fi
 
-# shellcheck disable=SC2086
-if [ -z ${primary_interface} ] || [ ${primary_interface} == "null" ]; then
-    bashio::exit.nok "No primary network interface found!"
+# Run automatic detection if no custom interface was set or if the custom one failed
+if [ -z "${primary_interface}" ]; then
+    primary_interface="$(bashio::api.supervisor 'GET' '/network/info' '' 'first(.interfaces[] | select (.primary == true)) .interface')"
+
+    # Try fallback method (e.g. in case NetworkManager is not available)
+    # shellcheck disable=SC2086
+    if [ -z ${primary_interface} ]; then
+      bashio::log.warning 'Trying fallback method to determine primary interface'
+      primary_interface="$(ip --json route show default | jq --raw-output '.[0].dev')"
+    fi
+
+    # shellcheck disable=SC2086
+    if [ -z ${primary_interface} ] || [ ${primary_interface} == "null" ]; then
+        bashio::exit.nok "No primary network interface found!"
+    fi
 fi
 
 if bashio::config.true "ble_proxy"; then

--- a/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
+++ b/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
@@ -141,14 +141,12 @@ if [ -z "${primary_interface}" ]; then
     primary_interface="$(bashio::api.supervisor 'GET' '/network/info' '' 'first(.interfaces[] | select (.primary == true)) .interface')"
 
     # Try fallback method (e.g. in case NetworkManager is not available)
-    # shellcheck disable=SC2086
-    if [ -z ${primary_interface} ]; then
+    if [ -z "${primary_interface}" ]; then
       bashio::log.warning 'Trying fallback method to determine primary interface'
       primary_interface="$(ip --json route show default | jq --raw-output '.[0].dev')"
     fi
 
-    # shellcheck disable=SC2086
-    if [ -z ${primary_interface} ] || [ ${primary_interface} == "null" ]; then
+    if [ -z "${primary_interface}" ] || [ "${primary_interface}" == "null" ]; then
         bashio::exit.nok "No primary network interface found!"
     fi
 fi

--- a/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
+++ b/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
@@ -141,7 +141,7 @@ if [ -z "${primary_interface}" ]; then
     primary_interface="$(bashio::api.supervisor 'GET' '/network/info' '' 'first(.interfaces[] | select (.primary == true)) .interface')"
 
     # Try fallback method (e.g. in case NetworkManager is not available)
-    if [ -z "${primary_interface}" ]; then
+    if [ -z "${primary_interface}" ] || [ "${primary_interface}" = "null" ]; then
       bashio::log.warning 'Trying fallback method to determine primary interface'
       primary_interface="$(ip --json route show default | jq --raw-output '.[0].dev')"
     fi

--- a/matter_server/translations/en.yaml
+++ b/matter_server/translations/en.yaml
@@ -65,5 +65,8 @@ configuration:
       Install custom Python Matter SDK wheels version (not applicable when
       using Beta flag). NOTE: The API might not be compatible with the Python
       Matter server.
+  matter_server_primary_interface:
+    name: "Primary Network Interface"
+    description: "Manually specify the primary network interface for the Matter Server (e.g., enp0s19). Leave empty to use the system default."
 network:
   5580/tcp: Matter Server WebSocket server port.


### PR DESCRIPTION
## Description
This PR introduces an optional configuration option `matter_server_primary_interface` to the Matter Server add-on. This allows users to manually specify the primary network interface used by the Matter Server (e.g., `enp0s19`), rather than relying solely on the Supervisor's automatic detection.

## Motivation & Context
In complex network environments (such as setups with multiple network interfaces, untagged/tagged VLANs, or multiple gateways), the automatic network interface detection by the Home Assistant Supervisor can sometimes select the wrong interface for the Matter Server. 

Currently, trying to append `--primary-interface` via `matter_server_args` results in duplicate arguments where the automatically detected one takes precedence, making it impossible for users to override it. This PR solves the issue by offering a dedicated, clean UI configuration field.

## How Has This Been Tested?
- **Empty configuration (Default):** Verified that the add-on falls back seamlessly to the Supervisor's automatic detection. No breaking changes for existing users.
- **Valid interface provided:** Verified that the custom interface is correctly injected and used by the Matter Server.
- **Invalid/Typo interface provided:** Verified that the built-in safety check (`ip link show`) detects the missing interface, logs a proper warning/error, and safely falls back to the system default instead of crashing the add-on loop.

## Checklist
- [x] Follows architecture guidelines for Home Assistant add-ons.
- [x] Includes English translations for the new configuration option.
- [x] Implementation is fully backwards-compatible.
- [x] Input validation included to prevent boot-loops caused by user typos.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional setting to manually specify the Matter Server’s primary network interface or leave empty to use the system default.
  * Added a user-facing name and description for this setting.

* **Bug Fixes / Behavior**
  * Better validation and clearer error logging for a user-specified interface.
  * Improved automatic detection fallback; startup now aborts with an explicit error if no primary interface is found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->