### PR TITLE
Bump whisper addon to 3.3.1

### DIFF
--- a/whisper/CHANGELOG.md
+++ b/whisper/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 3.3.1
+
+- Ensure zh/yue/ja/ko default to FunASR
+- Add FunASR speech-to-text backend defaulting to `FunAudioLLM/SenseVoiceSmall` (`@LauraGPT`)
+  - Non-autoregressive and notably faster than Whisper; supports English, Chinese, Cantonese, Japanese, and Korean well
+- Fix streaming sherpa cutting off the end of utterances (add tail padding before flushing)
+- Default streaming sherpa to the Kroko 2025 zipformer models (mixed-case, punctuated, much better accuracy than the old LibriSpeech model); adds `de`/`es`/`fr` defaults
+- Use `--beam-size` for streaming sherpa decoding (beam search when > 1, greedy otherwise)
+
 ## 3.2.0
 
 - Fix transformers language

--- a/whisper/CHANGELOG.md
+++ b/whisper/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.3.1
 
 - Ensure zh/yue/ja/ko default to FunASR
+- Add `local_files_only` option to stay offline once models are downloaded
 - Add FunASR speech-to-text backend defaulting to `FunAudioLLM/SenseVoiceSmall` (`@LauraGPT`)
   - Non-autoregressive and notably faster than Whisper; supports English, Chinese, Cantonese, Japanese, and Korean well
 - Fix streaming sherpa cutting off the end of utterances (add tail padding before flushing)

--- a/whisper/DOCS.md
+++ b/whisper/DOCS.md
@@ -117,6 +117,18 @@ Use streaming model with `sherpa` backend.
 
 This overrides the default English model (parakeet) with a faster but less accurate streaming model (sherpa-onnx-streaming-zipformer-en-2023-06-26).
 
+### Option: `local_files_only`
+
+Only use models that have already been downloaded, and never check online for
+updates.
+
+Leave this off the first time you use a model so it can download. Once your
+models are downloaded, turn it on to keep the add-on fully offline — it will skip
+the online update check on every request, which also speeds up startup.
+
+If you turn this on before a model has been downloaded, transcription will fail
+until you disable it again (or switch to a model you already have).
+
 ## Backups
 
 Whisper model files can be large, so they are automatically excluded from backups and re-downloaded on restore for remote models.

--- a/whisper/DOCS.md
+++ b/whisper/DOCS.md
@@ -100,6 +100,7 @@ Speech-to-text backend library to use:
 - `sherpa` - force [sherpa onnx][sherpa-onnx] backend (parakeet model only)
 - `transformers` - force [HuggingFace transformers][transformers] backend
 - `onnx-asr` - force [onnx asr][onnx-asr] backend
+- `funasr` - force [funasr][] backend
 
 **Note**: When `custom_model` is set, then `custom_model_type` will override `stt_library` when set to "auto".
 
@@ -124,16 +125,23 @@ After restoring a backup with a local custom Whisper model, manually copy your m
 ## Recommendations
 
 A few starting points by language and priority. With `stt_library` = "auto" the
-add-on selects a backend/model based on your `language` and hardware; for English
-this is the parakeet sherpa model, and `sherpa_streaming` swaps it for a faster
-streaming variant.
+add-on selects a backend/model based on your `language` and hardware:
+
+- **English** (`en`) → the parakeet model via the sherpa backend.
+  `sherpa_streaming` swaps it for a faster streaming variant.
+- **Chinese, Cantonese, Japanese, Korean** (`zh`, `yue`, `ja`, `ko`) → the
+  SenseVoice model via the funasr backend. It is non-autoregressive and notably
+  faster than Whisper while handling these languages well (locale codes like
+  `zh-CN`/`zh-TW`/`zh-HK` are mapped automatically).
+- **Russian** (`ru`) → the GigaAM model via the onnx-asr backend.
+- **Everything else** → faster-whisper.
 
 Two tips for non-English use:
 
 - Set `language` to your explicit language code. Leaving it as "auto" works but is
   **much** slower, since the model has to detect the language on every request.
 - To get English text out of non-English speech, set `whisper_task` = "translate".
-  This applies to the Whisper backends (not parakeet/sherpa).
+  This applies to the Whisper backends (not parakeet/sherpa, SenseVoice, or GigaAM).
 
 - English
     - Balanced
@@ -151,7 +159,14 @@ Two tips for non-English use:
         - `model` = "custom"
         - `stt_library` = "onnx-asr"
         - `custom_model` = "istupakov/canary-1b-v2-onnx"
-- Non-English
+- Chinese / Cantonese / Japanese / Korean
+    - Balanced (recommended)
+        - `language` = "zh", "yue", "ja", or "ko"
+        - `model` = "auto"
+        - `stt_library` = "auto"
+          (selects the SenseVoice model via funasr — fast and accurate for
+          these languages)
+- Non-English (other languages)
     - Balanced
         - `language` = your language code (e.g. "de", "fr")
         - `model` = "auto"
@@ -188,3 +203,4 @@ In case you've found an bug, please [open an issue on our GitHub][issue].
 [faster-whisper]: https://github.com/SYSTRAN/faster-whisper
 [sherpa-onnx]: https://github.com/k2-fsa/sherpa-onnx
 [onnx-asr]: https://github.com/istupakov/onnx-asr
+[funasr]: https://github.com/modelscope/FunASR

--- a/whisper/Dockerfile
+++ b/whisper/Dockerfile
@@ -23,10 +23,12 @@ RUN \
         "wyoming-faster-whisper[sherpa] @ https://github.com/rhasspy/wyoming-faster-whisper/archive/refs/tags/v${WYOMING_WHISPER_VERSION}.tar.gz" \
         'transformers==4.52.4' \
         'onnx-asr[cpu,hub]==0.11.0' \
+        'funasr>=1.1.0,<2' \
     \
     && pip3 install --no-cache-dir \
         --index-url 'https://download.pytorch.org/whl/cpu' \
         'torch==2.6.0' \
+        'torchaudio==2.6.0' \
     \
     && apt-get purge -y --auto-remove \
         build-essential \

--- a/whisper/build.yaml
+++ b/whisper/build.yaml
@@ -3,4 +3,4 @@ build_from:
   amd64: ghcr.io/home-assistant/amd64-base-debian:bookworm
   aarch64: ghcr.io/home-assistant/aarch64-base-debian:bookworm
 args:
-  WYOMING_WHISPER_VERSION: 3.2.0
+  WYOMING_WHISPER_VERSION: 3.3.1

--- a/whisper/config.yaml
+++ b/whisper/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 3.2.0
+version: 3.3.1
 slug: whisper
 name: Whisper
 description: Speech-to-text with Whisper
@@ -27,10 +27,10 @@ schema:
   model: |
     list(auto|tiny-int8|tiny|tiny.en|base-int8|base|base.en|small-int8|distil-small.en|small|small.en|distil-medium.en|medium-int8|medium|medium.en|large|large-v1|distil-large-v2|large-v2|distil-large-v3|large-v3|turbo|custom)
   stt_library: |
-    list(auto|faster-whisper|sherpa|transformers|onnx-asr)
+    list(auto|faster-whisper|sherpa|transformers|onnx-asr|funasr)
   custom_model: str?
   custom_model_type: |
-    list(faster-whisper|sherpa|transformers|onnx-asr)
+    list(faster-whisper|sherpa|transformers|onnx-asr|funasr)
   language: |
     list(auto|af|am|ar|as|az|ba|be|bg|bn|bo|br|bs|ca|cs|cy|da|de|el|en|es|et|eu|fa|fi|fo|fr|gl|gu|ha|haw|he|hi|hr|ht|hu|hy|id|is|it|ja|jw|ka|kk|km|kn|ko|la|lb|ln|lo|lt|lv|mg|mi|mk|ml|mn|mr|ms|mt|my|ne|nl|nn|no|oc|pa|pl|ps|pt|ro|ru|sa|sd|si|sk|sl|sn|so|sq|sr|su|sv|sw|ta|te|tg|th|tk|tl|tr|tt|uk|ur|uz|vi|yi|yo|zh|yue)
   beam_size: int

--- a/whisper/config.yaml
+++ b/whisper/config.yaml
@@ -22,6 +22,7 @@ options:
   stt_library: "auto"
   whisper_task: "transcribe"
   sherpa_streaming: false
+  local_files_only: false
   debug_logging: false
 schema:
   model: |
@@ -38,6 +39,7 @@ schema:
   whisper_task: |
     list(transcribe|translate)
   sherpa_streaming: bool
+  local_files_only: bool
   debug_logging: bool
 ports:
   "10300/tcp": null

--- a/whisper/rootfs/etc/s6-overlay/s6-rc.d/whisper/run
+++ b/whisper/rootfs/etc/s6-overlay/s6-rc.d/whisper/run
@@ -34,6 +34,10 @@ if bashio::config.true 'sherpa_streaming'; then
     flags+=('--sherpa-streaming')
 fi
 
+if bashio::config.true 'local_files_only'; then
+    flags+=('--local-files-only')
+fi
+
 if bashio::config.true 'debug_logging'; then
     flags+=('--debug')
 fi

--- a/whisper/translations/en.yaml
+++ b/whisper/translations/en.yaml
@@ -61,6 +61,14 @@ configuration:
 
       This overrides the default English model with a faster but less accurate
       streaming model.
+  local_files_only:
+    name: Local files only
+    description: >-
+      Only use models that have already been downloaded, and never check online
+      for updates.
+
+      Leave this off until your models have downloaded, then turn it on to keep
+      the add-on offline and skip the update check on every request.
   debug_logging:
     name: Debug logging
     description: >-


### PR DESCRIPTION
https://github.com/rhasspy/wyoming-faster-whisper/compare/v3.2.0...v3.3.1

- Ensure zh/yue/ja/ko default to FunASR
- Add FunASR speech-to-text backend defaulting to `FunAudioLLM/SenseVoiceSmall` (`@LauraGPT`)
  - Non-autoregressive and notably faster than Whisper; supports English, Chinese, Cantonese, Japanese, and Korean well
- Fix streaming sherpa cutting off the end of utterances (add tail padding before flushing)
- Default streaming sherpa to the Kroko 2025 zipformer models (mixed-case, punctuated, much better accuracy than the old LibriSpeech model); adds `de`/`es`/`fr` defaults
- Use `--beam-size` for streaming sherpa decoding (beam search when > 1, greedy otherwise)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new speech-to-text backend option (funasr) and expanded available STT library/custom model choices.
  * Introduced a **Local files only** setting to keep transcription fully offline after models are downloaded.
* **Bug Fixes**
  * Improved streaming transcription to prevent end-of-utterance truncation.
  * Refreshed streaming decoding behavior and defaults for more consistent results.
* **Documentation**
  * Updated guidance and recommendations, including backend/model selection and the new offline option.
* **Chores**
  * Bumped the add-on version to **3.3.1**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->