### PR TITLE
Bump to 3.4.0 and add vad_clip

### DIFF
--- a/whisper/CHANGELOG.md
+++ b/whisper/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.4.0
+
+- Add `vad_clip` option to enable VAD clipping of audio before processing (faster processing for many backends, may not work on Pi 4)
+- Bump `pysilero-vad` to use GGML version
+
 ## 3.3.2
 
 - Add `libgomp1` so `torch`/`torchaudio` can load again, fixing the startup crash loop introduced in 3.3.1

--- a/whisper/DOCS.md
+++ b/whisper/DOCS.md
@@ -117,6 +117,12 @@ Use streaming model with `sherpa` backend.
 
 This overrides the default English model (parakeet) with a faster but less accurate streaming model (sherpa-onnx-streaming-zipformer-en-2023-06-26).
 
+### Option: `vad_clip`
+
+Use voice activity detection (VAD) to clip silence from audio before transcription. This is disabled by default.
+
+This is mainly a latency win for silence-heavy audio with length-proportional batch backends like `sherpa` and `funasr`; streaming backends are unaffected.
+
 ### Option: `local_files_only`
 
 Only use models that have already been downloaded, and never check online for

--- a/whisper/build.yaml
+++ b/whisper/build.yaml
@@ -3,4 +3,4 @@ build_from:
   amd64: ghcr.io/home-assistant/amd64-base-debian:bookworm
   aarch64: ghcr.io/home-assistant/aarch64-base-debian:bookworm
 args:
-  WYOMING_WHISPER_VERSION: 3.3.1
+  WYOMING_WHISPER_VERSION: 3.4.0

--- a/whisper/config.yaml
+++ b/whisper/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 3.3.2
+version: 3.4.0
 slug: whisper
 name: Whisper
 description: Speech-to-text with Whisper
@@ -22,6 +22,7 @@ options:
   stt_library: "auto"
   whisper_task: "transcribe"
   sherpa_streaming: false
+  vad_clip: false
   local_files_only: false
   debug_logging: false
 schema:
@@ -39,6 +40,7 @@ schema:
   whisper_task: |
     list(transcribe|translate)
   sherpa_streaming: bool
+  vad_clip: bool
   local_files_only: bool
   debug_logging: bool
 ports:

--- a/whisper/rootfs/etc/s6-overlay/s6-rc.d/whisper/run
+++ b/whisper/rootfs/etc/s6-overlay/s6-rc.d/whisper/run
@@ -34,6 +34,10 @@ if bashio::config.true 'sherpa_streaming'; then
     flags+=('--sherpa-streaming')
 fi
 
+if bashio::config.true 'vad_clip'; then
+    flags+=('--vad-clip')
+fi
+
 if bashio::config.true 'local_files_only'; then
     flags+=('--local-files-only')
 fi

--- a/whisper/translations/en.yaml
+++ b/whisper/translations/en.yaml
@@ -61,6 +61,14 @@ configuration:
 
       This overrides the default English model with a faster but less accurate
       streaming model.
+  vad_clip:
+    name: VAD clip
+    description: >-
+      Use voice activity detection (VAD) to clip silence from audio before
+      transcription.
+
+      This is a latency win for silence-heavy audio, especially with batch
+      backends like sherpa and funasr. Streaming backends are unaffected.
   local_files_only:
     name: Local files only
     description: >-


### PR DESCRIPTION
- Bump wyoming-faster-whisper to 3.4.0 (disables VAD clip by default, see https://github.com/home-assistant/addons/issues/4694)
- Add `vad_clip` option for supported CPUs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new option to clip silence from audio before transcription, which can improve handling of silence-heavy recordings.
  * Updated the add-on to version 3.4.0.

* **Bug Fixes**
  * Improved audio processing behavior for supported batch-based backends when silence clipping is enabled.

* **Documentation**
  * Documented the new silence-clipping option and its default setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->