### PR TITLE
nginx_proxy: fix missing Host header by using $host instead of $http_host

### DIFF
--- a/nginx_proxy/CHANGELOG.md
+++ b/nginx_proxy/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.2.1
+
+- fix "Missing 'Host' header in request" for requests without a `Host` header (HTTP/3, HTTP/1.0) by proxying `$host` instead of `$http_host`
+
 ## 4.2.0
 
 - update SSL/TLS configuration and add PQC key exchange following Mozilla guidelines

--- a/nginx_proxy/config.yaml
+++ b/nginx_proxy/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 4.2.0
+version: 4.2.1
 hassio_api: true
 slug: nginx_proxy
 name: NGINX Home Assistant SSL proxy

--- a/nginx_proxy/rootfs/etc/nginx/nginx.conf.gtpl
+++ b/nginx_proxy/rootfs/etc/nginx/nginx.conf.gtpl
@@ -116,12 +116,12 @@ http {
             {{- end }}
             proxy_set_header Origin $http_origin;
             proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_set_header Host $http_host;
+            proxy_set_header Host $host;
             proxy_redirect http:// https://;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection $connection_upgrade;
-            proxy_set_header X-Forwarded-Host $http_host;
+            proxy_set_header X-Forwarded-Host $host;
             {{- if not .options.real_ip_from }}
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             {{- else }}


### PR DESCRIPTION
## Summary

Fixes the `400 Missing 'Host' header in request.` error when accessing Home Assistant through this add-on after upgrading to Core 2026.7.0. Reported in #4680.

## Root cause

The proxy sets the upstream `Host` (and `X-Forwarded-Host`) from `$http_host`:

```nginx
proxy_set_header Host $http_host;
proxy_set_header X-Forwarded-Host $http_host;
```

`$http_host` is the literal incoming `Host` **request header**, which is empty whenever the client sends none:

- **HTTP/3** carries the authority in the `:authority` pseudo-header and typically sends no `Host` header. This add-on offers HTTP/3 when `443/udp` is mapped (added in #4234).
- HTTP/1.0 and some clients likewise send no `Host` header.

HTTP/1.1 and HTTP/2 keep working because nginx populates/synthesises a `Host` for them, so the failure is intermittent — it often only appears once a browser caches `Alt-Svc: h3` and switches to HTTP/3 on a later visit.

Home Assistant Core 2026.7.0 bundles an aiohttp change (aio-libs/aiohttp#12264) that no longer defaults a missing `Host`, so the previously-tolerated empty `Host` now returns a 400.

## Fix

Use `$host` instead of `$http_host`. `$host` is derived from `:authority` / `Host` / `server_name` and is never empty for a matched server, so it is correct across HTTP/1.1, HTTP/2 and HTTP/3.

## Testing

- Reproduced on add-on 4.2.0 / Core 2026.7 with `443/udp` mapped: a browser negotiating HTTP/3 triggers the 400; HTTP/1.1 and HTTP/2 are unaffected.
- Confirmed the interim workaround (unmap `443/udp` to disable QUIC) restores access, isolating HTTP/3 + `$http_host` as the cause.

Closes #4680
