### PR TITLE
Matter Server: add time_sync option (auto/on/off)

### DIFF
--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 9.1.0
+
+- **⚠️ Please also consider the release notes for 9.0.0 when upgrading from 8.x.**
+- Add `time_sync` option (`auto`/`on`/`off`, default `auto`) to push the current time to Matter devices via the Matter Server's `--enable-time-sync` flag. `auto` enables time sync only when the host clock is NTP synchronised; `on` always enables it (with a warning if NTP is not synchronised); `off` disables it. The flag is only passed when the running Matter Server is new enough to support it (>= 1.2.0); on older servers a warning is logged and the flag is skipped so startup is not affected.
+
 ## 9.0.3
 
 - **⚠️ Please also consider the release notes for 9.0.0 when upgrading from 8.x.**

--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - **⚠️ When upgrading from 8.x, please also consider the release notes for 9.0.0.**
 - Update [Matter Server from 1.1.7 to 1.2.5](https://github.com/matter-js/matterjs-server/blob/main/CHANGELOG.md), which adds the `--enable-time-sync` flag used by the new `time_sync` option below.
-- Add `time_sync` option (`auto`/`on`/`off`, default `auto`) to push the current time to Matter devices via the Matter Server's `--enable-time-sync` flag. `auto` enables time sync only when the host clock is NTP synchronised; `on` always enables it (with a warning if NTP is not synchronised); `off` disables it.
+- Add `time_sync` option (`auto`/`on`/`off`, default `auto`) to push the current time to Matter devices via the Matter Server's `--enable-time-sync` flag. `auto` enables time sync only when the host clock is NTP synchronized; `on` always enables it (with a warning if NTP is not synchronized); `off` disables it.
 
 ## 9.0.4
 

--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## 9.1.0
 
 - **⚠️ Please also consider the release notes for 9.0.0 when upgrading from 8.x.**
-- Add `time_sync` option (`auto`/`on`/`off`, default `auto`) to push the current time to Matter devices via the Matter Server's `--enable-time-sync` flag. `auto` enables time sync only when the host clock is NTP synchronised; `on` always enables it (with a warning if NTP is not synchronised); `off` disables it. The flag is only passed when the running Matter Server is new enough to support it (>= 1.2.0); on older servers a warning is logged and the flag is skipped so startup is not affected.
+- Update [Matter Server to 1.2.5](https://github.com/matter-js/matterjs-server/blob/main/CHANGELOG.md), which adds the `--enable-time-sync` flag used by the new `time_sync` option below.
+- Add `time_sync` option (`auto`/`on`/`off`, default `auto`) to push the current time to Matter devices via the Matter Server's `--enable-time-sync` flag. `auto` enables time sync only when the host clock is NTP synchronised; `on` always enables it (with a warning if NTP is not synchronised); `off` disables it.
 
 ## 9.0.3
 

--- a/matter_server/DOCS.md
+++ b/matter_server/DOCS.md
@@ -53,6 +53,7 @@ App configuration:
 | log_level            | Logging level of the Matter Server component.                                                           |
 | beta                 | Install the latest `matter-server` from npm on startup instead of the bundled version. On failure a warning is logged and the bundled version is started. |
 | enable_test_net_dcl  | Enable test-net DCL for PAA root certificates, OTA updates and other device information.                |
+| time_sync            | Whether the Matter Server pushes the current time to Matter devices: `auto` (default; on only when the host clock is NTP synchronised), `on` (always; warns if NTP is not synchronised), or `off`. Requires Matter Server >= 1.2.0; on older servers a warning is logged and the option is skipped. |
 | ble_proxy            | Expose the BLE proxy endpoint so the Home Assistant Matter integration can drive BLE commissioning through Home Assistant's bluetooth stack. Mutually exclusive with `bluetooth_adapter_id`. |
 | bluetooth_adapter_id | **Deprecated** — use `ble_proxy` instead. Set BlueZ Bluetooth Controller ID (for local commissioning). Still works for now. |
 | matter_server_args   | Extra command-line arguments passed to the Matter Server at startup (advanced).                         |

--- a/matter_server/DOCS.md
+++ b/matter_server/DOCS.md
@@ -53,7 +53,7 @@ App configuration:
 | log_level            | Logging level of the Matter Server component.                                                           |
 | beta                 | Install the latest `matter-server` from npm on startup instead of the bundled version. On failure a warning is logged and the bundled version is started. |
 | enable_test_net_dcl  | Enable test-net DCL for PAA root certificates, OTA updates and other device information.                |
-| time_sync            | Whether the Matter Server pushes the current time to Matter devices: `auto` (default; on only when the host clock is NTP synchronised), `on` (always; warns if NTP is not synchronised), or `off`. Requires Matter Server >= 1.2.0; on older servers a warning is logged and the option is skipped. |
+| time_sync            | Whether the Matter Server pushes the current time to Matter devices: `auto` (default; on only when the host clock is NTP synchronised), `on` (always; warns if NTP is not synchronised), or `off`. |
 | ble_proxy            | Expose the BLE proxy endpoint so the Home Assistant Matter integration can drive BLE commissioning through Home Assistant's bluetooth stack. Mutually exclusive with `bluetooth_adapter_id`. |
 | bluetooth_adapter_id | **Deprecated** — use `ble_proxy` instead. Set BlueZ Bluetooth Controller ID (for local commissioning). Still works for now. |
 | matter_server_args   | Extra command-line arguments passed to the Matter Server at startup (advanced).                         |

--- a/matter_server/DOCS.md
+++ b/matter_server/DOCS.md
@@ -53,7 +53,7 @@ App configuration:
 | log_level            | Logging level of the Matter Server component.                                                           |
 | beta                 | Install the latest `matter-server` from npm on startup instead of the bundled version. On failure a warning is logged and the bundled version is started. |
 | enable_test_net_dcl  | Enable test-net DCL for PAA root certificates, OTA updates and other device information.                |
-| time_sync            | Whether the Matter Server pushes the current time to Matter devices: `auto` (default; on only when the host clock is NTP synchronised), `on` (always; warns if NTP is not synchronised), or `off`. |
+| time_sync            | Whether the Matter Server pushes the current time to Matter devices: `auto` (default; on only when the host clock is NTP synchronized), `on` (always; warns if NTP is not synchronized), or `off`. |
 | ble_proxy            | Expose the BLE proxy endpoint so the Home Assistant Matter integration can drive BLE commissioning through Home Assistant's bluetooth stack. Mutually exclusive with `bluetooth_adapter_id`. |
 | bluetooth_adapter_id | **Deprecated** — use `ble_proxy` instead. Set BlueZ Bluetooth Controller ID (for local commissioning). Still works for now. |
 | matter_server_args   | Extra command-line arguments passed to the Matter Server at startup (advanced).                         |

--- a/matter_server/build.yaml
+++ b/matter_server/build.yaml
@@ -1,7 +1,7 @@
 ---
 build_from:
-  aarch64: ghcr.io/matter-js/matterjs-server:1.1.2
-  amd64: ghcr.io/matter-js/matterjs-server:1.1.2
+  aarch64: ghcr.io/matter-js/matterjs-server:1.2.5
+  amd64: ghcr.io/matter-js/matterjs-server:1.2.5
 args:
   BASHIO_VERSION: 0.17.1
   TEMPIO_VERSION: 2024.11.2

--- a/matter_server/config.yaml
+++ b/matter_server/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 9.0.3
+version: 9.1.0
 breaking_versions: [9.0.0]
 slug: matter_server
 name: Matter Server
@@ -28,10 +28,12 @@ options:
   log_level: info
   beta: false
   enable_test_net_dcl: false
+  time_sync: auto
 schema:
   log_level: list(debug|info|notice|warn|error|fatal|verbose|warning|critical)
   beta: bool?
   enable_test_net_dcl: bool?
+  time_sync: list(auto|on|off)
   ble_proxy: bool?
   bluetooth_adapter_id: int?
   matter_server_args:

--- a/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
+++ b/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
@@ -119,6 +119,57 @@ if bashio::config.true "enable_test_net_dcl"; then
     extra_args+=('--ota-provider-dir' "/config/updates")
 fi
 
+# Resolve whether to enable time sync for nodes with the TimeSynchronization
+# cluster. The 'time_sync' option has three modes:
+#   - on:   always enable (warn if the host clock is not NTP synchronised)
+#   - off:  always leave disabled
+#   - auto: enable only when the host clock is NTP synchronised (default)
+time_sync_mode="$(bashio::string.lower "$(bashio::config 'time_sync' 'auto')")"
+ntp_synchronized="$(bashio::api.supervisor 'GET' '/supervisor/info' '' '.ntp_synchronized')"
+time_sync_enabled=false
+
+case "${time_sync_mode}" in
+  on)
+    time_sync_enabled=true
+    if [ "${ntp_synchronized}" != "true" ]; then
+        bashio::log.warning \
+          "Time sync is enabled but host NTP is not synchronised — time pushed to Matter devices may be inaccurate"
+    fi
+    ;;
+  off)
+    bashio::log.info "Time sync is disabled ('time_sync' set to off)."
+    ;;
+  *)
+    if [ "${ntp_synchronized}" = "true" ]; then
+        time_sync_enabled=true
+        bashio::log.info "Time sync 'auto': host NTP is synchronised, enabling time sync."
+    else
+        bashio::log.info "Time sync 'auto': host NTP is not synchronised, leaving time sync disabled."
+    fi
+    ;;
+esac
+
+if [ "${time_sync_enabled}" = "true" ]; then
+    # The --enable-time-sync flag was added to the Matter Server in 1.2.0 (see
+    # matter-js/matterjs-server#440). The server uses commander, which exits on
+    # unknown options, so only pass the flag when the running server is new
+    # enough; otherwise the option would break startup. A pre-release such as
+    # 1.2.0-alpha is treated as 1.2.0 by comparing the MAJOR.MINOR.PATCH core.
+    time_sync_min="1.2.0"
+    running_version=""
+    if [ -f /app/node_modules/matter-server/package.json ]; then
+        running_version="$(jq --raw-output '.version // empty' /app/node_modules/matter-server/package.json)"
+    fi
+    running_core="${running_version%%-*}"
+    if bashio::var.has_value "${running_core}" \
+        && [ "$(printf '%s\n%s\n' "${time_sync_min}" "${running_core}" | sort -V | head -n1)" = "${time_sync_min}" ]; then
+        extra_args+=('--enable-time-sync')
+    else
+        bashio::log.warning \
+          "Matter Server ${running_version:-(unknown)} does not support time sync (requires >= ${time_sync_min}); '--enable-time-sync' not passed. Update the Matter Server to enable this feature."
+    fi
+fi
+
 primary_interface="$(bashio::api.supervisor 'GET' '/network/info' '' 'first(.interfaces[] | select (.primary == true)) .interface')"
 
 # Try fallback method (e.g. in case NetworkManager is not available)

--- a/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
+++ b/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
@@ -133,11 +133,11 @@ fi
 
 # Resolve whether to enable time sync for nodes with the TimeSynchronization
 # cluster. The 'time_sync' option has three modes:
-#   - on:   always enable (warn if the host clock is not NTP synchronised)
+#   - on:   always enable (warn if the host clock is not NTP synchronized)
 #   - off:  always leave disabled
-#   - auto: enable only when the host clock is NTP synchronised (default)
+#   - auto: enable only when the host clock is NTP synchronized (default)
 time_sync_mode="$(bashio::string.lower "$(bashio::config 'time_sync' 'auto')")"
-ntp_synchronized="$(bashio::api.supervisor 'GET' '/supervisor/info' '' '.ntp_synchronized')"
+ntp_synchronized="$(bashio::api.supervisor 'GET' '/host/info' '' '.dt_synchronized')"
 time_sync_enabled=false
 
 case "${time_sync_mode}" in
@@ -145,7 +145,7 @@ case "${time_sync_mode}" in
     time_sync_enabled=true
     if [ "${ntp_synchronized}" != "true" ]; then
         bashio::log.warning \
-          "Time sync is enabled but host NTP is not synchronised — time pushed to Matter devices may be inaccurate"
+          "Time sync is enabled but host NTP is not synchronized — time pushed to Matter devices may be inaccurate"
     fi
     ;;
   off)
@@ -154,9 +154,9 @@ case "${time_sync_mode}" in
   *)
     if [ "${ntp_synchronized}" = "true" ]; then
         time_sync_enabled=true
-        bashio::log.info "Time sync 'auto': host NTP is synchronised, enabling time sync."
+        bashio::log.info "Time sync 'auto': host NTP is synchronized, enabling time sync."
     else
-        bashio::log.info "Time sync 'auto': host NTP is not synchronised, leaving time sync disabled."
+        bashio::log.info "Time sync 'auto': host NTP is not synchronized, leaving time sync disabled."
     fi
     ;;
 esac

--- a/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
+++ b/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
@@ -150,24 +150,7 @@ case "${time_sync_mode}" in
 esac
 
 if [ "${time_sync_enabled}" = "true" ]; then
-    # The --enable-time-sync flag was added to the Matter Server in 1.2.0 (see
-    # matter-js/matterjs-server#440). The server uses commander, which exits on
-    # unknown options, so only pass the flag when the running server is new
-    # enough; otherwise the option would break startup. A pre-release such as
-    # 1.2.0-alpha is treated as 1.2.0 by comparing the MAJOR.MINOR.PATCH core.
-    time_sync_min="1.2.0"
-    running_version=""
-    if [ -f /app/node_modules/matter-server/package.json ]; then
-        running_version="$(jq --raw-output '.version // empty' /app/node_modules/matter-server/package.json)"
-    fi
-    running_core="${running_version%%-*}"
-    if bashio::var.has_value "${running_core}" \
-        && [ "$(printf '%s\n%s\n' "${time_sync_min}" "${running_core}" | sort -V | head -n1)" = "${time_sync_min}" ]; then
-        extra_args+=('--enable-time-sync')
-    else
-        bashio::log.warning \
-          "Matter Server ${running_version:-(unknown)} does not support time sync (requires >= ${time_sync_min}); '--enable-time-sync' not passed. Update the Matter Server to enable this feature."
-    fi
+    extra_args+=('--enable-time-sync')
 fi
 
 primary_interface="$(bashio::api.supervisor 'GET' '/network/info' '' 'first(.interfaces[] | select (.primary == true)) .interface')"

--- a/matter_server/translations/en.yaml
+++ b/matter_server/translations/en.yaml
@@ -15,6 +15,16 @@ configuration:
       Enable PAA root certificates, software updates and other device
       information from test-net DCL. This is meant for development and testing
       purposes.
+  time_sync:
+    name: Time synchronisation
+    description: >-
+      Control whether the Matter Server pushes the current time to Matter
+      devices. "auto" (default) enables it only when the host clock is NTP
+      synchronised; "on" always enables it (a warning is logged if the host
+      clock is not NTP synchronised, since the time sent to devices is only as
+      accurate as the host clock); "off" disables it. Requires Matter Server
+      1.2.0 or later; on older servers a warning is logged and the option is
+      skipped.
   bluetooth_adapter_id:
     name: Bluetooth Adapter ID (deprecated)
     description: >-

--- a/matter_server/translations/en.yaml
+++ b/matter_server/translations/en.yaml
@@ -16,12 +16,12 @@ configuration:
       information from test-net DCL. This is meant for development and testing
       purposes.
   time_sync:
-    name: Time synchronisation
+    name: Time synchronization
     description: >-
       Control whether the Matter Server pushes the current time to Matter
       devices. "auto" (default) enables it only when the host clock is NTP
-      synchronised; "on" always enables it (a warning is logged if the host
-      clock is not NTP synchronised, since the time sent to devices is only as
+      synchronized; "on" always enables it (a warning is logged if the host
+      clock is not NTP synchronized, since the time sent to devices is only as
       accurate as the host clock); "off" disables it.
   bluetooth_adapter_id:
     name: Bluetooth Adapter ID (deprecated)

--- a/matter_server/translations/en.yaml
+++ b/matter_server/translations/en.yaml
@@ -22,9 +22,7 @@ configuration:
       devices. "auto" (default) enables it only when the host clock is NTP
       synchronised; "on" always enables it (a warning is logged if the host
       clock is not NTP synchronised, since the time sent to devices is only as
-      accurate as the host clock); "off" disables it. Requires Matter Server
-      1.2.0 or later; on older servers a warning is logged and the option is
-      skipped.
+      accurate as the host clock); "off" disables it.
   bluetooth_adapter_id:
     name: Bluetooth Adapter ID (deprecated)
     description: >-


### PR DESCRIPTION
## Breaking change

<!-- This PR is not a breaking change. -->
None. The new `time_sync` option defaults to `auto`, which enables time sync
only when the host clock is already NTP synchronised. On hosts that are not NTP
synchronised, behaviour is unchanged. On NTP-synchronised hosts the server now
pushes the correct time to commissioned Matter devices, which is the intended
improvement and can be turned off with `time_sync: off`.

## Proposed change

Adds a `time_sync` option (`auto` / `on` / `off`, default `auto`) to the Matter
Server add-on. It controls whether the server pushes the current time to
commissioned Matter devices via its `--enable-time-sync` flag:

- `auto` (default): enable only when the host clock is NTP synchronised, checked
  via the Supervisor API (`GET /supervisor/info`, field `ntp_synchronized`).
- `on`: always enable, logging an advisory warning if the host clock is not NTP
  synchronised (the time sent to devices is only as accurate as the host clock).
- `off`: never enable.

The bundled Matter Server base image is bumped to `1.2.5`, which includes the
`--enable-time-sync` flag added in matter-js/matterjs-server#440 (released in
matter-server `1.2.1`).

An earlier revision of this PR gated the flag behind a runtime server-version
check, because the Matter Server CLI uses commander.js (which exits on unknown
flags) and the bundled server predated the flag. Now that the flag ships in the
bundled server, that gate has been removed and `--enable-time-sync` is passed
directly whenever `time_sync` resolves to enabled.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Companion server pull request: matter-js/matterjs-server#440 (merged; released
  in matter-server `1.2.1`)
- Link to documentation pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] The add-on version in `config.yaml` was bumped and `CHANGELOG.md` updated.
- [x] The new option is added to `config.yaml` `options`/`schema` and documented
      in `DOCS.md` and `translations/en.yaml`.
- [x] The startup script passes shellcheck with no new findings, and follows the
      existing bashio conventions used in this add-on.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `time_sync` configuration option to control whether Matter Server pushes time to devices: `auto` (default), `on`, or `off`.
  * In `auto`, time sync is enabled only when the host clock is NTP-synchronized; `on` forces it and issues a warning if not synchronized.
* **Documentation**
  * Updated configuration docs, user-facing descriptions, and upgrade notes for the new option.
* **Chores**
  * Updated the Matter Server add-on to version 9.1.0 (including the underlying server image update).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->