### PR TITLE
nginx_proxy: Provide option to add configuration parameters to root level of generated nginx conf

### DIFF
--- a/nginx_proxy/DOCS.md
+++ b/nginx_proxy/DOCS.md
@@ -64,7 +64,7 @@ Value for the [`Strict-Transport-Security`][hsts] HTTP header to send. If empty,
 
 ### Option `customize.active` (required)
 
-If true, additional NGINX configuration files for the default server and additional servers are read from files in the `/share` directory specified by the `default` and `servers` variables.
+If true, additional NGINX configuration files for the default server and additional servers are read from files in the `/share` directory specified by the `default`, `servers`, and `root_blocks` variables.
 
 ### Option `customize.default` (required)
 
@@ -73,6 +73,10 @@ The filename of the NGINX configuration for the default server, found in the `/s
 ### Option `customize.servers` (required)
 
 The filename(s) of the NGINX configuration for the additional servers, found in the `/share` directory.
+
+### Option `customize.root_conf` (required)
+
+The filename of the NGINX configuration for additional parameters to place in the root level of the configuration file, found in the `/share` directory.
 
 ### Option `cloudflare` (optional)
 

--- a/nginx_proxy/DOCS.md
+++ b/nginx_proxy/DOCS.md
@@ -64,7 +64,7 @@ Value for the [`Strict-Transport-Security`][hsts] HTTP header to send. If empty,
 
 ### Option `customize.active` (required)
 
-If true, additional NGINX configuration files for the default server and additional servers are read from files in the `/share` directory specified by the `default`, `servers`, and `root_blocks` variables.
+If true, additional NGINX configuration files for the default server and additional servers are read from files in the `/share` directory specified by the `default`, `servers`, and `root_conf` variables.
 
 ### Option `customize.default` (required)
 

--- a/nginx_proxy/config.yaml
+++ b/nginx_proxy/config.yaml
@@ -24,6 +24,7 @@ options:
     active: false
     default: nginx_proxy_default*.conf
     servers: nginx_proxy/*.conf
+    root_blocks: nginx_root_blocks*.conf
   real_ip_from: []
 ports:
   443/tcp: 443

--- a/nginx_proxy/config.yaml
+++ b/nginx_proxy/config.yaml
@@ -24,7 +24,7 @@ options:
     active: false
     default: nginx_proxy_default*.conf
     servers: nginx_proxy/*.conf
-    root_blocks: nginx_root_blocks*.conf
+    root_conf: nginx_root_conf*.conf
   real_ip_from: []
 ports:
   443/tcp: 443

--- a/nginx_proxy/config.yaml
+++ b/nginx_proxy/config.yaml
@@ -41,5 +41,6 @@ schema:
     active: bool
     default: str
     servers: str
+    root_conf: str
   real_ip_from:
     - str

--- a/nginx_proxy/rootfs/etc/nginx/nginx.conf.gtpl
+++ b/nginx_proxy/rootfs/etc/nginx/nginx.conf.gtpl
@@ -10,6 +10,10 @@ events {
     worker_connections 1024;
 }
 
+{{- if .options.customize.active }}
+include /share/{{ .options.customize.root_conf }};
+{{- end }}
+
 http {
     map_hash_bucket_size 128;
 


### PR DESCRIPTION
Adding a `root_conf` parameter under `options.customize` which allows for including a file at the root level of the generated nginx conf. This allows support for features like using NGINX in layer 4 with the `stream` block.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new option to specify a custom root-level NGINX configuration filename that will be loaded when customization is enabled.

* **Documentation**
  * Updated customization documentation to explain that enabling customization loads additional NGINX configuration files and how to use the new root-level config option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->