### PR TITLE
ssh: update CLI to v5.2.0

### DIFF
--- a/ssh/CHANGELOG.md
+++ b/ssh/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 10.3.0
+
+- Update Home Assistant CLI to 5.2.0
+
 ## 10.2.0
 
 - Update Home Assistant CLI to 5.1.0

--- a/ssh/build.yaml
+++ b/ssh/build.yaml
@@ -3,4 +3,4 @@ build_from:
   aarch64: ghcr.io/home-assistant/aarch64-base:3.23-2026.04.0
   amd64: ghcr.io/home-assistant/amd64-base:3.23-2026.04.0
 args:
-  CLI_VERSION: 5.1.0
+  CLI_VERSION: 5.2.0

--- a/ssh/config.yaml
+++ b/ssh/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 10.2.0
+version: 10.3.0
 slug: ssh
 name: Terminal & SSH
 description: Allow logging in remotely to Home Assistant using SSH


### PR DESCRIPTION
CLI:
- https://github.com/home-assistant/cli/releases/tag/5.2.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 10.3.0 with updated Home Assistant CLI to version 5.2.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->