### PR TITLE
Bump deCONZ to v2.33.2

### DIFF
--- a/deconz/CHANGELOG.md
+++ b/deconz/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 8.7.2
+
+- Bump deCONZ to 2.33.2 [[CHANGELOG](https://github.com/dresden-elektronik/deconz-rest-plugin/releases/tag/v2.33.2)]
+
 ## 8.7.1
 
 - Avoid generating additional API keys upon HTTP/JSON errors

--- a/deconz/build.yaml
+++ b/deconz/build.yaml
@@ -3,4 +3,4 @@ build_from:
   aarch64: ghcr.io/home-assistant/aarch64-base-debian:bookworm
   amd64: ghcr.io/home-assistant/amd64-base-debian:bookworm
 args:
-  DECONZ_VERSION: 2.32.5
+  DECONZ_VERSION: 2.33.2

--- a/deconz/config.yaml
+++ b/deconz/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 8.7.1
+version: 8.7.2
 slug: deconz
 name: deCONZ
 description: >-


### PR DESCRIPTION
Update to the latest stable deCONZ release [v2.33.2](https://github.com/dresden-elektronik/deconz-rest-plugin/releases/tag/v2.33.2). I have also tested it in my repository, and it has been working for me for several weeks now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the add-on to deCONZ version 2.33.2.

* **Chores**
  * Released add-on version 8.7.2.
  * Added changelog information and a link to the corresponding deCONZ release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->