### PR TITLE
Docs: fix example for ACME `rfc2136_algorithm`

### DIFF
--- a/letsencrypt/DOCS.md
+++ b/letsencrypt/DOCS.md
@@ -1358,7 +1358,7 @@ And ensure you have an update policy in place in the zone that uses this key to 
      };
   ```
 
-For this provider, you will need to supply all the `rfc2136_*` options. Note that the `rfc2136_port` item is required (there is no default port in the app) and, most importantly, the port number must be quoted.  Also, be sure to copy in the key so certbot can authenticate to the DNS server.  Finally, the algorithm should be in all caps.
+For this provider, you will need to supply all the `rfc2136_*` options. Note that the `rfc2136_port` item is required (there is no default port in the app) and, most importantly, the port number must be quoted.  Also, be sure to copy in the key so certbot can authenticate to the DNS server.
 
 An example configuration:
 
@@ -1375,7 +1375,7 @@ An example configuration:
     rfc2136_port: '53'
     rfc2136_name: letsencrypt
     rfc2136_secret: "secret-key"
-    rfc2136_algorithm: HMAC-SHA512
+    rfc2136_algorithm: hmac-sha512
   ```
 
 </details>


### PR DESCRIPTION
Ref: https://github.com/home-assistant/addons/issues/4493

The switch-case handling "Algorithm" runs on [`CanonicalName(t.Algorithm)`](https://github.com/miekg/dns/blob/master/tsig.go#L44) so no need for the dot in the end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced RFC2136 DNS challenge documentation with refined guidance on required settings. Clarified that `rfc2136_port` must be quoted, all `rfc2136_*` options are mandatory, and proper key configuration is essential for certbot DNS authentication setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->