### PR TITLE
openthread_border_router: update beta toggle description

### DIFF
--- a/openthread_border_router/DOCS.md
+++ b/openthread_border_router/DOCS.md
@@ -70,7 +70,7 @@ App configuration:
 | firewall           | Enable OpenThread Border Router firewall to block unnecessary traffic |
 | nat64              | Enable NAT64 to allow Thread devices accessing IPv4 addresses |
 | network_device     | IP address and port to connect to a network-based RCP (see below) |
-| beta               | Enable beta mode with Thread 1.4 and native OpenThread mDNS |
+| beta               | Enable beta mode to run a newer, experimental version of OpenThread Border Router |
 
 > [!WARNING]
 > The OTBR expects the RCP connected radio to be on a reliable link such as

--- a/openthread_border_router/translations/en.yaml
+++ b/openthread_border_router/translations/en.yaml
@@ -37,7 +37,8 @@ configuration:
   beta:
     name: Beta
     description: >-
-      Enable beta mode with Thread 1.4 and native OpenThread mDNS.
+      Enable beta mode to run a newer, experimental version of OpenThread
+      Border Router.
 network:
   8080/tcp: OpenThread Web port
   8081/tcp: OpenThread REST API port


### PR DESCRIPTION
### Background

The stable and beta OTBR versions were both recently bumped with https://github.com/home-assistant/addons/pull/4619. Now, the beta toggle no longer unlocks "Thread 1.4" and the "native OpenThread mDNS", as that's already in the stable version. The beta just pins a newer OTBR commit.

### Change

So, This PR updates the description for the beta toggle. 

### Text choices

I'm not sure if the "experimental" part in the description potentially scares off users (or makes the text unnecessarily longer) – I'd also be fine with just "Enable beta mode to run a newer version of OpenThread [Border Router]." or similar. I think we should just get rid of the 1.4 and mDNS mention.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the description for the beta mode configuration option to better explain that it runs a newer, experimental version of the OpenThread Border Router.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->