### PR TITLE
Remove advanced mode step from SSH app

### DIFF
--- a/ssh/DOCS.md
+++ b/ssh/DOCS.md
@@ -4,10 +4,9 @@
 
 Follow these steps to get the app installed on your system:
 
-1. This app is only visible to "Advanced Mode" users. To enable advanced mode, go to **Profile** -> and turn on **Advanced Mode**.
-2. In Home Assistant, go to **Settings** > **Apps** > **Install app**.
-3. Find the "Terminal & SSH" app and click it.
-4. Click on the "INSTALL" button.
+1. In Home Assistant, go to **Settings** > **Apps** > **Install app**.
+2. Select **Terminal & SSH**.
+3. Select **Install**.
 
 ## How to use
 


### PR DESCRIPTION
Removes requirement of Advanced Mode from SSH app's installation steps.

Related to https://github.com/home-assistant/home-assistant.io/issues/45747

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Terminal & SSH installation instructions with a simplified, streamlined process: navigate through Home Assistant Settings → Apps → Install app, select Terminal & SSH, then choose Install.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->