### PR TITLE
Bump torch to avoid CPU regression

### DIFF
--- a/whisper/CHANGELOG.md
+++ b/whisper/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.5.0
+
+- Bump torch to avoid regression: https://github.com/pytorch/pytorch/issues/146792
+- Use `find_spec` to avoid importing modules for backend check
+
 ## 3.4.1
 
 - Add `vad_clip` option to enable VAD clipping of audio before processing (faster processing for many backends, may not work on Pi 4)

--- a/whisper/Dockerfile
+++ b/whisper/Dockerfile
@@ -28,8 +28,8 @@ RUN \
     \
     && pip3 install --no-cache-dir \
         --index-url 'https://download.pytorch.org/whl/cpu' \
-        'torch==2.6.0' \
-        'torchaudio==2.6.0' \
+        'torch==2.7.1' \
+        'torchaudio==2.7.1' \
     \
     && apt-get purge -y --auto-remove \
         build-essential \

--- a/whisper/build.yaml
+++ b/whisper/build.yaml
@@ -3,4 +3,4 @@ build_from:
   amd64: ghcr.io/home-assistant/amd64-base-debian:bookworm
   aarch64: ghcr.io/home-assistant/aarch64-base-debian:bookworm
 args:
-  WYOMING_WHISPER_VERSION: 3.4.1
+  WYOMING_WHISPER_VERSION: 3.5.0

--- a/whisper/config.yaml
+++ b/whisper/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 3.4.1
+version: 3.5.0
 slug: whisper
 name: Whisper
 description: Speech-to-text with Whisper


### PR DESCRIPTION
https://github.com/rhasspy/wyoming-faster-whisper/compare/v3.4.1...v3.5.0

Actual fix for: https://github.com/home-assistant/addons/issues/4694
We were hitting a torch regression: https://github.com/pytorch/pytorch/issues/146792