### PR TITLE
Change add-on to app description in config.yaml

### DIFF
--- a/openthread_border_router/config.yaml
+++ b/openthread_border_router/config.yaml
@@ -3,7 +3,7 @@ version: 3.0.1
 breaking_versions: [3.0.0]
 slug: openthread_border_router
 name: OpenThread Border Router
-description: OpenThread Border Router add-on
+description: OpenThread Border Router app
 url: >-
   https://github.com/home-assistant/addons/tree/master/openthread_border_router
 arch:


### PR DESCRIPTION
Change add-on to app

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the app description to use “OpenThread Border Router app” instead of “OpenThread Border Router add-on”.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->