### PR TITLE
Add Changelog note for watchdog

### DIFF
--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - **The Matter Server now runs on matter.js. Expect the first start to take noticeably longer while your data migrates automatically — this is normal.**
   - **⚠️ It is recommended to take a backup before updating.**
+  - **⚠️ If you have enabled the watchdog in HA, please disable for the initial migration to prevent restarts.**
   - The new matter server needs roughly twice the RAM of the old one, so please check free resources before updating.
   - The Python Matter Server has been replaced with a matter.js-based implementation (v1.1.0); your data migrates automatically with no action required
   - Later starts are much faster

--- a/matter_server/MIGRATION_FAQ.md
+++ b/matter_server/MIGRATION_FAQ.md
@@ -8,6 +8,8 @@ Version 9.0 of the Matter App is the first release for all Home Assistant users 
 ## Should I do a backup before installing the new version?
 Yes. Make a backup before installing the new version. The new version migrates your current data automatically, but a backup lets you roll back if anything goes wrong. Tick the "Create backup" checkbox when you update the server.
 
+Additionally, if you have enabled the watchdog feature in Home Assistant and have a higher number of Matter nodes, please disable the watchdog for the initial migration to prevent issues or mid-migration restarts.
+
 ## What happens on the first start of the new version?
 The first start of the new version **automatically migrates your current data**. This requires no manual intervention but needs some time to complete. **Wait for the migration to finish** — the log shows its progress.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added additional migration guidance for v9.0.0: if the Home Assistant watchdog is enabled (especially with multiple Matter nodes), disable it before starting the migration to prevent unwanted restarts during the process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->