### PR TITLE
Create vlc user and run vlc under the new user.

### DIFF
--- a/vlc/Dockerfile
+++ b/vlc/Dockerfile
@@ -4,7 +4,6 @@ FROM ${BUILD_FROM}
 # Install VLC
 WORKDIR /usr/src
 
-# create vlc user to run vlc without patching vlc to run as root
 RUN \
     set -x \
     && apk add --no-cache \
@@ -12,7 +11,7 @@ RUN \
         nginx \
         pwgen \
         vlc \
-    && addgroup -S vlc && adduser -D -D -G vlc vlc \
+    && addgroup vlc && adduser -D -D -G vlc vlc \
     && sed -i '197s#.*#    dir = dir == undefined ? "file:///media" : dir;#' /usr/share/vlc/lua/http/js/controllers.js
         
 WORKDIR /

--- a/vlc/Dockerfile
+++ b/vlc/Dockerfile
@@ -10,7 +10,7 @@ RUN \
         nginx \
         pwgen \
         vlc \
-    && sed -i 's/geteuid/getppid/' /usr/bin/vlc \
+    && addgroup -S vlc && adduser -D -D -G vlc vlc # create vlc user to run vlc without patching vlc to run as root \
     && sed -i '197s#.*#    dir = dir == undefined ? "file:///media" : dir;#' /usr/share/vlc/lua/http/js/controllers.js
         
 WORKDIR /

--- a/vlc/Dockerfile
+++ b/vlc/Dockerfile
@@ -3,6 +3,8 @@ FROM ${BUILD_FROM}
 
 # Install VLC
 WORKDIR /usr/src
+
+# create vlc user to run vlc without patching vlc to run as root
 RUN \
     set -x \
     && apk add --no-cache \
@@ -10,7 +12,7 @@ RUN \
         nginx \
         pwgen \
         vlc \
-    && addgroup -S vlc && adduser -D -D -G vlc vlc # create vlc user to run vlc without patching vlc to run as root \
+    && addgroup -S vlc && adduser -D -D -G vlc vlc \
     && sed -i '197s#.*#    dir = dir == undefined ? "file:///media" : dir;#' /usr/share/vlc/lua/http/js/controllers.js
         
 WORKDIR /

--- a/vlc/Dockerfile
+++ b/vlc/Dockerfile
@@ -11,7 +11,7 @@ RUN \
         nginx \
         pwgen \
         vlc \
-    && addgroup vlc && adduser -D -D -G vlc vlc \
+    && addgroup vlc && adduser -D -G vlc vlc \
     && sed -i '197s#.*#    dir = dir == undefined ? "file:///media" : dir;#' /usr/share/vlc/lua/http/js/controllers.js
         
 WORKDIR /

--- a/vlc/rootfs/etc/s6-overlay/s6-rc.d/vlc/run
+++ b/vlc/rootfs/etc/s6-overlay/s6-rc.d/vlc/run
@@ -19,5 +19,5 @@ bashio::log.info "PulseAudio socket available, starting VLC"
 # Send out discovery information to Home Assistant
 /etc/s6-overlay/scripts/vlc-discovery &
 
-# Run daemon
-exec cvlc -I http --no-dbus --extraintf telnet --http-host 127.0.0.1 --http-password "INGRESS" --telnet-password "${PASSWORD}" --aout=pulse
+# Run daemon as vlc user
+su -c "exec cvlc -I http --no-dbus --extraintf telnet --http-host 127.0.0.1 --http-password \"INGRESS\" --telnet-password \"${PASSWORD}\" --aout=pulse" vlc

--- a/vlc/rootfs/etc/s6-overlay/s6-rc.d/vlc/run
+++ b/vlc/rootfs/etc/s6-overlay/s6-rc.d/vlc/run
@@ -20,4 +20,4 @@ bashio::log.info "PulseAudio socket available, starting VLC"
 /etc/s6-overlay/scripts/vlc-discovery &
 
 # Run daemon as vlc user
-su -c "exec cvlc -I http --no-dbus --extraintf telnet --http-host 127.0.0.1 --http-password \"INGRESS\" --telnet-password \"${PASSWORD}\" --aout=pulse" vlc
+exec su -c "cvlc -I http --no-dbus --extraintf telnet --http-host 127.0.0.1 --http-password \"INGRESS\" --telnet-password \"${PASSWORD}\" --aout=pulse" vlc

--- a/vlc/rootfs/etc/s6-overlay/s6-rc.d/vlc/run
+++ b/vlc/rootfs/etc/s6-overlay/s6-rc.d/vlc/run
@@ -19,5 +19,8 @@ bashio::log.info "PulseAudio socket available, starting VLC"
 # Send out discovery information to Home Assistant
 /etc/s6-overlay/scripts/vlc-discovery &
 
+# set the home directory environment variable, if not set, s6-setuidgid will try to use the root home
+export HOME=/home/vlc
+
 # Run daemon as vlc user
-exec su -c "cvlc -I http --no-dbus --extraintf telnet --http-host 127.0.0.1 --http-password \"INGRESS\" --telnet-password \"${PASSWORD}\" --aout=pulse" vlc
+exec s6-setuidgid vlc cvlc -I http --no-dbus --extraintf telnet --http-host 127.0.0.1 --http-password "INGRESS" --telnet-password "${PASSWORD}" --aout=pulse


### PR DESCRIPTION
Current patching of the vlc binary in DockerFile poses a security risk.

VLC does not run under the root user because the source code explicitly contains a hardcoded security check that blocks execution if your Effective User ID

The Core Reason: Security Against Exploits

Media players process complex, untrusted, third-party media files and network streams. Historically, codecs and media demuxers have been vulnerable to buffer overflow and remote code execution vulnerabilities.

If an attacker crafts a malicious video file or network stream that exploits a bug in VLC while it runs as root, the attacker immediately gains full root control over the entire system. Because Docker containers run as root by default, a compromise inside the container drastically lowers the barrier for a container escape to compromise the underlying host system. To prevent this massive security risk, the VideoLAN developers chose to completely abort application startup if it detects a root environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved VLC container security by running the media daemon as a dedicated non-root user.
  * Updated service startup to set the runtime home directory and launch `cvlc` with user switching.
  * Preserved existing VLC runtime behavior, including HTTP/telnet settings, password handling, and audio output configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->