### PR TITLE
nginx_proxy: Update Host and X-Forwarded-Host headers

### DIFF
--- a/nginx_proxy/CHANGELOG.md
+++ b/nginx_proxy/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 4.3.0
 
-- Use `$host` instead of `$http_host` for Host and X-Forwarded-Host headers
+- use `$host` instead of `$http_host` for `Host` and `X-Forwarded-Host` headers
 
 ## 4.2.0
 

--- a/nginx_proxy/CHANGELOG.md
+++ b/nginx_proxy/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 4.3.0
+## 4.4.0
 
 - use `$host` instead of `$http_host` for `Host` and `X-Forwarded-Host` headers
+
+## 4.3.0
+
+- Update base image to Alpine 3.24 (base image tag 3.24-2026.06.1) with nginx 1.30.x
 
 ## 4.2.0
 

--- a/nginx_proxy/CHANGELOG.md
+++ b/nginx_proxy/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.3.0
+
+- Use `$host` instead of `$http_host` for Host and X-Forwarded-Host headers
+
 ## 4.2.0
 
 - update SSL/TLS configuration and add PQC key exchange following Mozilla guidelines

--- a/nginx_proxy/build.yaml
+++ b/nginx_proxy/build.yaml
@@ -1,4 +1,4 @@
 ---
 build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-base:3.23-2025.12.2
-  amd64: ghcr.io/home-assistant/amd64-base:3.23-2025.12.2
+  aarch64: ghcr.io/home-assistant/aarch64-base:3.24-2026.06.1
+  amd64: ghcr.io/home-assistant/amd64-base:3.24-2026.06.1

--- a/nginx_proxy/config.yaml
+++ b/nginx_proxy/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 4.3.0
+version: 4.4.0
 hassio_api: true
 slug: nginx_proxy
 name: NGINX Home Assistant SSL proxy

--- a/nginx_proxy/config.yaml
+++ b/nginx_proxy/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 4.2.0
+version: 4.3.0
 hassio_api: true
 slug: nginx_proxy
 name: NGINX Home Assistant SSL proxy

--- a/nginx_proxy/rootfs/etc/nginx/nginx.conf.gtpl
+++ b/nginx_proxy/rootfs/etc/nginx/nginx.conf.gtpl
@@ -116,12 +116,12 @@ http {
             {{- end }}
             proxy_set_header Origin $http_origin;
             proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_set_header Host $http_host;
+            proxy_set_header Host $host;
             proxy_redirect http:// https://;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection $connection_upgrade;
-            proxy_set_header X-Forwarded-Host $http_host;
+            proxy_set_header X-Forwarded-Host $host;
             {{- if not .options.real_ip_from }}
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             {{- else }}


### PR DESCRIPTION
This pull request updates the `Host` and `X-Forwarded-Host` headers in the Nginx proxy configuration to use the `$host` variable instead of `$http_host`.

Fixes #4680. When a client connects over HTTP/3, it sends the `:authority` pseudo-header instead of a literal `Host` header, leaving `$http_host` empty. Nginx omits headers with empty values, so no `Host` header was sent upstream at all. The aiohttp version shipped in Home Assistant 2026.7.0 now rejects HTTP/1.1 requests without a `Host` header (aio-libs/aiohttp#12264), which surfaced the issue.

`$host` is never empty — it falls back to `:authority` and then `server_name` — so upstream requests always include a valid `Host` header regardless of client protocol.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reverse-proxy header handling so forwarded requests now use the normalized host value (`Host` and `X-Forwarded-Host`).
  * This improves consistency of host-related behavior across proxied requests.
* **Documentation**
  * Updated the changelog to reflect the configuration change and bump the add-on version to 4.4.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->