### PR TITLE
Drop the note that main release 9.0.0 should be considered too

### DIFF
--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -7,18 +7,15 @@
 
 ## 9.0.3
 
-- **⚠️ When upgrading from 8.x, please also consider the release notes for 9.0.0.**
 - Update [Matter Server from 1.1.1 to 1.1.2](https://github.com/matter-js/matterjs-server/blob/main/CHANGELOG.md#112-2026-06-25) to address reported issues
 
 ## 9.0.2
 
-- **⚠️ When upgrading from 8.x, please also consider the release notes for 9.0.0.**
 - Update Matter Server to 1.1.1 with increased Health check timings
 - Speed up Beta version installation
 
 ## 9.0.1
 
-- **⚠️ Please also consider the release notes for 9.0.0 when upgrading from 8.x.**
 - Fixes Heath check with default port settings
 
 ## 9.0.0


### PR DESCRIPTION
The update entity presenting the update automatically filters the CHANGELOG.md by heading according to version upgrade. So users who update from 8.x.x will see the relevant release notes already. No additional note required. The additional note is actually a bit confusing for users who already upgraded to 9.x.x.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Cleaned up repeated upgrade warning entries in the release notes for several recent versions.
  * Removed redundant warning bullets in the 9.0.2–9.0.3 sections while keeping the version update entries intact, making the changelog easier to scan.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->