### PR TITLE
Samba: Add configuration option to disable WSDD

### DIFF
--- a/samba/CHANGELOG.md
+++ b/samba/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 12.9.0
+
+- Add configuration option to disable WSDD. When disabled, the wsdd service is
+  not started and the host is no longer advertised for automatic discovery.
+  Shares remain reachable by hostname or IP address.
+
 ## 12.8.1
 
 - Normalize stored `enabled_shares` values to lower case at startup. Values

--- a/samba/DOCS.md
+++ b/samba/DOCS.md
@@ -50,6 +50,7 @@ compatibility_mode: false
 apple_compatibility_mode: true
 netbios: true
 local_master: true
+wsdd: true
 server_signing: "default"
 veto_files:
   - ._*
@@ -118,6 +119,17 @@ Defaults to `true`.
 ### Option: `local_master`
 
 When NetBIOS is enabled, try and become a local master browser on a subnet.
+
+Defaults to `true`.
+
+### Option: `wsdd`
+
+Advertise the host on the network using Web Services Dynamic Discovery, so it
+appears automatically under Network in Windows File Explorer. Disable this if
+you connect to the shares by hostname or IP address and do not want the host
+to announce itself on the network.
+
+Disabling this has no effect on share availability; only on discovery.
 
 Defaults to `true`.
 

--- a/samba/DOCS.md
+++ b/samba/DOCS.md
@@ -50,7 +50,7 @@ compatibility_mode: false
 apple_compatibility_mode: true
 netbios: true
 local_master: true
-wsdd: true
+network_discovery: true
 server_signing: "default"
 veto_files:
   - ._*
@@ -122,7 +122,7 @@ When NetBIOS is enabled, try and become a local master browser on a subnet.
 
 Defaults to `true`.
 
-### Option: `wsdd`
+### Option: `network_discovery`
 
 Advertise the host on the network using Web Services Dynamic Discovery, so it
 appears automatically under Network in Windows File Explorer. Disable this if

--- a/samba/config.yaml
+++ b/samba/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 12.8.1
+version: 12.9.0
 slug: samba
 name: Samba share
 description: Expose Home Assistant folders with SMB/CIFS
@@ -35,6 +35,7 @@ options:
   apple_compatibility_mode: true
   netbios: true
   local_master: true
+  wsdd: true
   server_signing: "default"
   veto_files:
     - ._*
@@ -59,6 +60,7 @@ schema:
   apple_compatibility_mode: bool
   netbios: bool
   local_master: bool
+  wsdd: bool
   server_signing: list(default|auto|mandatory|disabled)
   veto_files:
     - str

--- a/samba/config.yaml
+++ b/samba/config.yaml
@@ -35,7 +35,7 @@ options:
   apple_compatibility_mode: true
   netbios: true
   local_master: true
-  wsdd: true
+  network_discovery: true
   server_signing: "default"
   veto_files:
     - ._*
@@ -60,7 +60,7 @@ schema:
   apple_compatibility_mode: bool
   netbios: bool
   local_master: bool
-  wsdd: bool
+  network_discovery: bool
   server_signing: list(default|auto|mandatory|disabled)
   veto_files:
     - str

--- a/samba/rootfs/etc/s6-overlay/scripts/enable-check.sh
+++ b/samba/rootfs/etc/s6-overlay/scripts/enable-check.sh
@@ -11,7 +11,7 @@ else
     bashio::log.info "Service nmbd disabled"
 fi
 
-if bashio::config.true 'wsdd'; then
+if bashio::config.true 'network_discovery'; then
     touch /etc/s6-overlay/s6-rc.d/user/contents.d/wsdd
     bashio::log.info "Service wsdd enabled"
 else

--- a/samba/rootfs/etc/s6-overlay/scripts/enable-check.sh
+++ b/samba/rootfs/etc/s6-overlay/scripts/enable-check.sh
@@ -1,7 +1,7 @@
 #!/command/with-contenv bashio
 # shellcheck shell=bash
 # ==============================================================================
-# Enable/disable nmbd service per config
+# Enable/disable optional services per config
 # ==============================================================================
 if bashio::config.true 'netbios'; then
     touch /etc/s6-overlay/s6-rc.d/user/contents.d/nmbd
@@ -9,4 +9,12 @@ if bashio::config.true 'netbios'; then
 else
     rm -f /etc/s6-overlay/s6-rc.d/user/contents.d/nmbd
     bashio::log.info "Service nmbd disabled"
+fi
+
+if bashio::config.true 'wsdd'; then
+    touch /etc/s6-overlay/s6-rc.d/user/contents.d/wsdd
+    bashio::log.info "Service wsdd enabled"
+else
+    rm -f /etc/s6-overlay/s6-rc.d/user/contents.d/wsdd
+    bashio::log.info "Service wsdd disabled"
 fi

--- a/samba/translations/en.yaml
+++ b/samba/translations/en.yaml
@@ -41,8 +41,8 @@ configuration:
     description: >-
       When NetBIOS is enabled, try and become a local master browser on a
       subnet.
-  wsdd:
-    name: Enable network discovery (WSDD)
+  network_discovery:
+    name: Enable network discovery
     description: >-
       Advertise the host with Web Services Dynamic Discovery so it appears
       automatically under Network in Windows File Explorer. Disable if you

--- a/samba/translations/en.yaml
+++ b/samba/translations/en.yaml
@@ -41,6 +41,13 @@ configuration:
     description: >-
       When NetBIOS is enabled, try and become a local master browser on a
       subnet.
+  wsdd:
+    name: Enable network discovery (WSDD)
+    description: >-
+      Advertise the host with Web Services Dynamic Discovery so it appears
+      automatically under Network in Windows File Explorer. Disable if you
+      connect by hostname or IP address and do not want the host to announce
+      itself on the network. Shares stay reachable either way.
   server_signing:
     name: Server signing
     description: >-


### PR DESCRIPTION
Fixes #4722

   WSDD has run unconditionally since 12.7.0, so the host is advertised in the
   Windows Network view with no way to opt out. `compatibility_mode: false` and
   `netbios: false` have no effect on it, since `enable-check.sh` only gates
   `nmbd`.

   This adds a `wsdd` boolean option following the exact pattern of the
   `netbios` option added in 12.8.0: the flag is checked in `enable-check.sh`
   and the service file is removed from `user/contents.d` when disabled.

   Defaults to `true`, so existing installations see no change in behaviour.
   Disabling it does not affect share availability, only discovery.

   Includes the schema entry, DOCS.md documentation, the `en.yaml` UI strings,
   a version bump to 12.9.0, and a changelog entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `network_discovery` configuration option to control WSDD-based advertising for Windows File Explorer.
  * When enabled (default), the host is discoverable on the local network; when disabled, it won’t be advertised.
  * Share access remains available by hostname or IP address regardless of discovery.

* **Documentation**
  * Updated documentation and example configuration to include `network_discovery`.
  * Added UI text and translation for the new setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->