### PR TITLE
Add configurable client max body size to NGINX proxy

### DIFF
--- a/nginx_proxy/CHANGELOG.md
+++ b/nginx_proxy/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.5.0
+
+- Allow setting the client max request body size from the UI (to be able to upload large files, such as a KNX project file through the proxy)
+
 ## 4.4.0
 
 - Fix HTTP/3 requests with Home Assistant 2026.7.0 and newer

--- a/nginx_proxy/config.yaml
+++ b/nginx_proxy/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 4.4.0
+version: 4.5.0
 hassio_api: true
 slug: nginx_proxy
 name: NGINX Home Assistant SSL proxy
@@ -20,6 +20,7 @@ options:
   keyfile: privkey.pem
   cloudflare: false
   use_ssl_backend: false
+  client_max_body_size_megabytes: 1
   customize:
     active: false
     default: nginx_proxy_default*.conf
@@ -36,6 +37,7 @@ schema:
   keyfile: str
   cloudflare: bool
   use_ssl_backend: bool
+  client_max_body_size_megabytes: int(0,)
   customize:
     active: bool
     default: str

--- a/nginx_proxy/rootfs/etc/nginx/nginx.conf.gtpl
+++ b/nginx_proxy/rootfs/etc/nginx/nginx.conf.gtpl
@@ -114,6 +114,14 @@ http {
 
         proxy_buffering off;
 
+        {{- if ne .options.client_max_body_size_megabytes nil }}
+        {{- if eq .options.client_max_body_size_megabytes 0 }}
+        client_max_body_size 0;
+        {{- else }}
+        client_max_body_size {{ .options.client_max_body_size_megabytes }}m;
+        {{- end }}
+        {{- end }}
+
         {{- if .options.customize.active }}
         include /share/{{ .options.customize.default }};
         {{- end }}

--- a/nginx_proxy/translations/en.yaml
+++ b/nginx_proxy/translations/en.yaml
@@ -24,6 +24,11 @@ configuration:
     name: Use SSL Backend
     description: >-
       If enabled, configure Nginx to use SSL to connect to backend.
+  client_max_body_size_megabytes:
+    name: Max body size (in MB)
+    description: >-
+      Configures Nginx to limit the maximum allowed size of the client request
+      body, specified in megabytes. Set to 0 to allow requests of any size.
   customize:
     name: Customize
     description: >-


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable maximum request body size for proxy requests.
  * Set the limit in megabytes from the add-on configuration.
  * Set the value to `0` to allow uploads of any size.

* **Documentation**
  * Added configuration guidance for supporting large file uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->