### PR TITLE
matter_server: migrate to matter.js server (9.0.0)

### DIFF
--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -13,7 +13,7 @@
   - Coming from Beta server < 0.7: the first start runs the storage data migration and the second start removes the migration fallback data. Both can take a while — be patient on both starts.
 - New Matter Server features:
   - The Web UI dashboard adds Thread and Wi-Fi network visualizations, plus many other improvements
-  - BLE proxy support is enabled automatically when no local Bluetooth adapter ID is configured
+  - BLE proxy support is available via the `ble_proxy` option, letting Home Assistant drive BLE commissioning through its own bluetooth stack
   - Otherwise, it offers the same functionality as the Python server, and behavior within Home Assistant should be unchanged
   - For more details on the differences, see [our Migration FAQ](https://github.com/home-assistant/addons/blob/master/matter_server/MIGRATION_FAQ.md)
 - The **Beta** option now installs the latest `matter-server` from npm on top of the bundled version

--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - **The Matter Server now runs on matter.js. Expect the first start to take noticeably longer while your data migrates automatically — this is normal.**
   - **⚠️ It is recommended to take a backup before updating.**
+  - The new matter server needs roughly twice the RAM of the old one, so please check free resources before updating.
   - The Python Matter Server has been replaced with a matter.js-based implementation; your data migrates automatically with no action required
   - Later starts are much faster thanks to matter.js optimizations
 - New Matter Server features:

--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -18,6 +18,8 @@
   - For more details on the differences, see [our Migration FAQ](https://github.com/home-assistant/addons/blob/master/matter_server/MIGRATION_FAQ.md)
 - The **Beta** option now installs the latest `matter-server` from npm on top of the bundled version
   - npm install failures are logged as a warning and the bundled version is started instead
+  - The **Beta** flag keeps its previous value across this update. If you enabled it for the earlier matter.js beta, it stays on. matter.js is now the default, so you can turn it off — but more betas will follow, so keep it on if you want to keep testing pre-releases.
+- The `bluetooth_adapter_id` option is now deprecated in favor of `ble_proxy`, which lets Home Assistant drive BLE commissioning through its own bluetooth stack. `bluetooth_adapter_id` still works for now.
 - `matter_server_version` now installs that specific `matter-server` version from npm (takes precedence over **Beta**); values with a major version >= 3 are ignored as leftover Python Matter Server versions, and the bundled version is used instead
 - Removed the `log_level_sdk` and `matter_sdk_wheels_version` options (Python Matter Server only)
 - Updated the `log_level` options to the matter.js levels (`debug`, `info`, `notice`, `warn`, `error`, `fatal`); the legacy `verbose`/`warning`/`critical` values are still accepted and mapped automatically

--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -2,27 +2,15 @@
 
 ## 9.0.0
 
-- **The Matter Server now runs on matter.js by default. Expect the first start to take noticeably longer while your data migrates automatically — this is normal. Let the migration finish before using Matter.** Details below.
-  - **⚠️ Consider a full backup before updating.**
-  - The add-on now builds on the official `matterjs-server` Docker image
-  - The Python Matter Server has been removed
-  - Your existing data migrates automatically; no action is required
-  - The first start re-discovers and fully interviews every node. Later starts are much faster because each node's last-known IP is reused and usually only a partial interview is needed.
-- **For former Beta testers:**
-  - Coming from Beta server 0.7.x/0.8.x: the first start removes the migration fallback data. Expect it to take a while.
-  - Coming from Beta server < 0.7: the first start runs the storage data migration, and the second start removes the migration fallback data. Expect both starts to take a while.
+- **The Matter Server now runs on matter.js. Expect the first start to take noticeably longer while your data migrates automatically — this is normal.**
+  - **⚠️ It is recommended to take a backup before updating.**
+  - The Python Matter Server has been replaced with a matter.js-based implementation; your data migrates automatically with no action required
+  - Later starts are much faster thanks to matter.js optimizations
 - New Matter Server features:
-  - The Web UI dashboard adds Thread and Wi-Fi network visualizations, plus many other improvements
-  - BLE proxy support is available via the `ble_proxy` option, letting Home Assistant drive BLE commissioning through its own bluetooth stack
-  - Otherwise, it offers the same functionality as the Python server, and behavior within Home Assistant should be unchanged
-  - For more details on the differences, see [our Migration FAQ](https://github.com/home-assistant/addons/blob/master/matter_server/MIGRATION_FAQ.md)
-- The **Beta** option now installs the latest `matter-server` from npm on top of the bundled version
-  - npm install failures are logged as a warning and the bundled version is started instead
-  - The **Beta** flag keeps its previous value across this update. If you enabled it for the earlier matter.js beta, it stays on. matter.js is now the default, so you can turn it off — but more betas will follow, so keep it on if you want to keep testing pre-releases.
-- The `bluetooth_adapter_id` option is now deprecated in favor of `ble_proxy`, which lets Home Assistant drive BLE commissioning through its own bluetooth stack. `bluetooth_adapter_id` still works for now.
-- `matter_server_version` now installs that specific `matter-server` version from npm (takes precedence over **Beta**); values with a major version >= 3 are ignored as leftover Python Matter Server versions, and the bundled version is used instead
-- Removed the `log_level_sdk` and `matter_sdk_wheels_version` options (Python Matter Server only)
-- Updated the `log_level` options to the matter.js levels (`debug`, `info`, `notice`, `warn`, `error`, `fatal`); the legacy `verbose`/`warning`/`critical` values are still accepted and mapped automatically
+  - The web UI dashboard adds Thread and Wi-Fi network visualizations, plus many other improvements
+  - Experimental BLE proxy support via the `ble_proxy` option, for commissioning via BLE proxies from the Matter Server dashboard
+- If you enabled the **Beta** flag for the earlier matter.js beta, it stays on; matter.js is now the default, so you can turn it off — keep it on to keep testing pre-releases
+- For more details, see the [Migration FAQ](https://github.com/home-assistant/addons/blob/master/matter_server/MIGRATION_FAQ.md)
 
 ## 8.5.0
 

--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -5,8 +5,8 @@
 - **The Matter Server now runs on matter.js. Expect the first start to take noticeably longer while your data migrates automatically — this is normal.**
   - **⚠️ It is recommended to take a backup before updating.**
   - The new matter server needs roughly twice the RAM of the old one, so please check free resources before updating.
-  - The Python Matter Server has been replaced with a matter.js-based implementation; your data migrates automatically with no action required
-  - Later starts are much faster thanks to matter.js optimizations
+  - The Python Matter Server has been replaced with a matter.js-based implementation (v1.1.0); your data migrates automatically with no action required
+  - Later starts are much faster
 - New Matter Server features:
   - The web UI dashboard adds Thread and Wi-Fi network visualizations, plus many other improvements
   - Experimental BLE proxy support via the `ble_proxy` option, for commissioning via BLE proxies from the Matter Server dashboard

--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -2,15 +2,15 @@
 
 ## 9.0.0
 
-- **The Matter Server now runs on matter.js by default. Your first start will take noticeably longer while your data migrates automatically. This is normal: please be patient and let it finish.** Details below.
+- **The Matter Server now runs on matter.js by default. Expect the first start to take noticeably longer while your data migrates automatically — this is normal. Let the migration finish before using Matter.** Details below.
   - **⚠️ Consider a full backup before updating.**
   - The add-on now builds on the official `matterjs-server` Docker image
   - The Python Matter Server has been removed
   - Your existing data migrates automatically; no action is required
   - The first start re-discovers and fully interviews every node. Later starts are much faster because each node's last-known IP is reused and usually only a partial interview is needed.
 - **For former Beta testers:**
-  - Coming from Beta server 0.7.x/0.8.x: the first start removes the migration fallback data, which can take a while. Be patient.
-  - Coming from Beta server < 0.7: the first start runs the storage data migration and the second start removes the migration fallback data. Both can take a while — be patient on both starts.
+  - Coming from Beta server 0.7.x/0.8.x: the first start removes the migration fallback data. Expect it to take a while.
+  - Coming from Beta server < 0.7: the first start runs the storage data migration, and the second start removes the migration fallback data. Expect both starts to take a while.
 - New Matter Server features:
   - The Web UI dashboard adds Thread and Wi-Fi network visualizations, plus many other improvements
   - BLE proxy support is available via the `ble_proxy` option, letting Home Assistant drive BLE commissioning through its own bluetooth stack

--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 9.0.0
+
+- **The Matter Server now runs on matter.js by default. Your first start will take noticeably longer while your data migrates automatically. This is normal: please be patient and let it finish.** Details below.
+  - **⚠️ Consider a full backup before updating.**
+  - The add-on now builds on the official `matterjs-server` Docker image
+  - The Python Matter Server has been removed
+  - Your existing data migrates automatically; no action is required
+  - The first start re-discovers and fully interviews every node. Later starts are much faster because each node's last-known IP is reused and usually only a partial interview is needed.
+- **For former Beta testers:**
+  - Coming from Beta server 0.7.x/0.8.x: the first start removes the migration fallback data, which can take a while. Be patient.
+  - Coming from Beta server < 0.7: the first start runs the storage data migration and the second start removes the migration fallback data. Both can take a while — be patient on both starts.
+- New Matter Server features:
+  - The Web UI dashboard adds Thread and Wi-Fi network visualizations, plus many other improvements
+  - BLE proxy support is enabled automatically when no local Bluetooth adapter ID is configured
+  - Otherwise, it offers the same functionality as the Python server, and behavior within Home Assistant should be unchanged
+  - For more details on the differences, see [our Migration FAQ](https://github.com/home-assistant/addons/blob/master/matter_server/MIGRATION_FAQ.md)
+- The **Beta** option now installs the latest `matter-server` from npm on top of the bundled version
+  - npm install failures are logged as a warning and the bundled version is started instead
+- `matter_server_version` now installs that specific `matter-server` version from npm (takes precedence over **Beta**); values with a major version >= 3 are ignored as leftover Python Matter Server versions, and the bundled version is used instead
+- Removed the `log_level_sdk` and `matter_sdk_wheels_version` options (Python Matter Server only)
+- Updated the `log_level` options to the matter.js levels (`debug`, `info`, `notice`, `warn`, `error`, `fatal`); the legacy `verbose`/`warning`/`critical` values are still accepted and mapped automatically
+
 ## 8.5.0
 
 - Add `ble_proxy` option to expose the Matter Server's BLE proxy endpoint, so the Home Assistant Matter integration can drive BLE commissioning through Home Assistant's bluetooth stack (including ESPHome BLE proxies). To actually use this BLE proxy you need Home Assistant 2026.06 or later (the Matter integration support landed there) and the Beta Matter Server (>= 0.7.1, JavaScript-based); mutually exclusive with `bluetooth_adapter_id` (the local adapter is ignored with a warning when `ble_proxy` is enabled).

--- a/matter_server/DOCS.md
+++ b/matter_server/DOCS.md
@@ -51,7 +51,7 @@ App configuration:
 | bluetooth_adapter_id | Set BlueZ Bluetooth Controller ID (for local commissioning).                                            |
 | matter_server_args   | Extra command-line arguments passed to the Matter Server at startup (advanced).                         |
 | matter_server_env_vars | Extra environment variables exported before the server starts. Use `KEY=VALUE` entries. |
-| matter_server_version | Install this specific `matter-server` version from npm (advanced; takes precedence over **Beta**). Values with a major version >= 3 are ignored (these are Python Matter Server versions) and the bundled version is used. |
+| matter_server_version | Install this specific `matter-server` version from npm (advanced; takes precedence over **Beta**). Values with a major version >= 3 are ignored (these are Python Matter Server versions); unless **Beta** is set, the bundled version is used. |
 
 ### `matter_server_env_vars`
 

--- a/matter_server/DOCS.md
+++ b/matter_server/DOCS.md
@@ -38,6 +38,12 @@ The server version bundled in the app image is used by default. The **Beta**
 flag installs the latest `matter-server` from npm on top of it, and
 `matter_server_version` installs a specific version (see below).
 
+> [!NOTE]
+> The **Beta** flag keeps its previous value across this update. If you enabled
+> it for the earlier matter.js beta, it stays on after updating to 9.0.0.
+> matter.js is now the default, so you can turn it off — but more betas will
+> follow, so keep it on if you want to keep testing pre-releases.
+
 ## Configuration
 
 App configuration:
@@ -48,7 +54,7 @@ App configuration:
 | beta                 | Install the latest `matter-server` from npm on startup instead of the bundled version. On failure a warning is logged and the bundled version is started. |
 | enable_test_net_dcl  | Enable test-net DCL for PAA root certificates, OTA updates and other device information.                |
 | ble_proxy            | Expose the BLE proxy endpoint so the Home Assistant Matter integration can drive BLE commissioning through Home Assistant's bluetooth stack. Mutually exclusive with `bluetooth_adapter_id`. |
-| bluetooth_adapter_id | Set BlueZ Bluetooth Controller ID (for local commissioning).                                            |
+| bluetooth_adapter_id | **Deprecated** — use `ble_proxy` instead. Set BlueZ Bluetooth Controller ID (for local commissioning). Still works for now. |
 | matter_server_args   | Extra command-line arguments passed to the Matter Server at startup (advanced).                         |
 | matter_server_env_vars | Extra environment variables exported before the server starts. Use `KEY=VALUE` entries. |
 | matter_server_version | Install this specific `matter-server` version from npm (advanced; takes precedence over **Beta**). Values with a major version >= 3 are ignored (these are Python Matter Server versions); unless **Beta** is set, the bundled version is used. |

--- a/matter_server/DOCS.md
+++ b/matter_server/DOCS.md
@@ -26,11 +26,17 @@ Matter Server WebSocket server port field.
 
 ## Server variants
 
-This app runs the Python Matter Server implementation from the
-[home-assistant-libs/python-matter-server][matter_server_repo] repository by default.
+> **⚠️ Make a full backup before updating to 9.0.0.** This is a major migration
+> to a new server. Keep the Supervisor's "Create backup" option enabled when you
+> update, so you can roll back if needed.
 
-Starting with version 8.2.0 and choosing the "Beta" flag (see below) the new OHF
-Matter(.js) Server is executed instead of the Python Matter Server.
+Starting with version 9.0.0 this app runs the [matter.js Matter
+Server][matter_server_repo] exclusively. The Python Matter Server has been
+removed; existing data is migrated automatically with no user action required.
+
+The server version bundled in the app image is used by default. The **Beta**
+flag installs the latest `matter-server` from npm on top of it, and
+`matter_server_version` installs a specific version (see below).
 
 ## Configuration
 
@@ -39,30 +45,20 @@ App configuration:
 | Configuration        | Description                                                                                             |
 |----------------------|---------------------------------------------------------------------------------------------------------|
 | log_level            | Logging level of the Matter Server component.                                                           |
-| log_level_sdk        | Logging level for Matter SDK logs (Python only).                                                        |
-| beta                 | Whether to install the latest beta version on startup (runs matter.js-based Matter Server starting with 8.2.0) |
+| beta                 | Install the latest `matter-server` from npm on startup instead of the bundled version. On failure a warning is logged and the bundled version is started. |
 | enable_test_net_dcl  | Enable test-net DCL for PAA root certificates, OTA updates and other device information.                |
-| bluetooth_adapter_id | Set BlueZ Bluetooth Controller ID (for local commissioning)                                             |
-| matter_server_env_vars | Extra environment variables exported before start (only relevant for the JavaScript Matter Server / Beta mode). Use `KEY=VALUE` entries. |
-| matter_server_version | Custom Matter Server version. In JavaScript/Beta mode, only `0.x.y` or `1.x.y` values are used; other values are ignored and latest is installed. |
+| ble_proxy            | Expose the BLE proxy endpoint so the Home Assistant Matter integration can drive BLE commissioning through Home Assistant's bluetooth stack. Mutually exclusive with `bluetooth_adapter_id`. |
+| bluetooth_adapter_id | Set BlueZ Bluetooth Controller ID (for local commissioning).                                            |
+| matter_server_env_vars | Extra environment variables exported before the server starts. Use `KEY=VALUE` entries. |
+| matter_server_version | Install this specific `matter-server` version from npm (advanced; takes precedence over **Beta**). Values with a major version >= 3 are ignored (these are Python Matter Server versions) and the bundled version is used. |
 
-### `matter_server_env_vars` (JavaScript server only)
-
-This option is only relevant when the **Beta** flag is enabled (JavaScript
-Matter Server).
+### `matter_server_env_vars`
 
 ```yaml
 matter_server_env_vars:
   - NODE_OPTIONS=--max-old-space-size=512
   - MY_FLAG=true
 ```
-
-### `matter_server_version`
-
-- Python mode: installs the configured `python-matter-server` version.
-- JavaScript/Beta mode: uses the configured version only if it matches
-  `0.x.y` or `1.x.y` (for example `1.2.3`); all other values are ignored and
-  `latest` is installed.
 
 ## Support
 
@@ -82,5 +78,5 @@ In case you've found a bug, please [open an issue on our GitHub][issue].
 [forum]: https://community.home-assistant.io
 [reddit]: https://reddit.com/r/homeassistant
 [issue]: https://github.com/home-assistant/addons/issues
-[matter_server_repo]: https://github.com/home-assistant-libs/python-matter-server
+[matter_server_repo]: https://github.com/matter-js/matterjs-server
 [matter_integration]: https://www.home-assistant.io/integrations/matter/

--- a/matter_server/DOCS.md
+++ b/matter_server/DOCS.md
@@ -49,6 +49,7 @@ App configuration:
 | enable_test_net_dcl  | Enable test-net DCL for PAA root certificates, OTA updates and other device information.                |
 | ble_proxy            | Expose the BLE proxy endpoint so the Home Assistant Matter integration can drive BLE commissioning through Home Assistant's bluetooth stack. Mutually exclusive with `bluetooth_adapter_id`. |
 | bluetooth_adapter_id | Set BlueZ Bluetooth Controller ID (for local commissioning).                                            |
+| matter_server_args   | Extra command-line arguments passed to the Matter Server at startup (advanced).                         |
 | matter_server_env_vars | Extra environment variables exported before the server starts. Use `KEY=VALUE` entries. |
 | matter_server_version | Install this specific `matter-server` version from npm (advanced; takes precedence over **Beta**). Values with a major version >= 3 are ignored (these are Python Matter Server versions) and the bundled version is used. |
 

--- a/matter_server/Dockerfile
+++ b/matter_server/Dockerfile
@@ -1,9 +1,8 @@
 ARG BUILD_FROM
 FROM ${BUILD_FROM}
 
-# The matter.js base image runs as an unprivileged user; s6-overlay needs root.
-# hadolint ignore=DL3002
-# The matter.js base image runs as an unprivileged user; the app requires root for Bluetooth via Noble raw hci access
+# The matter.js base image runs as an unprivileged user; the app requires root
+# for s6-overlay and for Bluetooth via Noble raw HCI access.
 # hadolint ignore=DL3002
 USER root
 

--- a/matter_server/Dockerfile
+++ b/matter_server/Dockerfile
@@ -1,6 +1,9 @@
 ARG BUILD_FROM
 FROM ${BUILD_FROM}
 
+# The matter.js base image runs as an unprivileged user; s6-overlay needs root.
+USER root
+
 # Default ENV
 ENV \
     LANG="C.UTF-8" \
@@ -33,12 +36,7 @@ RUN \
         curl \
         ca-certificates \
         xz-utils \
-        bluez \
-        libbluetooth-dev \
-        libudev-dev \
-        make \
-        gcc \
-        g++ \
+        iproute2 \
     && mkdir -p /usr/share/man/man1 \
     \
     && if [ "${BUILD_ARCH}" = "armv7" ]; then \
@@ -74,23 +72,6 @@ RUN \
     \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /usr/src/*
-
-# Install Node.js 22.x for JavaScript Matter Server (beta mode)
-# We download from nodejs.org instead of using OS packages to ensure
-# we have up-to-date Node.js versions with latest features and fixes
-ARG NODE_VERSION
-RUN \
-    set -x \
-    && DPKG_ARCH=$(dpkg --print-architecture) \
-    && case "${DPKG_ARCH}" in \
-         amd64) NODE_ARCH="x64" ;; \
-         *) NODE_ARCH="${DPKG_ARCH}" ;; \
-       esac \
-    && curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" -o /tmp/node.tar.xz \
-    && tar -xJf /tmp/node.tar.xz -C /usr/local --strip-components=1 --no-same-owner \
-    && rm -f /tmp/node.tar.xz \
-    && node --version \
-    && npm --version
 
 # S6-Overlay
 WORKDIR /root

--- a/matter_server/Dockerfile
+++ b/matter_server/Dockerfile
@@ -2,6 +2,7 @@ ARG BUILD_FROM
 FROM ${BUILD_FROM}
 
 # The matter.js base image runs as an unprivileged user; s6-overlay needs root.
+# hadolint ignore=DL3002
 USER root
 
 # Default ENV

--- a/matter_server/Dockerfile
+++ b/matter_server/Dockerfile
@@ -3,6 +3,8 @@ FROM ${BUILD_FROM}
 
 # The matter.js base image runs as an unprivileged user; s6-overlay needs root.
 # hadolint ignore=DL3002
+# The matter.js base image runs as an unprivileged user; the app requires root for Bluetooth via Noble raw hci access
+# hadolint ignore=DL3002
 USER root
 
 # Default ENV

--- a/matter_server/Dockerfile
+++ b/matter_server/Dockerfile
@@ -9,6 +9,7 @@ USER root
 
 # Default ENV
 ENV \
+    LOG_LEVEL="" \
     LANG="C.UTF-8" \
     DEBIAN_FRONTEND="noninteractive" \
     CURL_CA_BUNDLE="/etc/ssl/certs/ca-certificates.crt" \

--- a/matter_server/MIGRATION_FAQ.md
+++ b/matter_server/MIGRATION_FAQ.md
@@ -6,10 +6,10 @@ The new Matter Server is a complete rewrite of the Python-based Matter Server. I
 Version 9.0 is the first release of the new Matter Server.
 
 ## Should I do a backup before installing the new version?
-Yes. We always recommend making a backup before installing a new version of the server. The new version migrates your current data automatically, but it is always better to be safe than sorry. Just tick the "Create backup" checkbox when you update the server.
+Yes. Make a backup before installing the new version. The new version migrates your current data automatically, but a backup lets you roll back if anything goes wrong. Tick the "Create backup" checkbox when you update the server.
 
 ## What happens on the first start of the new version?
-The first start of the new version **automatically migrates your current data**. This requires no manual intervention but needs some time to complete. **Please be patient.** The log shows the progress of the migration.
+The first start of the new version **automatically migrates your current data**. This requires no manual intervention but needs some time to complete. **Wait for the migration to finish** — the log shows its progress.
 
 After the migration completes, the server discovers all your devices and performs a full interview to fetch the current data.
 All later starts automatically try to connect to the devices on their last known addresses and perform only a partial interview to update changed data. This significantly speeds up every subsequent start.
@@ -34,4 +34,4 @@ For Thread networks we also try to discover the border routers and show informat
 Note: you might also see "Unknown devices" or "External routers" in the network visualizations. This can mean different things depending on the network topology. They could be other Thread devices that do not belong to the Matter Server's fabric, or they could be stale data from the devices (for example, many sleepy battery devices do not update their network information regularly).
 
 ## Can I switch back to the old Matter Server?
-No. The new Matter Server was tested as a "Beta" with the community for the last four months, and we did our best to make sure it works as expected. If you run into any issues, please report them to us in this GitHub repository and we will try to fix them as soon as possible.
+No. The new Matter Server was tested as a "Beta" with the community for the last four months, and we did our best to make sure it works as expected. If you run into any issues, report them in this GitHub repository and we will try to fix them as soon as possible.

--- a/matter_server/MIGRATION_FAQ.md
+++ b/matter_server/MIGRATION_FAQ.md
@@ -14,6 +14,12 @@ The first start of the new version **automatically migrates your current data**.
 After the migration completes, the server discovers all your devices and performs a full interview to fetch the current data.
 All later starts automatically try to connect to the devices on their last known addresses and perform only a partial interview to update changed data. This significantly speeds up every subsequent start.
 
+## I already tested the matter.js Beta — what happens for me?
+Your start may run a one-time cleanup, which can take a while:
+
+- Coming from Beta server 0.7.x or 0.8.x: the first start removes the leftover migration fallback data.
+- Coming from a Beta server older than 0.7: the first start runs the storage data migration, and the second start removes the migration fallback data — so expect both starts to take a while.
+
 ## What is the difference between the old Matter Server and the new one?
 The main goal of this first new version is to be a complete drop-in replacement for the old Matter Server. The Home Assistant integration works with the new Matter Server without any changes.
 

--- a/matter_server/MIGRATION_FAQ.md
+++ b/matter_server/MIGRATION_FAQ.md
@@ -1,0 +1,37 @@
+# Python Matter Server v8.x --> matter.js-based Matter Server 9.0+ Migration FAQ
+
+## Why is there a new Matter Server?
+The new Matter Server is a complete rewrite of the Python-based Matter Server. It is now built on the matter.js library, a JavaScript implementation of the Matter standard. The new Matter Server is more performant, more stable, and more feature-complete than the old one.
+
+Version 9.0 is the first release of the new Matter Server.
+
+## Should I do a backup before installing the new version?
+Yes. We always recommend making a backup before installing a new version of the server. The new version migrates your current data automatically, but it is always better to be safe than sorry. Just tick the "Create backup" checkbox when you update the server.
+
+## What happens on the first start of the new version?
+The first start of the new version **automatically migrates your current data**. This requires no manual intervention but needs some time to complete. **Please be patient.** The log shows the progress of the migration.
+
+After the migration completes, the server discovers all your devices and performs a full interview to fetch the current data.
+All later starts automatically try to connect to the devices on their last known addresses and perform only a partial interview to update changed data. This significantly speeds up every subsequent start.
+
+## What is the difference between the old Matter Server and the new one?
+The main goal of this first new version is to be a complete drop-in replacement for the old Matter Server. The Home Assistant integration works with the new Matter Server without any changes.
+
+In the details, there are some differences between the old and the new version:
+* Some advanced configuration options have been removed, changed slightly, or added.
+* The new server uses the last known addresses of your devices on startup to speed up connections, and it is also aware of each device's network type. This especially optimizes environments with many Thread devices, connecting to them while respecting the bandwidth limitations of the Thread network.
+* The new server uses partial interviews when reconnecting to devices, fetching only the data that changed. This significantly improves performance on every server restart and device reconnection.
+* The old server allowed commissioning of uncertified devices with "just" a test/development certificate by default. This makes adding DIY devices easy but also carries the risk of adding a malicious device to the network. The new server still supports this, but requires you to enable the special "Test-Net DCL" option first.
+* The allowed certificates are usually downloaded when the server starts and are stored in the server's data directory. The new server already includes an initial set of certificates from the time of its release, so you can start it without an internet connection and still commission devices whose certificates were available at release time. The server updates the certificates in the background whenever it has an internet connection.
+* The new server also checks for revoked certificates during commissioning and treats them as invalid.
+* For OTA software updates, the old server started special temporary nodes in the Matter network, which often caused issues. In the new server the OTA update logic is fully integrated into the controller, which makes the process much more reliable.
+* The new server needs a bit more RAM than the old one, so make sure your Home Assistant host has enough free memory to run all services smoothly.
+
+We also used the time to improve the Web UI/dashboard of the Matter Server.
+Besides general consistency and usability improvements, we added network visualizations for your Thread and Wi-Fi networks. These use the connection details the devices report to visualize the network topology and give you insights into the quality of the connections. This is especially helpful for Thread networks, where the devices themselves decide which other device they use as a parent, and where you often have multiple hops between a device and the border router.
+For Thread networks we also try to discover the border routers and show information about them in the network visualizations.
+
+Note: you might also see "Unknown devices" or "External routers" in the network visualizations. This can mean different things depending on the network topology. They could be other Thread devices that do not belong to the Matter Server's fabric, or they could be stale data from the devices (for example, many sleepy battery devices do not update their network information regularly).
+
+## Can I switch back to the old Matter Server?
+No. The new Matter Server was tested as a "Beta" with the community for the last four months, and we did our best to make sure it works as expected. If you run into any issues, please report them to us in this GitHub repository and we will try to fix them as soon as possible.

--- a/matter_server/MIGRATION_FAQ.md
+++ b/matter_server/MIGRATION_FAQ.md
@@ -3,7 +3,7 @@
 ## Why is there a new Matter Server?
 The new Matter Server is a complete rewrite of the Python-based Matter Server. It is now built on the matter.js library, a JavaScript implementation of the Matter standard. The new Matter Server is more performant, more stable, and more feature-complete than the old one.
 
-Version 9.0 is the first release of the new Matter Server.
+Version 9.0 of the Matter App is the first release for all Home Assistant users which uses the new Matter Server.
 
 ## Should I do a backup before installing the new version?
 Yes. Make a backup before installing the new version. The new version migrates your current data automatically, but a backup lets you roll back if anything goes wrong. Tick the "Create backup" checkbox when you update the server.

--- a/matter_server/MIGRATION_FAQ.md
+++ b/matter_server/MIGRATION_FAQ.md
@@ -31,7 +31,7 @@ In the details, there are some differences between the old and the new version:
 * The allowed certificates are usually downloaded when the server starts and are stored in the server's data directory. The new server already includes an initial set of certificates from the time of its release, so you can start it without an internet connection and still commission devices whose certificates were available at release time. The server updates the certificates in the background whenever it has an internet connection.
 * The new server also checks for revoked certificates during commissioning and treats them as invalid.
 * For OTA software updates, the old server started special temporary nodes in the Matter network, which often caused issues. In the new server the OTA update logic is fully integrated into the controller, which makes the process much more reliable.
-* The new server needs a bit more RAM than the old one, so make sure your Home Assistant host has enough free memory to run all services smoothly.
+* The new server needs roughly twice the RAM than the old one and also a bit more CPU, so make sure your Home Assistant host has enough free memory to run all services smoothly.
 
 We also used the time to improve the Web UI/dashboard of the Matter Server.
 Besides general consistency and usability improvements, we added network visualizations for your Thread and Wi-Fi networks. These use the connection details the devices report to visualize the network topology and give you insights into the quality of the connections. This is especially helpful for Thread networks, where the devices themselves decide which other device they use as a parent, and where you often have multiple hops between a device and the border router.

--- a/matter_server/RELEASE.md
+++ b/matter_server/RELEASE.md
@@ -4,8 +4,7 @@
 
 When updating the server library in the app (formerly known as add-on) follow these steps:
 
-1. Update the `MATTER_SERVER_VERSION` argument in `build.yaml`.
-2. Check if the chip SDK version has changed in the server library.
-3. If the minimal supported schema version has changed, set the `homeassistant` key in `config.yaml` to the minimum version of Home Assistant Core required to install or update the app.
-4. Update the app version in `config.yaml`. Bump to a new major version if the minimum schema version has changed.
-5. Update the changelog in `CHANGELOG.md`. Include a markdown link to the GitHub release of the server in the changelog.
+1. Update the `matterjs-server` image tag in both `build_from` entries in `build.yaml`.
+2. If the minimal supported schema version has changed, set the `homeassistant` key in `config.yaml` to the minimum version of Home Assistant Core required to install or update the app.
+3. Update the app version in `config.yaml`. Bump to a new major version if the minimum schema version has changed.
+4. Update the changelog in `CHANGELOG.md`. Include a markdown link to the GitHub release of the server in the changelog.

--- a/matter_server/build.yaml
+++ b/matter_server/build.yaml
@@ -1,7 +1,7 @@
 ---
 build_from:
-  aarch64: ghcr.io/matter-js/matterjs-server:1.0.0
-  amd64: ghcr.io/matter-js/matterjs-server:1.0.0
+  aarch64: ghcr.io/matter-js/matterjs-server:1.1.0
+  amd64: ghcr.io/matter-js/matterjs-server:1.1.0
 args:
   BASHIO_VERSION: 0.17.1
   TEMPIO_VERSION: 2024.11.2

--- a/matter_server/build.yaml
+++ b/matter_server/build.yaml
@@ -1,9 +1,8 @@
 ---
 build_from:
-  aarch64: ghcr.io/matter-js/python-matter-server:8.1.2
-  amd64: ghcr.io/matter-js/python-matter-server:8.1.2
+  aarch64: ghcr.io/matter-js/matterjs-server:0.8.0
+  amd64: ghcr.io/matter-js/matterjs-server:0.8.0
 args:
   BASHIO_VERSION: 0.17.1
   TEMPIO_VERSION: 2024.11.2
   S6_OVERLAY_VERSION: 3.1.6.2
-  NODE_VERSION: 22.21.1

--- a/matter_server/build.yaml
+++ b/matter_server/build.yaml
@@ -1,7 +1,7 @@
 ---
 build_from:
-  aarch64: ghcr.io/matter-js/matterjs-server:0.8.0
-  amd64: ghcr.io/matter-js/matterjs-server:0.8.0
+  aarch64: ghcr.io/matter-js/matterjs-server:1.0.0
+  amd64: ghcr.io/matter-js/matterjs-server:1.0.0
 args:
   BASHIO_VERSION: 0.17.1
   TEMPIO_VERSION: 2024.11.2

--- a/matter_server/config.yaml
+++ b/matter_server/config.yaml
@@ -1,5 +1,6 @@
 ---
 version: 9.0.0
+breaking_versions: [9.0.0]
 slug: matter_server
 name: Matter Server
 description: Matter WebSocket Server for Home Assistant Matter support.

--- a/matter_server/config.yaml
+++ b/matter_server/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 8.5.0
+version: 9.0.0
 slug: matter_server
 name: Matter Server
 description: Matter WebSocket Server for Home Assistant Matter support.
@@ -25,12 +25,10 @@ map:
     read_only: false
 options:
   log_level: info
-  log_level_sdk: error
   beta: false
   enable_test_net_dcl: false
 schema:
-  log_level: list(verbose|debug|info|warning|error|critical)
-  log_level_sdk: list(automation|detail|progress|error|none)?
+  log_level: list(debug|info|notice|warn|error|fatal|verbose|warning|critical)
   beta: bool?
   enable_test_net_dcl: bool?
   ble_proxy: bool?
@@ -40,7 +38,6 @@ schema:
   matter_server_env_vars:
     - match(^[A-Za-z_][A-Za-z0-9_]*=.*$)?
   matter_server_version: str?
-  matter_sdk_wheels_version: str?
 ports:
   5580/tcp: null
 stage: stable

--- a/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
+++ b/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
@@ -9,10 +9,8 @@ bashio::log.info "Starting Matter Server..."
 declare server_port
 declare log_level
 declare primary_interface
+declare install_target
 declare matter_server_version
-declare npm_package
-declare chip_version
-declare use_js_server
 declare env_entry
 declare env_name
 declare env_value
@@ -25,90 +23,75 @@ if ! bashio::config.exists log_level; then
 fi
 log_level=$(bashio::string.lower "$(bashio::config log_level info)")
 
-# Determine server type based on beta flag
-use_js_server=$(bashio::config "beta")
+# Map legacy Python Matter Server log levels to their matter.js equivalents.
+case "${log_level}" in
+  verbose) log_level="debug" ;;
+  warning) log_level="warn" ;;
+  critical) log_level="fatal" ;;
+esac
 
-if [[ "${use_js_server}" == "true" ]]; then
-  # Beta mode: Use JavaScript Matter Server
-  bashio::log.info "Using JavaScript Matter Server (beta mode)"
-  npm_package="matter-server@latest"
-  if bashio::config.has_value "matter_server_version"; then
-    matter_server_version=$(bashio::config 'matter_server_version')
-    if [[ "${matter_server_version}" =~ ^(0|1)\.[0-9]+\.[0-9]+$ ]]; then
-      npm_package="matter-server@${matter_server_version}"
-      bashio::log.info "Installing JavaScript Matter Server ${matter_server_version} from npm..."
-    else
-      bashio::log.warning "Ignoring matter_server_version '${matter_server_version}' for JavaScript Matter Server. Only 0.x.y or 1.x.y are supported; installing latest."
-      bashio::log.info "Installing latest matter-server from npm..."
-    fi
+# Resolve which matter-server build to run. The base image ships a bundled
+# matter-server under /app. A pinned version wins over the "latest" beta switch.
+# matter.js uses 0.x-2.x versions; a major >= 3 is almost certainly a leftover
+# Python Matter Server version, so it is ignored to avoid installing the wrong package.
+install_target=""
+if bashio::config.has_value "matter_server_version"; then
+  matter_server_version=$(bashio::config 'matter_server_version')
+  if [[ "${matter_server_version}" =~ ^[^0-9]*([0-9]+) ]] && (( BASH_REMATCH[1] >= 3 )); then
+    bashio::log.warning \
+      "Ignoring matter_server_version '${matter_server_version}': a major version >= 3 looks like a Python Matter Server version. The matter.js Matter Server uses 0.x-2.x versions; please update or clear this option."
   else
-    bashio::log.info "Installing latest matter-server from npm..."
+    install_target="matter-server@${matter_server_version}"
   fi
-  mkdir -p /opt/matterjs
-  # shellcheck disable=SC2164
-  cd /opt/matterjs
-  if ! npm install --foreground-scripts "${npm_package}"; then
-    bashio::log.error "Failed to install Matter Server from npm. Aborting startup."
-    exit 1
+fi
+if ! bashio::var.has_value "${install_target}" && bashio::config.true "beta"; then
+  install_target="matter-server@latest"
+fi
+
+if bashio::var.has_value "${install_target}"; then
+  bashio::log.info "Installing ${install_target} from npm over the bundled server..."
+  # matter.js native modules may need compiling; the base image purges the
+  # toolchain, so add it back here. A failure here must not abort startup.
+  if ! { apt-get update \
+      && apt-get install -y --no-install-recommends \
+        python3 make gcc g++ libbluetooth-dev libudev-dev \
+      && cd /app \
+      && npm install --omit=dev --foreground-scripts "${install_target}"; }; then
+    bashio::log.warning \
+      "Failed to install ${install_target} from npm. Starting the bundled Matter Server instead."
+  else
+    npm cache clean --force || true
+    find /app/node_modules -type d -name "cjs" -path "*/@matter/*" -exec rm -rf {} + 2>/dev/null || true
+    find /app/node_modules -type d -name "cjs" -path "*/@project-chip/*" -exec rm -rf {} + 2>/dev/null || true
   fi
-  # Clean up to save disk space
-  npm cache clean --force
-  find ./node_modules -type d -name "cjs" -path "*/@matter/*" -exec rm -rf {} + 2>/dev/null || true
-  find ./node_modules -type d -name "cjs" -path "*/@project-chip/*" -exec rm -rf {} + 2>/dev/null || true
-  rm -rf /tmp/* /var/tmp/* /root/.npm /root/.cache 2>/dev/null || true
+fi
 
-  # JS server only uses --ota-provider-dir when --enable-test-net-dcl is also set
-  if bashio::config.true "enable_test_net_dcl"; then
-    extra_args+=('--ota-provider-dir' "/config/updates")
-  fi
+# Export custom environment variables before starting the server
+if bashio::config.has_value "matter_server_env_vars"; then
+  env_vars_count=$(bashio::config 'matter_server_env_vars | length')
+  for (( i=0; i < env_vars_count; i++ )); do
+    env_entry="$(bashio::config "matter_server_env_vars[${i}]")"
 
-  if bashio::config.has_value "matter_server_env_vars"; then
-    env_vars_count=$(bashio::config 'matter_server_env_vars | length')
-    for (( i=0; i < env_vars_count; i++ )); do
-      env_entry="$(bashio::config "matter_server_env_vars[${i}]")"
+    if [[ "${env_entry}" != *"="* ]]; then
+      bashio::exit.nok "Invalid matter_server_env_vars entry: ${env_entry} (expected KEY=VALUE)"
+    fi
 
-      if [[ "${env_entry}" != *"="* ]]; then
-        bashio::exit.nok "Invalid matter_server_env_vars entry: ${env_entry} (expected KEY=VALUE)"
-      fi
+    env_name="${env_entry%%=*}"
+    env_value="${env_entry#*=}"
 
-      env_name="${env_entry%%=*}"
-      env_value="${env_entry#*=}"
+    if ! [[ "${env_name}" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+      bashio::exit.nok "Invalid environment variable name in matter_server_env_vars: ${env_name}"
+    fi
 
-      if ! [[ "${env_name}" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
-        bashio::exit.nok "Invalid environment variable name in matter_server_env_vars: ${env_name}"
-      fi
+    export "${env_name}=${env_value}"
+    bashio::log.info "Exported Matter Server environment variable: ${env_name}"
+  done
+fi
 
-      export "${env_name}=${env_value}"
-      bashio::log.info "Exported Matter Server environment variable: ${env_name}"
-    done
-  fi
-else
-  # Non-beta mode: Use Python Matter Server
-  bashio::log.info "Using Python Matter Server"
-
-  # SDK log level is only supported by the Python server
-  extra_args+=('--log-level-sdk' "$(bashio::string.lower "$(bashio::config log_level_sdk error)")")
-
-  # PAA root cert dir is only supported by the Python server
-  extra_args+=('--paa-root-cert-dir' "/data/credentials")
-
-  # Python server uses --ota-provider-dir independently of --enable-test-net-dcl
-  extra_args+=('--ota-provider-dir' "/config/updates")
-
-  if bashio::config.has_value "matter_server_version"; then
-    matter_server_version=$(bashio::config 'matter_server_version')
-    bashio::log.info "Installing Python Matter Server ${matter_server_version}"
-    # shellcheck disable=SC2102
-    pip3 install --pre python-matter-server[server]=="${matter_server_version}"
-  fi
-
-  if bashio::config.has_value "matter_sdk_wheels_version"; then
-    chip_version=$(bashio::config 'matter_sdk_wheels_version')
-    bashio::log.info "Installing Matter SDK ${chip_version}"
-    pip3 install --pre --no-dependencies \
-      home-assistant-chip-clusters=="${chip_version}" \
-      home-assistant-chip-core=="${chip_version}"
-  fi
+# Remove leftover migration backup data from a former beta Matter Server.
+if [ -d /data/.migrations ]; then
+  bashio::log.info "Deleting former migration backup data ... this can take some time ... be patient"
+  rm -rf /data/.migrations
 fi
 
 # Bind to internal hassio network only unless user requests to expose
@@ -120,6 +103,7 @@ fi
 
 if bashio::config.true "enable_test_net_dcl"; then
     extra_args+=('--enable-test-net-dcl')
+    extra_args+=('--ota-provider-dir' "/config/updates")
 fi
 
 primary_interface="$(bashio::api.supervisor 'GET' '/network/info' '' 'first(.interfaces[] | select (.primary == true)) .interface')"
@@ -170,10 +154,4 @@ matter_server_args+=(
   ${extra_args[@]}
 )
 
-if [[ "${use_js_server}" == "true" ]]; then
-    # Start JavaScript Matter Server
-    exec node --enable-source-maps /opt/matterjs/node_modules/matter-server/dist/esm/MatterServer.js "${matter_server_args[@]}"
-else
-    # Start Python Matter Server
-    exec /usr/local/bin/matter-server "${matter_server_args[@]}"
-fi
+exec node --enable-source-maps /app/node_modules/matter-server/dist/esm/MatterServer.js "${matter_server_args[@]}"

--- a/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
+++ b/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
@@ -15,8 +15,19 @@ declare env_entry
 declare env_name
 declare env_value
 declare env_vars_count
+declare options
 matter_server_args=()
 extra_args=()
+
+# Delete options removed in 9.0.0 so the Supervisor does not warn that they are
+# no longer in the schema.
+options=$(bashio::addon.options)
+for old_key in log_level_sdk matter_sdk_wheels_version; do
+  if bashio::jq.exists "${options}" ".${old_key}"; then
+    bashio::log.info "Removing obsolete '${old_key}' option"
+    bashio::addon.option "${old_key}"
+  fi
+done
 
 if ! bashio::config.exists log_level; then
   bashio::log.magenta 'No log_level set in config, fallback to info'

--- a/matter_server/translations/en.yaml
+++ b/matter_server/translations/en.yaml
@@ -52,9 +52,9 @@ configuration:
     name: Matter Server version
     description: >-
       Install a specific "matter-server" version from npm (takes precedence over
-      the Beta flag). Only "0.x.y" or "1.x.y" values are used; values with a
-      major version >= 3 are ignored as leftover Python Matter Server versions;
-      unless the Beta flag is set, the bundled version is used instead. WARNING:
+      the Beta flag). Values with a major version >= 3 are ignored as leftover
+      Python Matter Server versions; unless the Beta flag is set, the bundled
+      version is used instead. WARNING:
       An older version might have an incompatible storage format! Use this
       feature with caution! Make sure you have a recent backup of the app!
 network:

--- a/matter_server/translations/en.yaml
+++ b/matter_server/translations/en.yaml
@@ -18,7 +18,7 @@ configuration:
   bluetooth_adapter_id:
     name: Bluetooth Adapter ID (deprecated)
     description: >-
-      DEPRECATED: Use the `Enable BLE proxy` option instead, which lets Home
+      DEPRECATED: Use the "Enable BLE proxy" option instead, which lets Home
       Assistant drive BLE commissioning through its own Bluetooth stack
       (including ESPHome BLE proxies). This option still works for now.
       BlueZ Bluetooth Adapter Controller ID used by the Matter Server. This is
@@ -34,25 +34,25 @@ configuration:
       own bluetooth stack (including ESPHome BLE proxies). To actually use
       the BLE proxy you need Home Assistant 2026.06 or later (where the
       Matter integration's proxy support landed). Mutually exclusive with
-      `Bluetooth Adapter ID` — the local adapter option is ignored with a
+      "Bluetooth Adapter ID" — the local adapter option is ignored with a
       warning when this is on.
   matter_server_env_vars:
     name: Matter Server environment variables
     description: >-
       Additional environment variables to export before starting Matter Server.
-      Provide one entry per list item in `KEY=VALUE` format.
+      Provide one entry per list item in "KEY=VALUE" format.
   matter_server_args:
     name: Extra Matter Server arguments
     description: >-
       This allows to pass additional command line arguments to the Matter
-      Server. Use `--help` to get a list of possible arguments. Note that
+      Server. Use "--help" to get a list of possible arguments. Note that
       arguments are also added by the startup script controlled by other
       app options.
   matter_server_version:
     name: Matter Server version
     description: >-
-      Install a specific `matter-server` version from npm (takes precedence over
-      the Beta flag). Only `0.x.y` or `1.x.y` values are used; values with a
+      Install a specific "matter-server" version from npm (takes precedence over
+      the Beta flag). Only "0.x.y" or "1.x.y" values are used; values with a
       major version >= 3 are ignored as leftover Python Matter Server versions;
       unless the Beta flag is set, the bundled version is used instead. WARNING:
       An older version might have an incompatible storage format! Use this

--- a/matter_server/translations/en.yaml
+++ b/matter_server/translations/en.yaml
@@ -19,7 +19,7 @@ configuration:
     name: Bluetooth Adapter ID (deprecated)
     description: >-
       DEPRECATED: Use the `Enable BLE proxy` option instead, which lets Home
-      Assistant drive BLE commissioning through its own bluetooth stack
+      Assistant drive BLE commissioning through its own Bluetooth stack
       (including ESPHome BLE proxies). This option still works for now.
       BlueZ Bluetooth Adapter Controller ID used by the Matter Server. This is
       required if local commissioning via Bluetooth is used. Note: Using the

--- a/matter_server/translations/en.yaml
+++ b/matter_server/translations/en.yaml
@@ -3,15 +3,12 @@ configuration:
   log_level:
     name: Matter Server Log Level
     description: Logging level of the Matter Server component.
-  log_level_sdk:
-    name: Matter SDK Log Level
-    description: Logging level of the Matter SDK (Python only).
   beta:
     name: Use the latest beta version
     description: >-
-      Installs the latest beta of the Matter Server (matter.js based). It is
-      highly recommended to create a backup before starting the app with
-      this flag enabled!
+      Installs the latest beta of the Matter Server (matter.js based) from npm
+      on top of the bundled version. It is highly recommended to create a backup
+      before starting the app with this flag enabled!
   enable_test_net_dcl:
     name: Enable test-net DCL usage.
     description: >-
@@ -19,8 +16,11 @@ configuration:
       information from test-net DCL. This is meant for development and testing
       purposes.
   bluetooth_adapter_id:
-    name: Bluetooth Adapter ID
+    name: Bluetooth Adapter ID (deprecated)
     description: >-
+      DEPRECATED: Use the `Enable BLE proxy` option instead, which lets Home
+      Assistant drive BLE commissioning through its own bluetooth stack
+      (including ESPHome BLE proxies). This option still works for now.
       BlueZ Bluetooth Adapter Controller ID used by the Matter Server. This is
       required if local commissioning via Bluetooth is used. Note: Using the
       Home Assistant Companion app commissioning method is recommended as it is
@@ -33,16 +33,14 @@ configuration:
       Matter integration can drive BLE commissioning through Home Assistant's
       own bluetooth stack (including ESPHome BLE proxies). To actually use
       the BLE proxy you need Home Assistant 2026.06 or later (where the
-      Matter integration's proxy support landed) and the Beta Matter Server
-      (>= 0.7.1, JavaScript-based). Mutually exclusive with `Bluetooth
-      Adapter ID` — the local adapter option is ignored with a warning when
-      this is on.
+      Matter integration's proxy support landed). Mutually exclusive with
+      `Bluetooth Adapter ID` — the local adapter option is ignored with a
+      warning when this is on.
   matter_server_env_vars:
     name: Matter Server environment variables
     description: >-
-      Additional environment variables to export before starting Matter Server
-      (only relevant when using the JavaScript server in Beta mode). Provide
-      one entry per list item in `KEY=VALUE` format.
+      Additional environment variables to export before starting Matter Server.
+      Provide one entry per list item in `KEY=VALUE` format.
   matter_server_args:
     name: Extra Matter Server arguments
     description: >-
@@ -53,17 +51,11 @@ configuration:
   matter_server_version:
     name: Matter Server version
     description: >-
-      Install a custom Matter Server version. In Python mode, this value is
-      used for python-matter-server. In JavaScript/Beta mode, only versions in
-      `0.x.y` or `1.x.y` format are used; other values are ignored and latest
-      is installed. WARNING: An older version might have an incompatible storage
-      format! Use this feature with caution! Make sure you have a recent backup
-      of the app!
-  matter_sdk_wheels_version:
-    name: Matter SDK wheels version
-    description: >-
-      Install custom Python Matter SDK wheels version (not applicable when
-      using Beta flag). NOTE: The API might not be compatible with the Python
-      Matter server.
+      Install a specific `matter-server` version from npm (takes precedence over
+      the Beta flag). Only `0.x.y` or `1.x.y` values are used; values with a
+      major version >= 3 are ignored as leftover Python Matter Server versions;
+      unless the Beta flag is set, the bundled version is used instead. WARNING:
+      An older version might have an incompatible storage format! Use this
+      feature with caution! Make sure you have a recent backup of the app!
 network:
   5580/tcp: Matter Server WebSocket server port.


### PR DESCRIPTION
## Summary

Promotes the Matter Server add-on to **9.0.0**, dropping the Python Matter Server entirely and building on the official matter.js server image.

- Base image → `ghcr.io/matter-js/matterjs-server:0.8.0` (node 24, `matter-server` pre-installed); the manual Node.js install and build toolchain are removed from the image.
- The bundled server runs as-is. The **Beta** flag installs `matter-server@latest` from npm; `matter_server_version` pins a specific npm version (takes precedence over Beta). A major version >= 3 is ignored as a leftover Python version and the bundled server is used.
- npm installs happen in-place in `/app` with the build toolchain installed at runtime only when needed; any apt/npm failure logs a warning and starts the bundled server instead (no hard fail).
- Drop python-only CLI args (`--log-level-sdk`, `--paa-root-cert-dir`) and options (`log_level_sdk`, `matter_sdk_wheels_version`).
- `log_level` schema updated to the matter.js levels (`debug|info|notice|warn|error|fatal`); legacy `verbose|warning|critical` still accepted and mapped.
- Delete a former beta `.migrations` backup directory on startup.
- Keeps the 8.5.0 `ble_proxy` option and `matter_server_env_vars`; `--ota-provider-dir` stays conditional on `enable_test_net_dcl`.
- Add `MIGRATION_FAQ.md`; update DOCS/CHANGELOG/RELEASE.

## Verification

- `shellcheck` clean on `run`; `config.yaml` / `build.yaml` valid YAML.
- 0.8.0 image config confirmed: entrypoint path, `/app` workdir, and `USER 1000` (hence the `USER root` override) all match the run script.
- Live build / commission / migration test is the maintainer gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Matter.js-based Matter Server now runs by default with automatic data migration (slower first start), plus experimental BLE proxy commissioning support
  * Web UI dashboard adds Thread and Wi‑Fi network visualizations

* **Documentation**
  * Added a migration FAQ and stronger full-backup/first-start guidance
  * Updated configuration, version-selection, and Beta/npm fallback behavior documentation and option text

* **Chores**
  * Updated the add-on to 9.0.0, refreshed server image targets, and adjusted container startup/log/config options (Python-specific items removed)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

closes #4627