### PR TITLE
Matter Server 9.0.4

### DIFF
--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 9.0.4
 
 - **⚠️ When upgrading from 8.x, please also consider the release notes for 9.0.0.**
-- Update [Matter Server from 1.1.2 to to 1.1.7](https://github.com/matter-js/matterjs-server/blob/main/CHANGELOG.md#117-2026-07-01) to address reported issues and optimize RAM and CPU usage (a lot)
+- Update [Matter Server from 1.1.2 to 1.1.7](https://github.com/matter-js/matterjs-server/blob/main/CHANGELOG.md#117-2026-07-01) to address reported issues and optimize RAM and CPU usage (a lot)
 
 ## 9.0.3
 

--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - **⚠️ When upgrading from 8.x, please also consider the release notes for 9.0.0.**
 - Update Matter Server to 1.1.1 with increased Health check timings
+- Speed up Beta version installation
 
 ## 9.0.1
 

--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -1,13 +1,18 @@
 # Changelog
 
+## 9.0.4
+
+- **⚠️ When upgrading from 8.x, please also consider the release notes for 9.0.0.**
+- Update [Matter Server from 1.1.2 to to 1.1.7](https://github.com/matter-js/matterjs-server/blob/main/CHANGELOG.md#117-2026-07-01) to address reported issues and optimize RAM and CPU usage (a lot)
+
 ## 9.0.3
 
-- **⚠️ Please also consider the release notes for 9.0.0 when upgrading from 8.x.**
-- Update [Matter Server to 1.1.2](https://github.com/matter-js/matterjs-server/blob/main/CHANGELOG.md#112-2026-06-25) to address reported issues
+- **⚠️ When upgrading from 8.x, please also consider the release notes for 9.0.0.**
+- Update [Matter Server from 1.1.1 to 1.1.2](https://github.com/matter-js/matterjs-server/blob/main/CHANGELOG.md#112-2026-06-25) to address reported issues
 
 ## 9.0.2
 
-- **⚠️ Please also consider the release notes for 9.0.0 when upgrading from 8.x.**
+- **⚠️ When upgrading from 8.x, please also consider the release notes for 9.0.0.**
 - Update Matter Server to 1.1.1 with increased Health check timings
 
 ## 9.0.1

--- a/matter_server/MIGRATION_FAQ.md
+++ b/matter_server/MIGRATION_FAQ.md
@@ -43,3 +43,25 @@ Note: you might also see "Unknown devices" or "External routers" in the network 
 
 ## Can I switch back to the old Matter Server?
 No. The new Matter Server was tested as a "Beta" with the community for the last four months, and we did our best to make sure it works as expected. If you run into any issues, report them in this GitHub repository and we will try to fix them as soon as possible.
+
+## Troubleshooting
+
+### When I try to start the server I get the error "Fabric with index X is already present but not under the control of the Fabric Authority"
+In this case it seems that there was some former migration try which somehow broke the storage. Please delete the server directory of your data directory.
+
+Using the Advanced SSH Add-on/App with "Protection mode" disabled: ssh into Home Assistant, then
+
+```bash
+docker exec -it addon_core_matter_server bash
+cd /data
+ls -la
+rm -rf server-2-134b
+^D
+^D
+```
+
+... under the assumption that the "ls -la" is showing a "server-2-134b" folder ... if the name is different just use that what's there but "server-*"
+
+### After the start all/some of my devices are/stay offline
+
+When devices are reported as offline after the initial start, this usually means that the devices are not announced via MDNS. This can happen in some cases and is usually solved with a restart (power-off/on) of the device. After we got the IP of the device at least once the new server will also try these IPs automatically. 

--- a/matter_server/build.yaml
+++ b/matter_server/build.yaml
@@ -1,7 +1,7 @@
 ---
 build_from:
-  aarch64: ghcr.io/matter-js/matterjs-server:1.1.2
-  amd64: ghcr.io/matter-js/matterjs-server:1.1.2
+  aarch64: ghcr.io/matter-js/matterjs-server:1.1.7
+  amd64: ghcr.io/matter-js/matterjs-server:1.1.7
 args:
   BASHIO_VERSION: 0.17.1
   TEMPIO_VERSION: 2024.11.2

--- a/matter_server/config.yaml
+++ b/matter_server/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 9.0.3
+version: 9.0.4
 breaking_versions: [9.0.0]
 slug: matter_server
 name: Matter Server

--- a/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
+++ b/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
@@ -11,6 +11,8 @@ declare log_level
 declare primary_interface
 declare install_target
 declare matter_server_version
+declare server_entry
+declare install_dir
 declare env_entry
 declare env_name
 declare env_value
@@ -46,6 +48,8 @@ esac
 # matter.js uses 0.x-2.x versions; a major >= 3 is almost certainly a leftover
 # Python Matter Server version, so it is ignored to avoid installing the wrong package.
 install_target=""
+server_entry="/app/node_modules/matter-server/dist/esm/MatterServer.js"
+install_dir="/opt/matter-server"
 if bashio::config.has_value "matter_server_version"; then
   matter_server_version=$(bashio::config 'matter_server_version')
   if [[ "${matter_server_version}" =~ ^[^0-9]*([0-9]+) ]] && (( BASH_REMATCH[1] >= 3 )); then
@@ -60,21 +64,29 @@ if ! bashio::var.has_value "${install_target}" && bashio::config.true "beta"; th
 fi
 
 if bashio::var.has_value "${install_target}"; then
-  bashio::log.info "Installing ${install_target} from npm over the bundled server..."
+  bashio::log.info "Installing ${install_target} from npm into ${install_dir}..."
   # matter.js native modules may need compiling; the base image purges the
-  # toolchain, so add it back here. A failure here must not abort startup.
+  # toolchain, so add it back here. The version is installed into a separate
+  # directory, leaving the bundled /app server intact as a fallback; a failure
+  # here must not abort startup. The directory is kept between restarts so that
+  # reinstalling an unchanged version is a fast npm no-op.
   if ! { apt-get update \
       && apt-get install -y --no-install-recommends \
         python3 make gcc g++ libbluetooth-dev libudev-dev \
-      && cd /app \
+      && mkdir -p "${install_dir}" \
+      && cd "${install_dir}" \
       && { bashio::log.info "Fetching ${install_target} from npmjs.org (this can take a while)..."; true; } \
       && npm install --omit=dev --foreground-scripts "${install_target}"; }; then
     bashio::log.warning \
       "Failed to install ${install_target} from npm. Starting the bundled Matter Server instead."
+  elif [ ! -f "${install_dir}/node_modules/matter-server/dist/esm/MatterServer.js" ]; then
+    bashio::log.warning \
+      "Installed ${install_target} is missing the expected server entrypoint. Starting the bundled Matter Server instead."
   else
+    server_entry="${install_dir}/node_modules/matter-server/dist/esm/MatterServer.js"
     npm cache clean --force || true
-    find /app/node_modules -type d -name "cjs" -path "*/@matter/*" -exec rm -rf {} + 2>/dev/null || true
-    find /app/node_modules -type d -name "cjs" -path "*/@project-chip/*" -exec rm -rf {} + 2>/dev/null || true
+    find "${install_dir}/node_modules" -type d -name "cjs" -path "*/@matter/*" -exec rm -rf {} + 2>/dev/null || true
+    find "${install_dir}/node_modules" -type d -name "cjs" -path "*/@project-chip/*" -exec rm -rf {} + 2>/dev/null || true
   fi
 fi
 
@@ -167,4 +179,4 @@ matter_server_args+=(
   ${extra_args[@]}
 )
 
-exec node --enable-source-maps /app/node_modules/matter-server/dist/esm/MatterServer.js "${matter_server_args[@]}"
+exec node --enable-source-maps "${server_entry}" "${matter_server_args[@]}"


### PR DESCRIPTION
* use Matter Server 1.1.7
* adjust Beta installation
* update changelog and migration FAQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated Matter Server to a newer release and improved beta installation performance and handling.
* **Bug Fixes**
  * Improved add-on startup reliability when a pinned/beta install fails, with a safer fallback to the bundled server.
  * Clarified recovery steps when devices go offline after initial setup (including reconnecting via known IP).
* **Documentation**
  * Expanded the migration FAQ with a new troubleshooting section for startup and connectivity issues.
  * Refreshed release notes/upgrade warnings and version guidance for the latest add-on update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->