### PR TITLE
nginx_proxy: always send Host header to Home Assistant

### DIFF
--- a/nginx_proxy/CHANGELOG.md
+++ b/nginx_proxy/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.4.0
+
+- Fix HTTP/3 requests with Home Assistant 2026.7.0 and newer
+
 ## 4.3.0
 
 - Update base image to Alpine 3.24 (base image tag 3.24-2026.06.1) with nginx 1.30.x

--- a/nginx_proxy/DOCS.md
+++ b/nginx_proxy/DOCS.md
@@ -94,6 +94,7 @@ If specified, configures Nginx to use HTTP/3 with QUIC/UDP on this UDP port in a
 ## Known issues and limitations
 
 - By default, port 80 is disabled in the app configuration in case the port is needed for other components or apps like `emulated_hue`.
+- With HTTP/3 (QUIC), Nginx cannot forward the port of the address used by the client to Home Assistant (the `Host` and `X-Forwarded-Host` headers contain the hostname without port). If Home Assistant is reachable on a non-default port (anything other than 443), this breaks features which validate the request host and port against the configured external URL, such as the OAuth2 discovery endpoints used by MCP clients. Regular browser and app logins are not affected. To avoid this, use the default port 443 or disable HTTP/3.
 
 ## Troubleshooting
 

--- a/nginx_proxy/config.yaml
+++ b/nginx_proxy/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 4.3.0
+version: 4.4.0
 hassio_api: true
 slug: nginx_proxy
 name: NGINX Home Assistant SSL proxy

--- a/nginx_proxy/rootfs/etc/nginx/nginx.conf.gtpl
+++ b/nginx_proxy/rootfs/etc/nginx/nginx.conf.gtpl
@@ -18,6 +18,16 @@ http {
         ''      close;
     }
 
+    # Prefer the verbatim Host header (preserves port), but fall back to
+    # $host when it is empty. HTTP/3 clients send an :authority pseudo-header
+    # instead of a Host header, leaving $http_host empty; nginx then omits the
+    # header entirely and aiohttp (HA 2026.7.0+) rejects the request with a
+    # 400 "Missing 'Host' header". $host falls back to :authority/server_name.
+    map $http_host $forward_host {
+        default $http_host;
+        ''      $host;
+    }
+
     server_tokens off;
 
     server_names_hash_bucket_size 128;
@@ -116,12 +126,12 @@ http {
             {{- end }}
             proxy_set_header Origin $http_origin;
             proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_set_header Host $http_host;
+            proxy_set_header Host $forward_host;
             proxy_redirect http:// https://;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection $connection_upgrade;
-            proxy_set_header X-Forwarded-Host $http_host;
+            proxy_set_header X-Forwarded-Host $forward_host;
             {{- if not .options.real_ip_from }}
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             {{- else }}


### PR DESCRIPTION
HTTP/3 clients send an :authority pseudo-header instead of a literal Host header. Unlike for HTTP/2, nginx does not populate $http_host from :authority for HTTP/3 (see https://github.com/nginx/nginx/issues/455), so "proxy_set_header Host $http_host;" evaluates to an empty value and nginx omits the Host header on the upstream request entirely. The same applies to X-Forwarded-Host.

Home Assistant 2026.7.0 ships aiohttp 3.14, which enforces RFC 9112 section 3.2: an HTTP/1.1 request without a Host header is rejected with 400 "Missing 'Host' header in request" (https://github.com/aio-libs/aiohttp/pull/12264). Since the proxy speaks HTTP/1.1 upstream, HTTP/3 clients started receiving 400 errors.

The common fix is to use $host instead (as e.g. Authelia recommends, https://github.com/authelia/authelia/discussions/7146), which falls back to :authority and then server_name and is therefore never empty. However, $host is normalized: lowercased and with the port stripped. Home Assistant's OAuth2 discovery endpoints (`/.well-known/oauth-authorization-server`, `/.well-known/oauth-protected-resource` and the WWW-Authenticate header on 401 responses, used by RFC 8414/9728 discovery, notably by MCP connectors) match the request host *and port* against the configured external URL. With plain $host, an external URL on a non-default port would never match again, regressing such setups.

Instead, map the client's Host header verbatim ($http_host, which preserves the port) and fall back to $host only when it is empty. This keeps HTTP/1.1 and HTTP/2 behavior byte-for-byte unchanged and fixes the missing Host header for HTTP/3.

Known limitation: for HTTP/3 clients the port is still lost in the fallback, as nginx exposes no variable carrying the full :authority. HTTP/3 combined with a non-default external port therefore still cannot pass the OAuth discovery port match; this is unfixable at the proxy layer until nginx populates the Host header from :authority for HTTP/3 as well.

Fixes #4680

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved HTTP/3 handling so requests now preserve the correct host information when forwarded.
  * Added a new release note entry for version 4.4.0.

* **Bug Fixes**
  * Fixed issues affecting HTTP/3 requests with newer Home Assistant releases.
  * Reduced host/port validation problems for some non-default port setups, especially during certain login and discovery flows.

* **Documentation**
  * Updated the known issues section with guidance for HTTP/3 deployments and port 443 recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->