### PR TITLE
vlc: Fix default media directory and bump to Alpine 3.24

### DIFF
--- a/vlc/CHANGELOG.md
+++ b/vlc/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.1.0
+
+- Run VLC with user privileges
+- Fix default media directory
+- Update to Alpine 3.24
+
 ## 1.0.0
 
 - Remove unsupported architectures (armv7, i386)

--- a/vlc/Dockerfile
+++ b/vlc/Dockerfile
@@ -12,6 +12,7 @@ RUN \
         pwgen \
         vlc \
     && addgroup vlc && adduser -D -G vlc vlc \
+    && grep -q "dir == undefined ? 'file://~'" /usr/share/vlc/lua/http/js/controllers.js \
     && sed -i "s#dir == undefined ? 'file://~'#dir == undefined ? 'file:///media'#" \
            /usr/share/vlc/lua/http/js/controllers.js
         

--- a/vlc/Dockerfile
+++ b/vlc/Dockerfile
@@ -12,7 +12,8 @@ RUN \
         pwgen \
         vlc \
     && addgroup vlc && adduser -D -G vlc vlc \
-    && sed -i '197s#.*#    dir = dir == undefined ? "file:///media" : dir;#' /usr/share/vlc/lua/http/js/controllers.js
+    && sed -i "s#dir == undefined ? 'file://~'#dir == undefined ? 'file:///media'#" \
+           /usr/share/vlc/lua/http/js/controllers.js
         
 WORKDIR /
 COPY rootfs /

--- a/vlc/build.yaml
+++ b/vlc/build.yaml
@@ -1,4 +1,4 @@
 ---
 build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-base:3.23
-  amd64: ghcr.io/home-assistant/amd64-base:3.23
+  aarch64: ghcr.io/home-assistant/aarch64-base:3.24
+  amd64: ghcr.io/home-assistant/amd64-base:3.24

--- a/vlc/config.yaml
+++ b/vlc/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 1.0.0
+version: 1.1.0
 slug: vlc
 name: VLC
 description: Turn your device into a Media Player with VLC


### PR DESCRIPTION
The `sed` patch does not apply correctly with VLC shipped with Alpine 3.23 (and possible previous versions). This updates `sed` replacement to work with Alpine 3.23. While at it, also update to Alpine 3.24, the same `sed` command appears to work there too.

And finally, also include the changes of #4660 to `CHANGELOG.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated VLC to run with user-level permissions.
  * Fixed the default media directory location.
* **Chores**
  * Bumped the add-on version to **1.1.0**.
  * Updated the base environment to **Alpine 3.24**.
* **Documentation**
  * Added a new **1.1.0** entry to the add-on changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->