### PR TITLE
Configurator: migrate to all_app_configs folder mapping, bump base image

### DIFF
--- a/configurator/CHANGELOG.md
+++ b/configurator/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 6.1.0
+
+- Migrate to the new `all_app_configs` folder mapping name introduced in Home Assistant Supervisor
+- Update base image to 3.24-2026.06.1
+
 ## 6.0.0
 
 - Update hass-configurator to 0.6.0 (see [changelog](https://github.com/danielperna84/hass-configurator/releases/tag/0.6.0) for details)

--- a/configurator/build.yaml
+++ b/configurator/build.yaml
@@ -1,6 +1,6 @@
 ---
 build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-base:3.23
-  amd64: ghcr.io/home-assistant/amd64-base:3.23
+  aarch64: ghcr.io/home-assistant/aarch64-base:3.24-2026.06.1
+  amd64: ghcr.io/home-assistant/amd64-base:3.24-2026.06.1
 args:
   CONFIGURATOR_VERSION: 0.6.0

--- a/configurator/config.yaml
+++ b/configurator/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 6.0.0
+version: 6.1.0
 slug: configurator
 name: File editor
 description: Simple browser-based file editor for Home Assistant
@@ -13,7 +13,7 @@ image: homeassistant/{arch}-addon-configurator
 ingress: true
 init: false
 map:
-  - all_addon_configs:rw
+  - all_app_configs:rw
   - backup:rw
   - homeassistant_config:rw
   - media:rw


### PR DESCRIPTION
Rename the deprecated `all_addon_configs` folder mapping to the new `all_app_configs` name introduced in Home Assistant Supervisor (#6992). Also update the base image to 3.24-2026.06.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the Configurator add-on to version 6.1.0.
  * Updated the app configuration folder mapping to the latest naming convention.

* **Chores**
  * Updated the underlying base image to version 3.24-2026.06.1 for supported architectures.
  * Added release notes documenting these updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->