### PR TITLE
Matter Server: Change panel icon to 'mdi:matter'

### DIFF
--- a/matter_server/config.yaml
+++ b/matter_server/config.yaml
@@ -20,6 +20,7 @@ host_dbus: true
 image: homeassistant/{arch}-addon-matter-server
 ingress: true
 ingress_port: 5580
+panel_icon: mdi:matter
 init: false
 map:
   - type: addon_config


### PR DESCRIPTION
This changes the `panel_icon` for the Matter Server add-on to the [newly added `mdi:matter` icon](https://github.com/home-assistant/frontend/pull/52568).

As this icon was only introduced with Home Assistant Core 2026.7.0, we probably want to wait a bit until a good amount of people have upgraded before merging this.

Fixes: https://github.com/home-assistant/addons/issues/4308

<details><summary>Note: Related similar change for ESPHome (click to expand)</summary>
<p>

Paulus made a similar change for ESPHome right after the Core release with its new icon, which led to a PR suggesting to revert that change due to the missing icon:
- https://github.com/esphome/home-assistant-addon/pull/231
  (introduction of new icon)
- https://github.com/esphome/home-assistant-addon/pull/236
  (PR suggesting to revert)

</p>
</details> 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Matter icon to the add-on’s configuration panel for improved visual identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->