### PR TITLE
nginx_proxy: Set nginx proxy to start in services phase

### DIFF
--- a/nginx_proxy/CHANGELOG.md
+++ b/nginx_proxy/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.3.0
+
+- Change startup to `services` phase to start nginx before Home Assistant Core
+
 ## 4.2.0
 
 - update SSL/TLS configuration and add PQC key exchange following Mozilla guidelines

--- a/nginx_proxy/config.yaml
+++ b/nginx_proxy/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 4.2.0
+version: 4.3.0
 hassio_api: true
 slug: nginx_proxy
 name: NGINX Home Assistant SSL proxy

--- a/nginx_proxy/config.yaml
+++ b/nginx_proxy/config.yaml
@@ -42,3 +42,4 @@ schema:
     servers: str
   real_ip_from:
     - str
+startup: services


### PR DESCRIPTION
Hi,

I would like to propose changing the startup phase of the nginx_proxy to 'services' as in other similar projects (e.g. https://github.com/hassio-addons/addon-nginx-proxy-manager/blob/main/proxy-manager/config.yaml#L9). There was already an attempt at this (https://github.com/home-assistant/addons/pull/4164), but I want to try again with a cleaner pull request. Because in my mind, it makes more sense that way and makes the system as a whole feel more responsive when starting up.

I would greatly appreciate it if this could be merged, or let me know your thoughts and/or suggestions. Thanks for what you do!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved container startup behavior so required services are launched automatically on startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->