### PR TITLE
Samba: Add service discovery using mDNS

### DIFF
--- a/samba/CHANGELOG.md
+++ b/samba/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 12.9.0
+
+- Add service discovery over mDNS with a configuration option to disable.
+
 ## 12.8.1
 
 - Normalize stored `enabled_shares` values to lower case at startup. Values

--- a/samba/CHANGELOG.md
+++ b/samba/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 12.11.0
+
+- Add service discovery using DNS-SD/mDNS controlled by the `network_discovery` configuration option added in 12.9.0.
+
 ## 12.10.0
 
 - Rename the `addons` and `addon_configs` shares to `local_apps` and `app_configs` to match Home Assistant's app terminology. Existing `enabled_shares` configurations are migrated automatically on start (extending the lower-case normalization added in 12.8.1).

--- a/samba/DOCS.md
+++ b/samba/DOCS.md
@@ -48,6 +48,7 @@ enabled_shares:
   - ssl
 compatibility_mode: false
 apple_compatibility_mode: true
+mdns: true
 netbios: true
 local_master: true
 server_signing: "default"
@@ -105,6 +106,12 @@ Defaults to `false`.
 
 Enable Samba configurations to improve interoperability with Apple devices.
 This can cause issues with file systems that do not support xattr such as exFAT.
+
+Defaults to `true`.
+
+### Option: `mdns`
+
+Enable service discovery over mDNS.
 
 Defaults to `true`.
 

--- a/samba/DOCS.md
+++ b/samba/DOCS.md
@@ -130,10 +130,9 @@ Defaults to `true`.
 
 ### Option: `network_discovery`
 
-Advertise the host on the network using Web Services Dynamic Discovery, so it
-appears automatically under Network in Windows File Explorer. Disable this if
-you connect to the shares by hostname or IP address and do not want the host
-to announce itself on the network.
+Advertise the host on the network using DNS-SD/mDNS and WS-Discovery. Disable
+this if you connect to the shares by hostname or IP address and do not want the
+host to announce itself on the network.
 
 Disabling this has no effect on share availability; only on discovery.
 

--- a/samba/Dockerfile
+++ b/samba/Dockerfile
@@ -6,7 +6,7 @@ ENV LANG C.UTF-8
 
 # Setup base
 RUN \
-    apk add --no-cache samba wsdd \
+    apk add --no-cache samba wsdd glib \
     && mkdir -p /var/lib/samba \
     && touch \
         /etc/samba/lmhosts \

--- a/samba/config.yaml
+++ b/samba/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 12.8.1
+version: 12.9.0
 slug: samba
 name: Samba share
 description: Expose Home Assistant folders with SMB/CIFS
@@ -9,6 +9,7 @@ arch:
   - amd64
 hassio_api: true
 host_network: true
+host_dbus: true
 image: homeassistant/{arch}-addon-samba
 init: false
 map:
@@ -33,6 +34,7 @@ options:
     - ssl
   compatibility_mode: false
   apple_compatibility_mode: true
+  mdns: true
   netbios: true
   local_master: true
   server_signing: "default"
@@ -57,6 +59,7 @@ schema:
     - "match(^(?i:(addons|addon_configs|backup|config|media|share|ssl))$)"
   compatibility_mode: bool
   apple_compatibility_mode: bool
+  mdns: bool
   netbios: bool
   local_master: bool
   server_signing: list(default|auto|mandatory|disabled)

--- a/samba/config.yaml
+++ b/samba/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 12.10.0
+version: 12.11.0
 slug: samba
 name: Samba share
 description: Expose Home Assistant folders with SMB/CIFS

--- a/samba/rootfs/etc/s6-overlay/s6-rc.d/smbd/finish
+++ b/samba/rootfs/etc/s6-overlay/s6-rc.d/smbd/finish
@@ -14,6 +14,16 @@ bashio::log.info \
   "Service ${service} exited with code ${exit_code_service}" \
   "(by signal ${exit_code_signal})"
 
+if bashio::config.true 'mdns'; then
+bashio::log.info "Unregistering smb service in mDNS"
+app_hostname=$(hostname)
+gdbus call --system \
+  --dest=org.freedesktop.resolve1 \
+  --object-path=/org/freedesktop/resolve1 \
+  --method=org.freedesktop.resolve1.Manager.UnregisterService \
+  "/org/freedesktop/resolve1/dnssd/${app_hostname//-/_2d}"
+fi
+
 if [[ "${exit_code_service}" -eq 256 ]]; then
   if [[ "${exit_code_container}" -eq 0 ]]; then
     echo $((128 + exit_code_signal)) > /run/s6-linux-init-container-results/exitcode

--- a/samba/rootfs/etc/s6-overlay/s6-rc.d/smbd/finish
+++ b/samba/rootfs/etc/s6-overlay/s6-rc.d/smbd/finish
@@ -17,6 +17,7 @@ bashio::log.info \
 if bashio::config.true 'network_discovery'; then
 bashio::log.info "Unregistering smb service in mDNS"
 app_hostname=$(hostname)
+# Fix object path encoding by replacing "-" with "_2d"
 gdbus call --system \
   --dest=org.freedesktop.resolve1 \
   --object-path=/org/freedesktop/resolve1 \

--- a/samba/rootfs/etc/s6-overlay/s6-rc.d/smbd/finish
+++ b/samba/rootfs/etc/s6-overlay/s6-rc.d/smbd/finish
@@ -19,9 +19,9 @@ bashio::log.info "Unregistering smb service in mDNS"
 app_hostname=$(hostname)
 # Fix object path encoding by replacing "-" with "_2d"
 gdbus call --system \
-  --dest=org.freedesktop.resolve1 \
-  --object-path=/org/freedesktop/resolve1 \
-  --method=org.freedesktop.resolve1.Manager.UnregisterService \
+  --dest org.freedesktop.resolve1 \
+  --object-path /org/freedesktop/resolve1 \
+  --method org.freedesktop.resolve1.Manager.UnregisterService \
   "/org/freedesktop/resolve1/dnssd/${app_hostname//-/_2d}"
 fi
 

--- a/samba/rootfs/etc/s6-overlay/s6-rc.d/smbd/run
+++ b/samba/rootfs/etc/s6-overlay/s6-rc.d/smbd/run
@@ -10,7 +10,7 @@ gdbus call --system \
   --dest org.freedesktop.resolve1 \
   --object-path /org/freedesktop/resolve1 \
   --method org.freedesktop.resolve1.Manager.RegisterService \
-  $(hostname) \
+  "$(hostname)" \
   "%H" \
   "_smb._tcp" \
   445 \

--- a/samba/rootfs/etc/s6-overlay/s6-rc.d/smbd/run
+++ b/samba/rootfs/etc/s6-overlay/s6-rc.d/smbd/run
@@ -4,6 +4,21 @@
 # ==============================================================================
 # Start smbd service
 # ==============================================================================
+if bashio::config.true 'mdns'; then
+bashio::log.info "Registering smb service in mDNS"
+gdbus call --system \
+  --dest org.freedesktop.resolve1 \
+  --object-path /org/freedesktop/resolve1 \
+  --method org.freedesktop.resolve1.Manager.RegisterService \
+  $(hostname) \
+  "%H" \
+  "_smb._tcp" \
+  445 \
+  0 \
+  0 \
+  []
+fi
+
 exec smbd \
   --foreground \
   --debug-stdout \

--- a/samba/translations/en.yaml
+++ b/samba/translations/en.yaml
@@ -30,6 +30,9 @@ configuration:
       Enable Samba configurations to improve interoperability with Apple
       devices. May cause issues with file systems that do not support xattr
       such as exFAT.
+  mdns:
+    name: Enable DNS-SD/mDNS
+    description: Enable service discovery over mDNS.
   netbios:
     name: Enable NetBIOS over IP
     description: >-

--- a/samba/translations/en.yaml
+++ b/samba/translations/en.yaml
@@ -46,8 +46,7 @@ configuration:
   network_discovery:
     name: Enable network discovery
     description: >-
-      Advertise the host with Web Services Dynamic Discovery so it appears
-      automatically under Network in Windows File Explorer. Disable if you
+      Advertise the host with DNS-SD/mDNS and WS-Discovery. Disable if you
       connect by hostname or IP address and do not want the host to announce
       itself on the network. Shares stay reachable either way.
   server_signing:


### PR DESCRIPTION
Added the capability to register smb service in mDNS for service discovery. This uses the `RegisterService` call on the `org.freedesktop.resolve1` service so the OS level mDNS announcer `systemd-resolved` is used.

- Use existing `network_discovery` configuration option for control of this feature.
- Add `glib` package which provides `gdbus` command needed.
- Add `host_dbus: true` to `config.yaml` to allow D-Bus access.
- In smbd `run` script, use `gdbus` command to register smb service on port 445 in mDNS.
- In smbd `finish` script, use `gdbus` command to unregister smb service in mDNS.
- Bump version to 12.11.0 and update documentation and changelog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added DNS-SD/mDNS service discovery alongside WS-Discovery for Samba on local networks.
  * Samba service entries are automatically unregistered from mDNS when stopping.

* **Documentation**
  * Updated configuration guidance and English translations to describe both discovery methods.

* **Chores**
  * Updated the release to version **12.11.0**.
  * Improved runtime support for network discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->