### PR TITLE
Bump to wyoming-faster-whisper 3.2.0

### DIFF
--- a/whisper/CHANGELOG.md
+++ b/whisper/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 3.2.0
+
+- Fix transformers language
+- Add initial prompt to transformers
+- Add `--whisper-task` which can be set to "translate" instead of "transcribe" (`@M4TH1EU`)
+- Add `--sherpa-streaming` to prefer streaming models (`@pkrahmer`)
+- Bump `onnx-asr` to 0.11.0 (supports `istupakov/canary-1b-v2-onnx`)
+
 ## 3.1.0
 
 - Fix model selection for language

--- a/whisper/DOCS.md
+++ b/whisper/DOCS.md
@@ -121,6 +121,52 @@ This overrides the default English model (parakeet) with a faster but less accur
 Whisper model files can be large, so they are automatically excluded from backups and re-downloaded on restore for remote models.
 After restoring a backup with a local custom Whisper model, manually copy your model directory again.
 
+## Recommendations
+
+A few starting points by language and priority. With `stt_library` = "auto" the
+add-on selects a backend/model based on your `language` and hardware; for English
+this is the parakeet sherpa model, and `sherpa_streaming` swaps it for a faster
+streaming variant.
+
+Two tips for non-English use:
+
+- Set `language` to your explicit language code. Leaving it as "auto" works but is
+  **much** slower, since the model has to detect the language on every request.
+- To get English text out of non-English speech, set `whisper_task` = "translate".
+  This applies to the Whisper backends (not parakeet/sherpa).
+
+- English
+    - Balanced
+        - `language` = "en"
+        - `model` = "auto"
+        - `stt_library` = "auto"
+        - `sherpa_streaming` = false
+    - Fast
+        - `language` = "en"
+        - `model` = "auto"
+        - `stt_library` = "auto"
+        - `sherpa_streaming` = true
+    - Accurate
+        - `language` = "en"
+        - `model` = "custom"
+        - `stt_library` = "onnx-asr"
+        - `custom_model` = "istupakov/canary-1b-v2-onnx"
+- Non-English
+    - Balanced
+        - `language` = your language code (e.g. "de", "fr")
+        - `model` = "auto"
+        - `stt_library` = "auto"
+    - Fast
+        - `language` = your language code
+        - `model` = "base-int8" (or "small-int8" if your CPU allows)
+        - `stt_library` = "faster-whisper"
+    - Accurate
+        - `language` = your language code
+        - `model` = "custom"
+        - `stt_library` = "onnx-asr"
+        - `custom_model` = "istupakov/canary-1b-v2-onnx"
+          (~25 European languages; needs a capable CPU, not a Raspberry Pi)
+
 ## Support
 
 Got questions?

--- a/whisper/DOCS.md
+++ b/whisper/DOCS.md
@@ -36,7 +36,7 @@ If you select "auto", the model will run **much** slower but will auto-detect th
 
 Whisper model that will be used for transcription. Choose `custom` to use the model name in `custom_model`, which may be a HuggingFace model ID like "Systran/faster-distil-whisper-small.en".
 
-The default model is `auto`, which selects `tiny-int8` for ARM devices like the Raspberry Pi 4 and `base-int8` otherwise.
+The default model is "auto", which selects `tiny-int8` for ARM devices like the Raspberry Pi 4 and `base-int8` otherwise.
 Compressed models (`int8`) are slightly less accurate than their counterparts, but smaller and faster. [Distilled](https://github.com/huggingface/distil-whisper) models are not compressed, but are faster and smaller than their non-distilled counterparts.
 
 Available models:
@@ -77,12 +77,7 @@ Then, set the `custom_model` path to:
 
 ### Option: `custom_model_type`
 
-Either `faster-whisper` (the default) or `transformers`.
-
-When set to `transformers`, the `custom_model` option must be a HuggingFace transformers-based Whisper model like "openai/whisper-tiny.en".
-
-**Note:** Initial prompt is currently not supported for transformers-based models.
-
+Determines which speech-to-text backend to use for `custom_model` if `stt_library` is set to "auto".
 
 ### Option: `beam_size`
 
@@ -101,11 +96,25 @@ See [this discussion](https://github.com/openai/whisper/discussions/963) for an 
 Speech-to-text backend library to use:
 
 - `auto` - select the best backend based on language/hardware
-- `faster-whisper` - force faster whisper backend
-- `sherpa` - force sherpa onnx backend (parakeet model only)
-- `transformers` - force HuggingFace transformers backend
+- `faster-whisper` - force [faster whisper][faster-whisper] backend
+- `sherpa` - force [sherpa onnx][sherpa-onnx] backend (parakeet model only)
+- `transformers` - force [HuggingFace transformers][transformers] backend
+- `onnx-asr` - force [onnx asr][onnx-asr] backend
 
-**Note**: When `custom_model` is set, then `custom_model_type` will override `stt_library`.
+**Note**: When `custom_model` is set, then `custom_model_type` will override `stt_library` when set to "auto".
+
+### Option: `whisper_task`
+
+Task to perform with the model:
+
+- `transcribe` - transcribe audio in the spoken language (default)
+- `translate` - translate the spoken audio into English
+
+### Option: `sherpa_streaming`
+
+Use streaming model with `sherpa` backend.
+
+This overrides the default English model (parakeet) with a faster but less accurate streaming model (sherpa-onnx-streaming-zipformer-en-2023-06-26).
 
 ## Backups
 
@@ -129,3 +138,7 @@ In case you've found an bug, please [open an issue on our GitHub][issue].
 [issue]: https://github.com/home-assistant/addons/issues
 [reddit]: https://reddit.com/r/homeassistant
 [repository]: https://github.com/hassio-addons/repository
+[transformers]: https://huggingface.co/docs/transformers
+[faster-whisper]: https://github.com/SYSTRAN/faster-whisper
+[sherpa-onnx]: https://github.com/k2-fsa/sherpa-onnx
+[onnx-asr]: https://github.com/istupakov/onnx-asr

--- a/whisper/Dockerfile
+++ b/whisper/Dockerfile
@@ -19,10 +19,10 @@ RUN \
         setuptools \
         wheel \
     && pip3 install --no-cache-dir \
-        "wyoming[zeroconf]==1.8.0" \
+        "wyoming[zeroconf]==1.9.0" \
         "wyoming-faster-whisper[sherpa] @ https://github.com/rhasspy/wyoming-faster-whisper/archive/refs/tags/v${WYOMING_WHISPER_VERSION}.tar.gz" \
         'transformers==4.52.4' \
-        'onnx-asr[cpu,hub]==0.7.0' \
+        'onnx-asr[cpu,hub]==0.11.0' \
     \
     && pip3 install --no-cache-dir \
         --index-url 'https://download.pytorch.org/whl/cpu' \

--- a/whisper/build.yaml
+++ b/whisper/build.yaml
@@ -3,4 +3,4 @@ build_from:
   amd64: ghcr.io/home-assistant/amd64-base-debian:bookworm
   aarch64: ghcr.io/home-assistant/aarch64-base-debian:bookworm
 args:
-  WYOMING_WHISPER_VERSION: 3.1.0
+  WYOMING_WHISPER_VERSION: 3.2.0

--- a/whisper/config.yaml
+++ b/whisper/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 3.1.0
+version: 3.2.0
 slug: whisper
 name: Whisper
 description: Speech-to-text with Whisper
@@ -20,19 +20,24 @@ options:
   beam_size: 0
   custom_model_type: "faster-whisper"
   stt_library: "auto"
+  whisper_task: "transcribe"
+  sherpa_streaming: false
   debug_logging: false
 schema:
   model: |
     list(auto|tiny-int8|tiny|tiny.en|base-int8|base|base.en|small-int8|distil-small.en|small|small.en|distil-medium.en|medium-int8|medium|medium.en|large|large-v1|distil-large-v2|large-v2|distil-large-v3|large-v3|turbo|custom)
   stt_library: |
-    list(auto|faster-whisper|sherpa|transformers)
+    list(auto|faster-whisper|sherpa|transformers|onnx-asr)
   custom_model: str?
   custom_model_type: |
-    list(faster-whisper|transformers)
+    list(faster-whisper|sherpa|transformers|onnx-asr)
   language: |
     list(auto|af|am|ar|as|az|ba|be|bg|bn|bo|br|bs|ca|cs|cy|da|de|el|en|es|et|eu|fa|fi|fo|fr|gl|gu|ha|haw|he|hi|hr|ht|hu|hy|id|is|it|ja|jw|ka|kk|km|kn|ko|la|lb|ln|lo|lt|lv|mg|mi|mk|ml|mn|mr|ms|mt|my|ne|nl|nn|no|oc|pa|pl|ps|pt|ro|ru|sa|sd|si|sk|sl|sn|so|sq|sr|su|sv|sw|ta|te|tg|th|tk|tl|tr|tt|uk|ur|uz|vi|yi|yo|zh|yue)
   beam_size: int
   initial_prompt: str?
+  whisper_task: |
+    list(transcribe|translate)
+  sherpa_streaming: bool
   debug_logging: bool
 ports:
   "10300/tcp": null

--- a/whisper/rootfs/etc/s6-overlay/s6-rc.d/whisper/run
+++ b/whisper/rootfs/etc/s6-overlay/s6-rc.d/whisper/run
@@ -19,12 +19,19 @@ if [ "${model}" = 'custom' ]; then
     if [ -z "${model}" ]; then
         bashio::exit.nok "Custom model is not set"
     fi
-    stt_library="$(bashio::config 'custom_model_type')"
+    if [ "${stt_library}" = 'auto' ]; then
+        # Need to know what kind of custom model
+        stt_library="$(bashio::config 'custom_model_type')"
+    fi
 elif [ "${model}" != 'auto' ]; then
     if [ "${stt_library}" = 'auto' ]; then
         # Default to faster whisper if model is selected
         stt_library='faster-whisper'
     fi
+fi
+
+if bashio::config.true 'sherpa_streaming'; then
+    flags+=('--sherpa-streaming')
 fi
 
 if bashio::config.true 'debug_logging'; then
@@ -40,5 +47,6 @@ exec python3 -m wyoming_faster_whisper \
     --beam-size "$(bashio::config 'beam_size')" \
     --language "$(bashio::config 'language')" \
     --initial-prompt "$(bashio::config 'initial_prompt')" \
+    --whisper-task "$(bashio::config 'whisper_task')" \
     --data-dir /data \
     --download-dir /data ${flags[@]}

--- a/whisper/translations/en.yaml
+++ b/whisper/translations/en.yaml
@@ -13,12 +13,11 @@ configuration:
   model:
     name: Model
     description: |
-      Whisper model that will be used for transcription (faster-whisper only).
+      Whisper model that will be used for transcription.
 
-      The default model is `tiny-int8`, a compressed version of the smallest
-      Whisper model which is able to run on a Raspberry Pi 4. Compressed models
-      (`int8`) are slightly less accurate than their counterparts, but smaller
-      and faster.
+      The default `auto` selects `tiny-int8` for ARM devices like the Raspberry
+      Pi 4 and `base-int8` otherwise. Compressed models (`int8`) are slightly
+      less accurate than their counterparts, but smaller and faster.
   custom_model:
     name: Custom model
     description: |
@@ -32,13 +31,8 @@ configuration:
   custom_model_type:
     name: Custom model type
     description: |
-      Type of Whisper model expected from custom model.
-
-      The default is 'faster-whisper' which requires a CTranslate2-converted
-      Whisper model. If set to 'transformers', a HuggingFace transformers-based
-      Whisper model may be used.
-
-      Overrides `stt_library` when `custom_model` is set.
+      Speech-to-text backend to use for `custom_model` if `stt_library` is set
+      to auto.
   initial_prompt:
     name: Initial prompt
     description: >-
@@ -53,6 +47,20 @@ configuration:
       language/hardware.
 
       Overridden by `custom_model_type` when `custom_model` is set.
+  whisper_task:
+    name: Whisper task
+    description: >-
+      Task to perform with the model.
+
+      The default `transcribe` transcribes audio in the spoken language, while
+      `translate` translates the spoken audio into English.
+  sherpa_streaming:
+    name: Sherpa streaming
+    description: >-
+      Use streaming model with sherpa backend.
+
+      This overrides the default English model with a faster but less accurate
+      streaming model.
   debug_logging:
     name: Debug logging
     description: >-


### PR DESCRIPTION
https://github.com/rhasspy/wyoming-faster-whisper/compare/v3.1.0...v3.2.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `sherpa_streaming` option to prefer a streaming Sherpa model.
  * Added `whisper_task` to choose between `transcribe` and `translate`.
  * Extended speech-to-text backend options to include `onnx-asr`.

* **Documentation**
  * Refined configuration guidance with clearer `custom_model_type`, `whisper_task`, and `sherpa_streaming` explanations, plus updated examples and backend links.

* **Bug Fixes**
  * Improved `custom` model handling so `stt_library` is only overridden when `stt_library` is set to `auto`.

* **Chores**
  * Updated dependency pins and bumped add-on version to 3.2.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->