### PR TITLE
Improve Matter server healthcheck timings

### DIFF
--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -2,12 +2,12 @@
 
 ## 9.0.2
 
-- **⚠️ Please also consider the release notes for 9.0.0 wne upgrading from 8.x.**
+- **⚠️ Please also consider the release notes for 9.0.0 when upgrading from 8.x.**
 - Update Matter Server to 1.1.1 with increased Health check timings
 
 ## 9.0.1
 
-- **⚠️ Please also consider the release notes for 9.0.0 wne upgrading from 8.x.**
+- **⚠️ Please also consider the release notes for 9.0.0 when upgrading from 8.x.**
 - Fixes Heath check with default port settings
 
 ## 9.0.0

--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -1,7 +1,13 @@
 # Changelog
 
+## 9.0.2
+
+- **⚠️ Please also consider the release notes for 9.0.0 wne upgrading from 8.x.**
+- Update Matter Server to 1.1.1 with increased Health check timings
+
 ## 9.0.1
 
+- **⚠️ Please also consider the release notes for 9.0.0 wne upgrading from 8.x.**
 - Fixes Heath check with default port settings
 
 ## 9.0.0

--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -2,12 +2,12 @@
 
 ## 9.0.2
 
-- **⚠️ Please also consider the release notes for 9.0.0 when upgrading from 8.x.**
+- **⚠️ Please also consider the [release notes for 9.0.0](#900) when upgrading from 8.x.**
 - Update Matter Server to 1.1.1 with increased Health check timings
 
 ## 9.0.1
 
-- **⚠️ Please also consider the release notes for 9.0.0 when upgrading from 8.x.**
+- **⚠️ Please also consider the [release notes for 9.0.0](#900) when upgrading from 8.x.**
 - Fixes Heath check with default port settings
 
 ## 9.0.0

--- a/matter_server/build.yaml
+++ b/matter_server/build.yaml
@@ -1,7 +1,7 @@
 ---
 build_from:
-  aarch64: ghcr.io/matter-js/matterjs-server:1.1.0
-  amd64: ghcr.io/matter-js/matterjs-server:1.1.0
+  aarch64: ghcr.io/matter-js/matterjs-server:1.1.1
+  amd64: ghcr.io/matter-js/matterjs-server:1.1.1
 args:
   BASHIO_VERSION: 0.17.1
   TEMPIO_VERSION: 2024.11.2

--- a/matter_server/config.yaml
+++ b/matter_server/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 9.0.1
+version: 9.0.2
 breaking_versions: [9.0.0]
 slug: matter_server
 name: Matter Server


### PR DESCRIPTION
and update the Matter server to 1.1.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Released version 9.0.2 and updated the container image tag for both architectures.

* **Bug Fixes**
  * Updated health check timing.

* **Documentation**
  * Expanded release documentation with upgrade consideration notes (including the 9.0.1 entry) and added them to 9.0.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->