### PR TITLE
Samba: Normalize stored enabled_shares values to lower case

### DIFF
--- a/samba/CHANGELOG.md
+++ b/samba/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 12.7.2
+
+- Normalize stored `enabled_shares` values to lower case at startup. Values
+  were already handled case-insensitively at runtime; this persists the
+  canonical form in preparation for a stricter schema in a future release.
+
 ## 12.7.1
 
 - Enabled kernel oplocks in smb.conf to ensure changes made to files on disk are available immediately via SMBD. This covers all shares except backup, and media as the contents shouldn't be changed by the server once they're written in those shares.

--- a/samba/config.yaml
+++ b/samba/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 12.7.1
+version: 12.7.2
 slug: samba
 name: Samba share
 description: Expose Home Assistant folders with SMB/CIFS

--- a/samba/rootfs/etc/s6-overlay/s6-rc.d/init-smbd/run
+++ b/samba/rootfs/etc/s6-overlay/s6-rc.d/init-smbd/run
@@ -8,6 +8,8 @@ declare password
 declare username
 declare config_username
 declare samba_username
+declare stored_options
+declare migration_payload
 declare -a interfaces=()
 export HOSTNAME
 
@@ -20,6 +22,19 @@ if ! bashio::config.has_value 'username' || ! bashio::config.has_value 'password
 fi
 
 bashio::config.require "enabled_shares" "Samba is a tool for sharing folders. Starting it without sharing any folders defeats the purpose."
+
+# Migrate stored enabled_shares values to lower case. Values have always
+# been treated case-insensitively at runtime; persisting them lower case
+# prepares for a future release that restricts the schema to the exact
+# share names.
+stored_options=$(bashio::api.supervisor GET /addons/self/info false | jq '.options')
+if jq -e '(.enabled_shares // []) | any(. != ascii_downcase)' <<< "${stored_options}" > /dev/null; then
+    bashio::log.info "Migrating enabled_shares configuration values to lower case"
+    migration_payload=$(jq -c '{options: (.enabled_shares |= map(ascii_downcase))}' <<< "${stored_options}")
+    if ! bashio::api.supervisor POST /addons/self/options "${migration_payload}"; then
+        bashio::log.warning "Could not migrate enabled_shares values; will retry on next start"
+    fi
+fi
 
 # Read hostname from API or setting default "hassio"
 HOSTNAME=$(bashio::info.hostname)


### PR DESCRIPTION
## Summary

Step 1 of the plan agreed in home-assistant/supervisor#7023: prepare `enabled_shares` for a strict `list()` schema by normalizing stored values to lower case at startup. Values have always been validated case-insensitively and lower-cased at runtime before rendering smb.conf, so this changes no behavior — it only persists the canonical form.

On startup the app reads its stored options via the Supervisor API and, only when an `enabled_shares` value is not already lower case, writes them back lower-cased. On API failure it logs a warning and continues to boot, retrying on the next start.

Step 2 (separate, breaking): home-assistant/addons#4718 switches the schema from `match()` to `list()`, which also fixes the empty suggestion list in the configuration UI (home-assistant/frontend#51510).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic normalization of stored share names to lowercase during startup.
  * If updating stored configuration fails, a warning is logged and the update will be retried on the next startup.

* **Documentation**
  * Updated release notes with a new 12.8.1 entry describing the startup-time normalization behavior.

* **Chores**
  * Updated the Samba add-on version to 12.8.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->