### PR TITLE
Update README to include ZBT-2 support

### DIFF
--- a/openthread_border_router/README.md
+++ b/openthread_border_router/README.md
@@ -4,7 +4,7 @@ OpenThread Border Router app (formerly known as add-on). The app uses the upstre
 Border Router implementation and wraps it as an app for Home Assistant.
 
 **NOTE:** This requires a supported 802.15.4 capable radio with OpenThread
-RCP firmware. If you are using [Home Assistant Yellow](https://www.home-assistant.io/yellow/) or [Home Assistant Connect ZBT-1](https://www.home-assistant.io/connectzbt1/) (previously called SkyConnect) then
+RCP firmware. If you are using [Home Assistant Yellow](https://www.home-assistant.io/yellow/), [Home Assistant Connect ZBT-1](https://www.home-assistant.io/connectzbt1/) (previously called SkyConnect), and [Home Assistant Connect ZBT-2](https://www.home-assistant.io/connect/zbt-2/) then
 the correct firmware is automatically installed.
 
 ![Supports aarch64 Architecture][aarch64-shield]


### PR DESCRIPTION
Added information about Home Assistant Connect ZBT-2 support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Home Assistant device and firmware guidance to include Home Assistant Connect ZBT-2.
  * Clarified that Yellow, Connect ZBT-1, and Connect ZBT-2 support automatic installation of the correct RCP firmware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->