### PR TITLE
Samba: Restrict enabled_shares schema to list() of share names

### DIFF
--- a/samba/CHANGELOG.md
+++ b/samba/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 12.7.2
+
+- Normalize stored `enabled_shares` values to lower case at startup. Values
+  were already handled case-insensitively at runtime; this persists the
+  canonical form in preparation for a stricter schema in a future release.
+
 ## 12.7.1
 
 - Enabled kernel oplocks in smb.conf to ensure changes made to files on disk are available immediately via SMBD. This covers all shares except backup, and media as the contents shouldn't be changed by the server once they're written in those shares.

--- a/samba/CHANGELOG.md
+++ b/samba/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 13.0.0
+
+- BREAKING: `enabled_shares` values must now be lower case. The schema
+  restricts values to the exact share names and the configuration UI offers
+  them as a multi-select. Configs saved on 12.7.2 or later were migrated
+  automatically; older configs with non-lower-case values fail validation
+  with a clear error and must be re-selected.
+
 ## 12.7.2
 
 - Normalize stored `enabled_shares` values to lower case at startup. Values

--- a/samba/config.yaml
+++ b/samba/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 12.7.2
+version: 13.0.0
 slug: samba
 name: Samba share
 description: Expose Home Assistant folders with SMB/CIFS
@@ -54,7 +54,7 @@ schema:
   workgroup: str
   local_master: bool
   enabled_shares:
-    - "match(^(?i:(addons|addon_configs|backup|config|media|share|ssl))$)"
+    - "list(addons|addon_configs|backup|config|media|share|ssl)"
   compatibility_mode: bool
   apple_compatibility_mode: bool
   server_signing: list(default|auto|mandatory|disabled)

--- a/samba/config.yaml
+++ b/samba/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 12.7.1
+version: 12.7.2
 slug: samba
 name: Samba share
 description: Expose Home Assistant folders with SMB/CIFS

--- a/samba/rootfs/etc/s6-overlay/s6-rc.d/init-smbd/run
+++ b/samba/rootfs/etc/s6-overlay/s6-rc.d/init-smbd/run
@@ -8,6 +8,8 @@ declare password
 declare username
 declare config_username
 declare samba_username
+declare stored_options
+declare migration_payload
 declare -a interfaces=()
 export HOSTNAME
 
@@ -20,6 +22,19 @@ if ! bashio::config.has_value 'username' || ! bashio::config.has_value 'password
 fi
 
 bashio::config.require "enabled_shares" "Samba is a tool for sharing folders. Starting it without sharing any folders defeats the purpose."
+
+# Migrate stored enabled_shares values to lower case. Values have always
+# been treated case-insensitively at runtime; persisting them lower case
+# prepares for a future release that restricts the schema to the exact
+# share names.
+stored_options=$(bashio::api.supervisor GET /addons/self/info false | jq '.options')
+if jq -e '(.enabled_shares // []) | any(. != ascii_downcase)' <<< "${stored_options}" > /dev/null; then
+    bashio::log.info "Migrating enabled_shares configuration values to lower case"
+    migration_payload=$(jq -c '{options: (.enabled_shares |= map(ascii_downcase))}' <<< "${stored_options}")
+    if ! bashio::api.supervisor POST /addons/self/options "${migration_payload}"; then
+        bashio::log.warning "Could not migrate enabled_shares values; will retry on next start"
+    fi
+fi
 
 # Read hostname from API or setting default "hassio"
 HOSTNAME=$(bashio::info.hostname)

--- a/samba/rootfs/etc/s6-overlay/s6-rc.d/init-smbd/run
+++ b/samba/rootfs/etc/s6-overlay/s6-rc.d/init-smbd/run
@@ -8,8 +8,6 @@ declare password
 declare username
 declare config_username
 declare samba_username
-declare stored_options
-declare migration_payload
 declare -a interfaces=()
 export HOSTNAME
 
@@ -22,19 +20,6 @@ if ! bashio::config.has_value 'username' || ! bashio::config.has_value 'password
 fi
 
 bashio::config.require "enabled_shares" "Samba is a tool for sharing folders. Starting it without sharing any folders defeats the purpose."
-
-# Migrate stored enabled_shares values to lower case. Values have always
-# been treated case-insensitively at runtime; persisting them lower case
-# prepares for a future release that restricts the schema to the exact
-# share names.
-stored_options=$(bashio::api.supervisor GET /addons/self/info false | jq '.options')
-if jq -e '(.enabled_shares // []) | any(. != ascii_downcase)' <<< "${stored_options}" > /dev/null; then
-    bashio::log.info "Migrating enabled_shares configuration values to lower case"
-    migration_payload=$(jq -c '{options: (.enabled_shares |= map(ascii_downcase))}' <<< "${stored_options}")
-    if ! bashio::api.supervisor POST /addons/self/options "${migration_payload}"; then
-        bashio::log.warning "Could not migrate enabled_shares values; will retry on next start"
-    fi
-fi
 
 # Read hostname from API or setting default "hassio"
 HOSTNAME=$(bashio::info.hostname)
@@ -64,7 +49,6 @@ fi
 
 jq --arg username "${samba_username}" \
     ".interfaces = $(jq -c -n '$ARGS.positional' --args -- "${interfaces[@]}") |
-    .enabled_shares.[] |= ascii_downcase |
     .username = \$username" /data/options.json \
     | tempio \
       -template /usr/share/tempio/smb.gtpl \

--- a/samba/rootfs/etc/s6-overlay/s6-rc.d/init-smbd/run
+++ b/samba/rootfs/etc/s6-overlay/s6-rc.d/init-smbd/run
@@ -8,8 +8,6 @@ declare password
 declare username
 declare config_username
 declare samba_username
-declare stored_options
-declare migration_payload
 declare -a interfaces=()
 export HOSTNAME
 
@@ -22,19 +20,6 @@ if ! bashio::config.has_value 'username' || ! bashio::config.has_value 'password
 fi
 
 bashio::config.require "enabled_shares" "Samba is a tool for sharing folders. Starting it without sharing any folders defeats the purpose."
-
-# Migrate stored enabled_shares values to lower case. Values have always
-# been treated case-insensitively at runtime; persisting them lower case
-# prepares for a future release that restricts the schema to the exact
-# share names.
-stored_options=$(bashio::api.supervisor GET /addons/self/info false | jq '.options')
-if jq -e '(.enabled_shares // []) | any(. != ascii_downcase)' <<< "${stored_options}" > /dev/null; then
-    bashio::log.info "Migrating enabled_shares configuration values to lower case"
-    migration_payload=$(jq -c '{options: (.enabled_shares |= map(ascii_downcase))}' <<< "${stored_options}")
-    if ! bashio::api.supervisor POST /addons/self/options "${migration_payload}"; then
-        bashio::log.warning "Could not migrate enabled_shares values; will retry on next start"
-    fi
-fi
 
 # Read hostname from API or setting default "hassio"
 HOSTNAME=$(bashio::info.hostname)

--- a/samba/translations/en.yaml
+++ b/samba/translations/en.yaml
@@ -15,14 +15,8 @@ configuration:
     name: Local master
     description: Enable to try and become a local master browser on a subnet.
   enabled_shares:
-    name: >-
-      Enabled Shares - allowed values are:
-      addons, addon_configs, backup, config, media, share, or ssl.
-    description: >-
-      List of file shares to make available.
-      Adding a share requires typing its name to add it.
-      The listed values are the only allowed values.
-      The configuration cannot be saved if any non-allowed value is in the list.
+    name: Enabled Shares
+    description: List of file shares to make available.
   compatibility_mode:
     name: Enable Compatibility Mode
     description: >-


### PR DESCRIPTION
## Summary

Step 2 of the plan from home-assistant/supervisor#7023: switch `enabled_shares` from `match(^(?i:(...))$)` to `list(addons|addon_configs|backup|config|media|share|ssl)`. The configuration UI then offers the valid share names as a populated multi-select instead of an empty free-text suggestion list, resolving home-assistant/frontend#51510.

BREAKING: values must be exactly lower case. Configs saved on 12.7.2+ (home-assistant/addons#4717) were migrated automatically; older configs with non-lower-case values fail validation with a clear message. The step-1 startup migration and the runtime lower-casing are removed as dead code.

Stacked on #4717 (the diff includes it until that PR merges). Opened as a draft so maintainers can schedule/bundle it with other breaking changes (e.g. the NetBIOS default change mentioned in the supervisor discussion).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Enabled share names must now be entered in lowercase.
  * Existing configurations saved on version 12.8.1 or later are migrated automatically.
  * Older configurations with uppercase share names may fail validation and require the shares to be selected again.

* **Documentation**
  * Simplified the enabled shares label and instructions.
  * Updated release information for version 13.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

**Update (2026-07-15):** #4717 merged; the step-1 migration shipped as 12.8.1 (the 12.7.2 references above predate the renumbering). This PR is no longer stacked — the diff is step 2 only, rebased on current master. Configs saved on 12.8.1 or later were migrated automatically; older configs with non-lower-case values fail validation with a clear message. The 12.8.1 startup migration and the runtime lower-casing are removed as dead code: with the strict schema, validation rejects a non-migrated config before the add-on can start, so the migration could never run when it was needed.
