### PR TITLE
Matter Server App 9.1.1 preparation

### DIFF
--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Changelog
 
-## 9.1.0
+## 9.1.1
 
 - **⚠️ When upgrading from 8.x, please also consider the release notes for 9.0.0.**
+- Update [Matter Server from 1.2.6 to 1.3.3](https://github.com/matter-js/matterjs-server/blob/main/CHANGELOG.md)
+  - Optimizations in the Dashboard for Camera, Time-Synchronization, ICD devices and Thread visualization
+  - Optimization and fixes for commissioning and operation of the Matter devices
+
+## 9.1.0
+
 - Update [Matter Server from 1.1.7 to 1.2.6](https://github.com/matter-js/matterjs-server/blob/main/CHANGELOG.md)
   - Supports Matter 1.6.0
   - Synchronize Time to devices that support this

--- a/matter_server/CHANGELOG.md
+++ b/matter_server/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Update [Matter Server from 1.2.6 to 1.3.3](https://github.com/matter-js/matterjs-server/blob/main/CHANGELOG.md)
   - Optimizations in the Dashboard for Camera, Time-Synchronization, ICD devices and Thread visualization
   - Optimization and fixes for commissioning and operation of the Matter devices
+- Change Matter server panel icon
 
 ## 9.1.0
 

--- a/matter_server/build.yaml
+++ b/matter_server/build.yaml
@@ -1,7 +1,7 @@
 ---
 build_from:
-  aarch64: ghcr.io/matter-js/matterjs-server:1.2.6
-  amd64: ghcr.io/matter-js/matterjs-server:1.2.6
+  aarch64: ghcr.io/matter-js/matterjs-server:1.3.3
+  amd64: ghcr.io/matter-js/matterjs-server:1.3.3
 args:
   BASHIO_VERSION: 0.17.1
   TEMPIO_VERSION: 2024.11.2

--- a/matter_server/config.yaml
+++ b/matter_server/config.yaml
@@ -23,7 +23,7 @@ ingress_port: 5580
 panel_icon: mdi:matter
 init: false
 map:
-  - type: addon_config
+  - type: app_config
     read_only: false
 options:
   log_level: info

--- a/matter_server/config.yaml
+++ b/matter_server/config.yaml
@@ -20,6 +20,7 @@ host_dbus: true
 image: homeassistant/{arch}-addon-matter-server
 ingress: true
 ingress_port: 5580
+panel_icon: mdi:matter
 init: false
 map:
   - type: addon_config

--- a/matter_server/config.yaml
+++ b/matter_server/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 9.1.0
+version: 9.1.1
 breaking_versions: [9.0.0]
 slug: matter_server
 name: Matter Server


### PR DESCRIPTION
includes Matter Server 1.3.3

Release planned for Wednesday 29.7.2026

And incorporates https://github.com/home-assistant/addons/pull/4706

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Matter Server panel icon for easier identification.
  * Updated the Matter Server to version 1.3.3, including the latest optimizations and fixes.
* **Bug Fixes**
  * Improved add-on configuration handling and compatibility.
* **Documentation**
  * Added upgrade guidance and release information for version 9.1.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->