### PR TITLE
nginx_proxy: bump to Alpine 3.24

### DIFF
--- a/nginx_proxy/CHANGELOG.md
+++ b/nginx_proxy/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.3.0
+
+- Update base image to Alpine 3.24 (base image tag 3.24-2026.06.1)
+
 ## 4.2.0
 
 - update SSL/TLS configuration and add PQC key exchange following Mozilla guidelines

--- a/nginx_proxy/CHANGELOG.md
+++ b/nginx_proxy/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 4.3.0
 
-- Update base image to Alpine 3.24 (base image tag 3.24-2026.06.1)
+- Update base image to Alpine 3.24 (base image tag 3.24-2026.06.1) with nginx 1.30.x
 
 ## 4.2.0
 

--- a/nginx_proxy/build.yaml
+++ b/nginx_proxy/build.yaml
@@ -1,4 +1,4 @@
 ---
 build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-base:3.23-2025.12.2
-  amd64: ghcr.io/home-assistant/amd64-base:3.23-2025.12.2
+  aarch64: ghcr.io/home-assistant/aarch64-base:3.24-2026.06.1
+  amd64: ghcr.io/home-assistant/amd64-base:3.24-2026.06.1

--- a/nginx_proxy/config.yaml
+++ b/nginx_proxy/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 4.2.0
+version: 4.3.0
 hassio_api: true
 slug: nginx_proxy
 name: NGINX Home Assistant SSL proxy


### PR DESCRIPTION
Release: https://github.com/home-assistant/docker-base/releases/tag/2026.06.1
Diff: https://github.com/home-assistant/docker-base/compare/2025.12.2...2026.06.1

New nginx version is 1.30.3-r0 and closes https://github.com/home-assistant/addons/issues/4645
Openssl version is the same as on Alpine 3.23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the base image version used for both supported build targets to a newer Alpine release.
  * Bumped the add-on version to **4.3.0** and refreshed the changelog accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->