### PR TITLE
openthread_border_router: Honor otbr_log_level for the web UI & bump beta to v2026.07.0

### DIFF
--- a/openthread_border_router/CHANGELOG.md
+++ b/openthread_border_router/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.0.2
+
+- Honor the configured `otbr_log_level` for the OTBR web interface (previously always logged at info level)
+- Bump beta to OTBR POSIX version ec16e396 (tag v2026.07.0)
+
 ## 3.0.1
 
 - Backport fix for [CVE-2026-8369](https://github.com/advisories/GHSA-f6vh-g7gh-wh6h) to stable. This only affects users who have enabled NAT64 and use an untrusted network.

--- a/openthread_border_router/DOCS.md
+++ b/openthread_border_router/DOCS.md
@@ -2,7 +2,7 @@
 
 ## Installation
 
-Follow these steps to get the app (formerly knowon as add-on) installed on your system:
+Follow these steps to get the app (formerly known as add-on) installed on your system:
 
 1. In Home Assistant, go to **Settings** > **Apps** > **Install app**.
 2. Select the top right menu and **Repository**.

--- a/openthread_border_router/Dockerfile
+++ b/openthread_border_router/Dockerfile
@@ -16,7 +16,6 @@ ENV DOCKER=1
 
 
 COPY openthread-core-ha-config-posix.h /usr/src/
-COPY 0001-rest-SO_REUSEADDR.patch /usr/src/
 
 WORKDIR /usr/src
 RUN \
@@ -44,8 +43,7 @@ RUN \
     && cd /usr/src/ot-br-posix \
     && git fetch origin ${OTBR_BETA_VERSION} \
     && git checkout ${OTBR_BETA_VERSION} \
-    && git submodule update --init --recursive --depth 1 \
-    && patch -p1 < /usr/src/0001-rest-SO_REUSEADDR.patch
+    && git submodule update --init --recursive --depth 1
 
 WORKDIR /usr/src/ot-br-posix
 RUN \

--- a/openthread_border_router/build.yaml
+++ b/openthread_border_router/build.yaml
@@ -3,7 +3,7 @@ build_from:
   aarch64: ghcr.io/home-assistant/aarch64-base-debian:trixie
   amd64: ghcr.io/home-assistant/amd64-base-debian:trixie
 args:
-  OTBR_BETA_VERSION: 78d9c289473602d3faab535c4e7fbd12ca8d32f5
+  OTBR_BETA_VERSION: ec16e396382b4559e70a2c6fdeecb7d596a5e915
   OTBR_VERSION: 624a7d98e0dac5984c2982068f71fc81d2dbceb5
   UNIVERSAL_SILABS_FLASHER_VERSION: 0.1.2
   SERIALX_VERSION: 1.8.0

--- a/openthread_border_router/config.yaml
+++ b/openthread_border_router/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 3.0.1
+version: 3.0.2
 breaking_versions: [3.0.0]
 slug: openthread_border_router
 name: OpenThread Border Router

--- a/openthread_border_router/rootfs/etc/s6-overlay/s6-rc.d/otbr-agent/run
+++ b/openthread_border_router/rootfs/etc/s6-overlay/s6-rc.d/otbr-agent/run
@@ -13,7 +13,6 @@ declare device
 declare baudrate
 declare flow_control
 declare migrate_flow_control
-declare otbr_log_level
 declare otbr_log_level_int
 declare otbr_rest_listen
 declare otbr_rest_listen_port
@@ -59,36 +58,8 @@ else
     migrate_flow_control="none"
 fi
 
-otbr_log_level=$(bashio::string.lower "$(bashio::config otbr_log_level)")
-case "${otbr_log_level}" in
-    debug)
-        otbr_log_level_int="7"
-        ;;
-    info)
-        otbr_log_level_int="6"
-        ;;
-    notice)
-        otbr_log_level_int="5"
-        ;;
-    warning)
-        otbr_log_level_int="4"
-        ;;
-    error)
-        otbr_log_level_int="3"
-        ;;
-    critical)
-        otbr_log_level_int="2"
-        ;;
-    alert)
-        otbr_log_level_int="1"
-        ;;
-    emergency)
-        otbr_log_level_int="0"
-        ;;
-    *)
-        bashio::exit.nok "Unknown otbr_log_level: ${otbr_log_level}"
-        ;;
-esac
+otbr_log_level_int="$(otbr_log_level_int)" \
+    || bashio::exit.nok "Unknown otbr_log_level: $(bashio::config otbr_log_level)"
 
 # shellcheck disable=SC2015
 mkdir -p /data/thread && ln -sft /var/lib /data/thread || bashio::exit.nok "Could not create directory /var/lib/thread to store Thread data."

--- a/openthread_border_router/rootfs/etc/s6-overlay/s6-rc.d/otbr-agent/run
+++ b/openthread_border_router/rootfs/etc/s6-overlay/s6-rc.d/otbr-agent/run
@@ -58,7 +58,7 @@ else
     migrate_flow_control="none"
 fi
 
-otbr_log_level_int="$(otbr_log_level_int)" \
+otbr_log_level_int="$(otbr_log_level_to_int)" \
     || bashio::exit.nok "Unknown otbr_log_level: $(bashio::config otbr_log_level)"
 
 # shellcheck disable=SC2015

--- a/openthread_border_router/rootfs/etc/s6-overlay/s6-rc.d/otbr-web/run
+++ b/openthread_border_router/rootfs/etc/s6-overlay/s6-rc.d/otbr-web/run
@@ -4,9 +4,15 @@
 # ==============================================================================
 # Start OpenThread BorderRouter web interface
 # ==============================================================================
+# shellcheck source=./openthread_border_router/rootfs/etc/s6-overlay/scripts/otbr-agent-common
+. /etc/s6-overlay/scripts/otbr-agent-common
+
 bashio::log.info "Starting otbr-web..."
 declare otbr_web_port
+declare otbr_log_level_int
 
 otbr_web_port="$(bashio::addon.port 8080)"
+otbr_log_level_int="$(otbr_log_level_int)" \
+    || bashio::exit.nok "Unknown otbr_log_level: $(bashio::config otbr_log_level)"
 
-exec stdbuf -oL /usr/sbin/otbr-web -I wpan0 -d6 -s -a "::" -p "${otbr_web_port}"
+exec stdbuf -oL /usr/sbin/otbr-web -I wpan0 -d"${otbr_log_level_int}" -s -a "::" -p "${otbr_web_port}"

--- a/openthread_border_router/rootfs/etc/s6-overlay/s6-rc.d/otbr-web/run
+++ b/openthread_border_router/rootfs/etc/s6-overlay/s6-rc.d/otbr-web/run
@@ -12,7 +12,7 @@ declare otbr_web_port
 declare otbr_log_level_int
 
 otbr_web_port="$(bashio::addon.port 8080)"
-otbr_log_level_int="$(otbr_log_level_int)" \
+otbr_log_level_int="$(otbr_log_level_to_int)" \
     || bashio::exit.nok "Unknown otbr_log_level: $(bashio::config otbr_log_level)"
 
 exec stdbuf -oL /usr/sbin/otbr-web -I wpan0 -d"${otbr_log_level_int}" -s -a "::" -p "${otbr_web_port}"

--- a/openthread_border_router/rootfs/etc/s6-overlay/scripts/otbr-agent-common
+++ b/openthread_border_router/rootfs/etc/s6-overlay/scripts/otbr-agent-common
@@ -12,3 +12,25 @@ otbr_forward_egress_chain="OTBR_FORWARD_EGRESS"
 otbr_forward_nat64_chain="OTBR_FORWARD_NAT64"
 otbr_fw_mark="0x1001"
 
+# Map the configured otbr_log_level to the numeric level expected by the
+# otbr-agent/otbr-web -d flag. Echoes the numeric level on success, exits
+# non-zero on an unknown level.
+otbr_log_level_int() {
+    local level
+    level=$(bashio::string.lower "$(bashio::config otbr_log_level)")
+    case "${level}" in
+        debug)     echo "7" ;;
+        info)      echo "6" ;;
+        notice)    echo "5" ;;
+        warning)   echo "4" ;;
+        error)     echo "3" ;;
+        critical)  echo "2" ;;
+        alert)     echo "1" ;;
+        emergency) echo "0" ;;
+        *)
+            bashio::log.error "Unknown otbr_log_level: ${level}"
+            return 1
+            ;;
+    esac
+}
+

--- a/openthread_border_router/rootfs/etc/s6-overlay/scripts/otbr-agent-common
+++ b/openthread_border_router/rootfs/etc/s6-overlay/scripts/otbr-agent-common
@@ -13,9 +13,9 @@ otbr_forward_nat64_chain="OTBR_FORWARD_NAT64"
 otbr_fw_mark="0x1001"
 
 # Map the configured otbr_log_level to the numeric level expected by the
-# otbr-agent/otbr-web -d flag. Echoes the numeric level on success, exits
-# non-zero on an unknown level.
-otbr_log_level_int() {
+# otbr-agent/otbr-web -d flag. Echoes the numeric level on success, returns
+# non-zero on an unknown level (callers own the user-facing error message).
+otbr_log_level_to_int() {
     local level
     level=$(bashio::string.lower "$(bashio::config otbr_log_level)")
     case "${level}" in
@@ -27,10 +27,7 @@ otbr_log_level_int() {
         critical)  echo "2" ;;
         alert)     echo "1" ;;
         emergency) echo "0" ;;
-        *)
-            bashio::log.error "Unknown otbr_log_level: ${level}"
-            return 1
-            ;;
+        *)         return 1 ;;
     esac
 }
 


### PR DESCRIPTION
Bump the beta version to upstream tag v2026.07.0.

The web UI now respects otbr_log_level. otbr-web previously hardcoded -d6 (info), ignoring the configured level. The mapping is now a shared otbr_log_level_to_int() helper in otbr-agent-common, used by both otbr-web/run and otbr-agent/run (which drops its inline 30-line case block).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The add-on now honors the configured log level for both the web interface and core service logs.
  * Updated the bundled beta build to a newer upstream version.
* **Bug Fixes**
  * Improved startup behavior by validating `otbr_log_level` and exiting with a clear error if it can’t be mapped.
  * The web interface now launches with the correct configured port and matching log verbosity.
* **Documentation**
  * Fixed a typo in the Home Assistant installation instructions.
* **Chores**
  * Adjusted the beta build process to stop applying a legacy socket option patch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->