### PR TITLE
Matter Server: bump to 1.2.6, add time_sync and default_fabric_label options (9.1.0)

### DIFF
--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -1,8 +1,18 @@
 # Changelog
 
-## 9.0.4
+## 9.1.0
 
 - **⚠️ When upgrading from 8.x, please also consider the release notes for 9.0.0.**
+- Update [Matter Server from 1.1.7 to 1.2.6](https://github.com/matter-js/matterjs-server/blob/main/CHANGELOG.md)
+  - Supports Matter 1.6.0
+  - Synchronize Time to devices that support this
+  - Experimental Support for Battery Saving mode of ICD devices
+  - Many Optimizations and Fixes
+- Add `time_sync` option (`auto`/`on`/`off`, default `auto`) to push the current time to Matter devices via the Matter Server's `--enable-time-sync` flag. `auto` enables time sync only when the host clock is NTP synchronized; `on` always enables it (with a warning if NTP is not synchronized); `off` disables it.
+- Add `default_fabric_label` option to pin the fabric label via the Matter Server's `--default-fabric-label` flag. When set, changing the label via the WebSocket API is blocked.
+
+## 9.0.4
+
 - Update [Matter Server from 1.1.2 to 1.1.7](https://github.com/matter-js/matterjs-server/blob/main/CHANGELOG.md#117-2026-07-01) to address reported issues and optimize RAM and CPU usage (a lot)
 
 ## 9.0.3

--- a/matter_server/DOCS.md
+++ b/matter_server/DOCS.md
@@ -54,7 +54,7 @@ App configuration:
 | beta                 | Install the latest `matter-server` from npm on startup instead of the bundled version. On failure a warning is logged and the bundled version is started. |
 | enable_test_net_dcl  | Enable test-net DCL for PAA root certificates, OTA updates and other device information.                |
 | time_sync            | Whether the Matter Server pushes the current time to Matter devices: `auto` (default; on only when the host clock is NTP synchronized), `on` (always; warns if NTP is not synchronized), or `off`. |
-| default_fabric_label | Pin the fabric label (shown on Matter devices, max 32 characters) to this value. Use this if you use the Matter Server from multiple Home Assistant instances, which otherwise each keep pushing their own instance name as the label. When set, changing the label via the WebSocket API is blocked. |
+| default_fabric_label | Pin the fabric label (shown on Matter devices, max 32 characters) to this value. By default the Home Assistant home name is used. This is useful if the Matter Server is used from multiple Home Assistant instances, which otherwise each keep pushing their own home name as the label. When set, changing the label via the WebSocket API is blocked. |
 | ble_proxy            | Expose the BLE proxy endpoint so the Home Assistant Matter integration can drive BLE commissioning through Home Assistant's bluetooth stack. Mutually exclusive with `bluetooth_adapter_id`. |
 | bluetooth_adapter_id | **Deprecated** — use `ble_proxy` instead. Set BlueZ Bluetooth Controller ID (for local commissioning). Still works for now. |
 | matter_server_args   | Extra command-line arguments passed to the Matter Server at startup (advanced).                         |

--- a/matter_server/DOCS.md
+++ b/matter_server/DOCS.md
@@ -53,6 +53,8 @@ App configuration:
 | log_level            | Logging level of the Matter Server component.                                                           |
 | beta                 | Install the latest `matter-server` from npm on startup instead of the bundled version. On failure a warning is logged and the bundled version is started. |
 | enable_test_net_dcl  | Enable test-net DCL for PAA root certificates, OTA updates and other device information.                |
+| time_sync            | Whether the Matter Server pushes the current time to Matter devices: `auto` (default; on only when the host clock is NTP synchronized), `on` (always; warns if NTP is not synchronized), or `off`. |
+| default_fabric_label | Pin the fabric label (shown on Matter devices, max 32 characters) to this value. Use this if you use the Matter Server from multiple Home Assistant instances, which otherwise each keep pushing their own instance name as the label. When set, changing the label via the WebSocket API is blocked. |
 | ble_proxy            | Expose the BLE proxy endpoint so the Home Assistant Matter integration can drive BLE commissioning through Home Assistant's bluetooth stack. Mutually exclusive with `bluetooth_adapter_id`. |
 | bluetooth_adapter_id | **Deprecated** — use `ble_proxy` instead. Set BlueZ Bluetooth Controller ID (for local commissioning). Still works for now. |
 | matter_server_args   | Extra command-line arguments passed to the Matter Server at startup (advanced).                         |

--- a/matter_server/build.yaml
+++ b/matter_server/build.yaml
@@ -1,7 +1,7 @@
 ---
 build_from:
-  aarch64: ghcr.io/matter-js/matterjs-server:1.1.7
-  amd64: ghcr.io/matter-js/matterjs-server:1.1.7
+  aarch64: ghcr.io/matter-js/matterjs-server:1.2.6
+  amd64: ghcr.io/matter-js/matterjs-server:1.2.6
 args:
   BASHIO_VERSION: 0.17.1
   TEMPIO_VERSION: 2024.11.2

--- a/matter_server/config.yaml
+++ b/matter_server/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 9.0.4
+version: 9.1.0
 breaking_versions: [9.0.0]
 slug: matter_server
 name: Matter Server
@@ -28,10 +28,13 @@ options:
   log_level: info
   beta: false
   enable_test_net_dcl: false
+  time_sync: auto
 schema:
   log_level: list(debug|info|notice|warn|error|fatal|verbose|warning|critical)
   beta: bool?
   enable_test_net_dcl: bool?
+  time_sync: list(auto|on|off)
+  default_fabric_label: str(0,32)?
   ble_proxy: bool?
   bluetooth_adapter_id: int?
   matter_server_args:

--- a/matter_server/config.yaml
+++ b/matter_server/config.yaml
@@ -34,7 +34,7 @@ schema:
   beta: bool?
   enable_test_net_dcl: bool?
   time_sync: list(auto|on|off)
-  default_fabric_label: str(0,32)?
+  default_fabric_label: match(^.{1,32}$)?
   ble_proxy: bool?
   bluetooth_adapter_id: int?
   matter_server_args:

--- a/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
+++ b/matter_server/rootfs/etc/s6-overlay/s6-rc.d/matter-server/run
@@ -131,6 +131,44 @@ if bashio::config.true "enable_test_net_dcl"; then
     extra_args+=('--ota-provider-dir' "/config/updates")
 fi
 
+# Resolve whether to enable time sync for nodes with the TimeSynchronization
+# cluster. The 'time_sync' option has three modes:
+#   - on:   always enable (warn if the host clock is not NTP synchronized)
+#   - off:  always leave disabled
+#   - auto: enable only when the host clock is NTP synchronized (default)
+time_sync_mode="$(bashio::string.lower "$(bashio::config 'time_sync' 'auto')")"
+ntp_synchronized="$(bashio::api.supervisor 'GET' '/host/info' '' '.dt_synchronized')"
+time_sync_enabled=false
+
+case "${time_sync_mode}" in
+  on)
+    time_sync_enabled=true
+    if [ "${ntp_synchronized}" != "true" ]; then
+        bashio::log.warning \
+          "Time sync is enabled but host NTP is not synchronized — time pushed to Matter devices may be inaccurate"
+    fi
+    ;;
+  off)
+    bashio::log.info "Time sync is disabled ('time_sync' set to off)."
+    ;;
+  *)
+    if [ "${ntp_synchronized}" = "true" ]; then
+        time_sync_enabled=true
+        bashio::log.info "Time sync 'auto': host NTP is synchronized, enabling time sync."
+    else
+        bashio::log.info "Time sync 'auto': host NTP is not synchronized, leaving time sync disabled."
+    fi
+    ;;
+esac
+
+if [ "${time_sync_enabled}" = "true" ]; then
+    extra_args+=('--enable-time-sync')
+fi
+
+if bashio::config.has_value "default_fabric_label"; then
+    extra_args+=('--default-fabric-label' "$(bashio::config 'default_fabric_label')")
+fi
+
 primary_interface="$(bashio::api.supervisor 'GET' '/network/info' '' 'first(.interfaces[] | select (.primary == true)) .interface')"
 
 # Try fallback method (e.g. in case NetworkManager is not available)
@@ -168,7 +206,6 @@ bashio::log.info "Using '${primary_interface}' as primary network interface."
 # shellcheck disable=SC2164
 cd /root
 
-# shellcheck disable=SC2206
 matter_server_args+=(
   '--storage-path' "/data"
   '--port' "${server_port}"
@@ -176,7 +213,7 @@ matter_server_args+=(
   '--primary-interface' "${primary_interface}"
   '--fabricid' 2
   '--vendorid' 4939
-  ${extra_args[@]}
+  "${extra_args[@]}"
 )
 
 exec node --enable-source-maps "${server_entry}" "${matter_server_args[@]}"

--- a/matter_server/translations/en.yaml
+++ b/matter_server/translations/en.yaml
@@ -27,10 +27,11 @@ configuration:
     name: Default Fabric Label
     description: >-
       Pin the fabric label (shown on Matter devices for this controller, max
-      32 characters) to this value. Use this if you use the Matter Server from
-      multiple Home Assistant instances, which otherwise each keep pushing
-      their own instance name as the label. When set, changing the label via
-      the WebSocket API is blocked.
+      32 characters) to this value. By default the Home Assistant home name is
+      used. This is useful if the Matter Server is used from multiple Home
+      Assistant instances, which otherwise each keep pushing their own home
+      name as the label. When set, changing the label via the WebSocket API is
+      blocked.
   bluetooth_adapter_id:
     name: Bluetooth Adapter ID (deprecated)
     description: >-

--- a/matter_server/translations/en.yaml
+++ b/matter_server/translations/en.yaml
@@ -15,6 +15,22 @@ configuration:
       Enable PAA root certificates, software updates and other device
       information from test-net DCL. This is meant for development and testing
       purposes.
+  time_sync:
+    name: Time synchronization
+    description: >-
+      Control whether the Matter Server pushes the current time to Matter
+      devices. "auto" (default) enables it only when the host clock is NTP
+      synchronized; "on" always enables it (a warning is logged if the host
+      clock is not NTP synchronized, since the time sent to devices is only as
+      accurate as the host clock); "off" disables it.
+  default_fabric_label:
+    name: Default Fabric Label
+    description: >-
+      Pin the fabric label (shown on Matter devices for this controller, max
+      32 characters) to this value. Use this if you use the Matter Server from
+      multiple Home Assistant instances, which otherwise each keep pushing
+      their own instance name as the label. When set, changing the label via
+      the WebSocket API is blocked.
   bluetooth_adapter_id:
     name: Bluetooth Adapter ID (deprecated)
     description: >-


### PR DESCRIPTION
## Breaking change

None. The new `time_sync` option defaults to `auto`, which enables time sync only when the host clock is NTP synchronized — on hosts that are not NTP synchronized, behaviour is unchanged. The new `default_fabric_label` option is optional and inactive unless set.

## Proposed change

Takes over and finalizes #4685 (thanks @markvp for the groundwork!) and adds a few things on top:

- Bump the bundled Matter Server image from `1.1.7` to [`1.2.6`](https://github.com/matter-js/matterjs-server/blob/main/CHANGELOG.md), which brings Matter 1.6.0 support, time synchronization to devices, experimental ICD battery-saving support and many optimizations and fixes.
- Add a `time_sync` option (`auto` / `on` / `off`, default `auto`) controlling the server's `--enable-time-sync` flag (from #4685):
  - `auto` (default): enable only when the host clock is NTP synchronized (checked via the Supervisor `/host/info` `dt_synchronized` field).
  - `on`: always enable, logging a warning if the host clock is not NTP synchronized.
  - `off`: never enable.
- Add a `default_fabric_label` option (max 32 characters) wired to the server's `--default-fabric-label` flag. Use this if you use the Matter Server from multiple Home Assistant instances, which otherwise each keep pushing their own instance name as the label. When set, changing the label via the WebSocket API is blocked.
- Quote the final `extra_args` expansion in the startup script so option values containing spaces (e.g. a fabric label like "Living Room") are passed as a single argument.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Supersedes #4685
- Link to documentation pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] The add-on version in `config.yaml` was bumped and `CHANGELOG.md` updated.
- [x] The new options are added to `config.yaml` `options`/`schema` and documented in `DOCS.md` and `translations/en.yaml`.
- [x] The startup script passes shellcheck with no new findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable device time synchronization with `auto`, `on`, and `off` modes.
  - Added an option to set a `default_fabric_label`, including protection against WebSocket label changes when configured.
  - Added support for Matter 1.6.0.
- **Documentation**
  - Updated configuration docs and the changelog for the 9.1.0 upgrade, including new options and upgrade guidance.
- **Improvements**
  - Updated the Matter Server base image to a newer version.
  - Improved startup argument handling for more reliable extra argument boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->