### PR TITLE
Matter: Ensures matter server is reachable on localhost for health check

### DIFF
--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 9.0.1
+
+- Fixes Heath check with default port settings
+
 ## 9.0.0
 
 - **The Matter Server now runs on matter.js. Expect the first start to take noticeably longer while your data migrates automatically — this is normal.**

--- a/matter_server/config.yaml
+++ b/matter_server/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 9.0.0
+version: 9.0.1
 breaking_versions: [9.0.0]
 slug: matter_server
 name: Matter Server

--- a/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
+++ b/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
@@ -110,6 +110,7 @@ server_port="$(bashio::addon.port 5580)"
 if ! bashio::var.has_value "${server_port}"; then
     server_port=5580
     extra_args+=('--listen-address' "$(bashio::addon.ip_address)")
+    extra_args+=('--listen-address' '127.0.0.1')  # so the base-image healthcheck (localhost) reaches us
 fi
 
 if bashio::config.true "enable_test_net_dcl"; then


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## v9.0.1 Release

* **Bug Fixes**
  * Resolved health check connectivity issues for Matter Server when using default port configuration. The server now properly binds to localhost instead of all interfaces, ensuring health checks can successfully reach and monitor the service. This improves reliability for standard deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->