### PR TITLE
whisper: Add libgomp1 runtime dependency

### DIFF
--- a/whisper/CHANGELOG.md
+++ b/whisper/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.3.2
+
+- Add `libgomp1` so `torch`/`torchaudio` can load again, fixing the startup crash loop introduced in 3.3.1
+
 ## 3.3.1
 
 - Ensure zh/yue/ja/ko default to FunASR

--- a/whisper/Dockerfile
+++ b/whisper/Dockerfile
@@ -10,6 +10,7 @@ RUN \
     apt-get update \
     && apt-get install -y --no-install-recommends \
         build-essential \
+        libgomp1 \
         netcat-traditional \
         python3 \
         python3-dev \

--- a/whisper/config.yaml
+++ b/whisper/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 3.3.1
+version: 3.3.2
 slug: whisper
 name: Whisper
 description: Speech-to-text with Whisper


### PR DESCRIPTION
Fixes #4692

Since 3.3.1 the add-on crash-loops on startup with:

```
OSError: libgomp.so.1: cannot open shared object file: No such file or directory
```

`build-essential` pulls in `libgomp1` (via gcc), but `apt-get purge --auto-remove build-essential python3-dev` removes it again. `torchaudio` — imported unconditionally through `funasr` in `load_transcriber()` — links `libgomp.so.1` at runtime, so every backend fails to load regardless of `stt_library`.

Installing `libgomp1` explicitly makes it survive the auto-remove purge.

Tested on `aarch64`: the add-on now reaches `Ready` and registers with Home Assistant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a startup crash loop by restoring the ability for audio-related libraries to load correctly.
* **Chores**
  * Updated the add-on version to **3.3.2**.
  * Included an additional system package in the image build to support the fix.
* **Documentation**
  * Added a changelog entry for **3.3.2** describing the crash-loop fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->