### PR TITLE
Let Home Assistant own the Z-Wave JS statistics opt-in

### DIFF
--- a/zwave_js/rootfs/usr/share/tempio/zwave_config.conf
+++ b/zwave_js/rootfs/usr/share/tempio/zwave_config.conf
@@ -22,6 +22,7 @@
         "S2_Authenticated": "{{ .lr_s2_authenticated }}"
     },
     "enableSoftReset": {{ .soft_reset }},
+    "enableStatistics": false,
     "presets": {{ .presets }},
     "serverEnabled": true,
     "serverPort": 3000,


### PR DESCRIPTION
Setting `"enableStatistics": false` in the external settings marks the statistics opt-in as externally managed in Z-Wave JS UI. This stops the UI from showing its own opt-in dialog and enabling statistics with its application name before Home Assistant can.

Statistics are now enabled solely through Home Assistant's data collection preference, so usage is attributed to "Home Assistant" again. Requires a Z-Wave JS UI release containing `zwave-js/zwave-js-ui` support for externally managed statistics; older versions ignore the unknown field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new configuration option to disable statistics collection in generated Z-Wave configuration output by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->