### PR TITLE
Upgrade piper to trixie

### DIFF
--- a/piper/CHANGELOG.md
+++ b/piper/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.3.2
+
+- Migrate base image from bookworm to trixie
+
 ## 2.3.1
 
 - Upgrade to `wyoming-piper` 2.3.1

--- a/piper/Dockerfile
+++ b/piper/Dockerfile
@@ -8,18 +8,19 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 WORKDIR /usr/src
 ARG BUILD_ARCH
 ARG WYOMING_PIPER_VERSION
-ENV PIP_BREAK_SYSTEM_PACKAGES=1
 RUN \
     apt-get update \
     && apt-get install -y --no-install-recommends \
         netcat-traditional \
         python3 \
         python3-pip \
+        python3-venv \
     \
-    && pip3 install --no-cache-dir -U \
+    && python3 -m venv .venv \
+    && .venv/bin/pip3 install --no-cache-dir -U \
         setuptools \
         wheel \
-    && pip3 install --no-cache-dir \
+    && .venv/bin/pip3 install --no-cache-dir \
         --extra-index-url https://www.piwheels.org/simple \
         --extra-index-url https://download.pytorch.org/whl/cpu \
         "wyoming-piper[zeroconf,zh] @ https://github.com/rhasspy/wyoming-piper/archive/refs/tags/v${WYOMING_PIPER_VERSION}.tar.gz" \

--- a/piper/Dockerfile
+++ b/piper/Dockerfile
@@ -27,6 +27,7 @@ RUN \
     \
     && rm -rf /var/lib/apt/lists/*
 
+ENV PATH="/usr/src/.venv/bin:$PATH"
 WORKDIR /
 COPY rootfs /
 

--- a/piper/build.yaml
+++ b/piper/build.yaml
@@ -1,6 +1,6 @@
 ---
 build_from:
-  amd64: ghcr.io/home-assistant/amd64-base-debian:bookworm
-  aarch64: ghcr.io/home-assistant/aarch64-base-debian:bookworm
+  amd64: ghcr.io/home-assistant/amd64-base-debian:trixie
+  aarch64: ghcr.io/home-assistant/aarch64-base-debian:trixie
 args:
   WYOMING_PIPER_VERSION: 2.3.1

--- a/piper/config.yaml
+++ b/piper/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 2.3.1
+version: 2.3.2
 slug: piper
 name: Piper
 description: Text-to-speech with Piper

--- a/piper/rootfs/etc/s6-overlay/s6-rc.d/piper/run
+++ b/piper/rootfs/etc/s6-overlay/s6-rc.d/piper/run
@@ -4,8 +4,6 @@
 # ==============================================================================
 # Start Piper service
 # ==============================================================================
-cd /usr/src || exit 1
-
 flags=()
 if bashio::config.true 'update_voices'; then
     flags+=('--update-voices')

--- a/piper/rootfs/etc/s6-overlay/s6-rc.d/piper/run
+++ b/piper/rootfs/etc/s6-overlay/s6-rc.d/piper/run
@@ -25,7 +25,7 @@ for old_key in 'max_piper_procs' 'streaming'; do
 done
 
 # shellcheck disable=SC2068
-exec .venv/bin/python3 -m wyoming_piper \
+exec python3 -m wyoming_piper \
     --uri 'tcp://0.0.0.0:10200' \
     --zeroconf \
     --length-scale "$(bashio::config 'length_scale')" \

--- a/piper/rootfs/etc/s6-overlay/s6-rc.d/piper/run
+++ b/piper/rootfs/etc/s6-overlay/s6-rc.d/piper/run
@@ -4,6 +4,8 @@
 # ==============================================================================
 # Start Piper service
 # ==============================================================================
+cd /usr/src || exit 1
+
 flags=()
 if bashio::config.true 'update_voices'; then
     flags+=('--update-voices')
@@ -23,7 +25,7 @@ for old_key in 'max_piper_procs' 'streaming'; do
 done
 
 # shellcheck disable=SC2068
-exec python3 -m wyoming_piper \
+exec .venv/bin/python3 -m wyoming_piper \
     --uri 'tcp://0.0.0.0:10200' \
     --zeroconf \
     --length-scale "$(bashio::config 'length_scale')" \


### PR DESCRIPTION
Use trixie Debian base for piper instead of bookworm (see: https://github.com/home-assistant/docker-base/pull/382)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the Piper add-on to version 2.3.2.
  * Migrated the add-on’s base environment to Debian Trixie.
* **Bug Fixes**
  * Improved Python package isolation and installation reliability.
  * Ensured Piper starts in the correct working directory.
  * Improved startup consistency across supported architectures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->