### PR TITLE
openthread_border_router: Fix installation docs

### DIFF
--- a/openthread_border_router/DOCS.md
+++ b/openthread_border_router/DOCS.md
@@ -5,8 +5,6 @@
 Follow these steps to get the app (formerly known as add-on) installed on your system:
 
 1. In Home Assistant, go to **Settings** > **Apps** > **Install app**.
-2. Select the top right menu and **Repository**.
-3. Add "https://github.com/home-assistant/addons" to add the **Home Assistant App Repository for Development** repository.
 4. Find the **OpenThread Border Router** app and select it.
 5. Select the **Install** button.
 

--- a/openthread_border_router/DOCS.md
+++ b/openthread_border_router/DOCS.md
@@ -5,8 +5,8 @@
 Follow these steps to get the app (formerly known as add-on) installed on your system:
 
 1. In Home Assistant, go to **Settings** > **Apps** > **Install app**.
-4. Find the **OpenThread Border Router** app and select it.
-5. Select the **Install** button.
+2. Find the **OpenThread Border Router** app and select it.
+3. Select the **Install** button.
 
 ## How to use
 


### PR DESCRIPTION
The installation docs still mention the development app repository which this app has been graduated from a while back. Adjust accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Simplified Home Assistant OpenThread Border Router installation instructions by removing the step to configure the development add-ons repository (including the earlier top-right menu guidance and URL entry).
  * Updated the flow so that, after the initial Home Assistant navigation step, you are directed immediately to find the **OpenThread Border Router** app and select **Install** (with the steps renumbered accordingly).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->