### PR TITLE
Create vlc user and run VLC under the new user.

### DIFF
--- a/vlc/Dockerfile
+++ b/vlc/Dockerfile
@@ -10,7 +10,7 @@ RUN \
         nginx \
         pwgen \
         vlc \
-    && sed -i 's/geteuid/getppid/' /usr/bin/vlc \
+    && addgroup -S vlc && adduser -D -D -G vlc vlc # create vlc user to run vlc without patching vlc to run as root \
     && sed -i '197s#.*#    dir = dir == undefined ? "file:///media" : dir;#' /usr/share/vlc/lua/http/js/controllers.js
         
 WORKDIR /

--- a/vlc/rootfs/etc/s6-overlay/s6-rc.d/vlc/run
+++ b/vlc/rootfs/etc/s6-overlay/s6-rc.d/vlc/run
@@ -19,5 +19,5 @@ bashio::log.info "PulseAudio socket available, starting VLC"
 # Send out discovery information to Home Assistant
 /etc/s6-overlay/scripts/vlc-discovery &
 
-# Run daemon
-exec cvlc -I http --no-dbus --extraintf telnet --http-host 127.0.0.1 --http-password "INGRESS" --telnet-password "${PASSWORD}" --aout=pulse
+# Run daemon as vlc user
+su -c "exec cvlc -I http --no-dbus --extraintf telnet --http-host 127.0.0.1 --http-password \"INGRESS\" --telnet-password \"${PASSWORD}\" --aout=pulse" vlc


### PR DESCRIPTION
Current patching of the VLC binary in DockerFile poses a security risk.

VLC does not run under the root user because the source code explicitly contains a hardcoded security check that blocks execution if your Effective User ID

The Core Reason: Security Against Exploits

Media players process complex, untrusted, third-party media files and network streams. Historically, codecs and media demuxers have been vulnerable to buffer overflow and remote code execution vulnerabilities.

If an attacker crafts a malicious video file or network stream that exploits a bug in VLC while it runs as root, the attacker immediately gains full root control over the entire system. Because Docker containers run as root by default, a compromise inside the container drastically lowers the barrier for a container escape to compromise the underlying host system. To prevent this massive security risk, the VideoLAN developers chose to completely abort application startup if it detects a root environment.