### PR TITLE
letsencrypt: update certbot-dns-multi to 5.2.2

### DIFF
--- a/letsencrypt/CHANGELOG.md
+++ b/letsencrypt/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.4.0
+
+- Update certbot-dns-multi to 5.2.2, adding several DNS providers (see [lego's changelog](https://github.com/go-acme/lego/blob/v5.2.2/CHANGELOG.md) for details). The following deprecated DNS providers have been removed: `googledomains`, `azure` (replaced by `azuredns`), `cloudxns`, `dnspod`, `brandit`, `iwantmyname`, `iij` (replaced by `iijdpf`).
+
 ## 6.3.2
 
 - No longer override lego's DNS propagation timeout with `propagation_seconds`. Allows lego configuration and defaults.

--- a/letsencrypt/build.yaml
+++ b/letsencrypt/build.yaml
@@ -5,7 +5,7 @@ build_from:
 args:
   ACME_VERSION: 3.3.0
   # certbot-dns-multi replaces most individual DNS plugins using lego
-  CERTBOT_DNS_MULTI_VERSION: 4.33.0
+  CERTBOT_DNS_MULTI_VERSION: 5.2.2
   # Only legacy plugins are kept for providers not supported by lego:
   # gehirn, eurodns, noris
   CERTBOT_DNS_EURODNS_VERSION: 1.8.1

--- a/letsencrypt/config.yaml
+++ b/letsencrypt/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 6.3.2
+version: 6.4.0
 breaking_versions: [5.3.0, 6.0.0]
 slug: letsencrypt
 name: Let's Encrypt


### PR DESCRIPTION
See lego changelog: https://github.com/go-acme/lego/blob/main/CHANGELOG.md

Some deprecated dns providers were removed in 5.0.0, but otherwise, I don't see any breaking changes between 4.x and 5.x. Perhaps someone more familiar with this topic can comment.

I need the updated version because I have a provider that was added in 5.x.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the add-on to version **6.4.0**.
  * Upgraded bundled DNS integration to a newer release.

* **Bug Fixes**
  * Removed several deprecated DNS providers.
  * Replaced the old **Azure** provider with **Azure DNS** support.

* **Documentation**
  * Added a new changelog entry for the latest release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->