### PR TITLE
Add date to logs in LetsEncrypt

### DIFF
--- a/letsencrypt/Dockerfile
+++ b/letsencrypt/Dockerfile
@@ -4,6 +4,9 @@ FROM $BUILD_FROM
 # Allow pip to install packages system-wide on Debian
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
 
+# Log the full date next to the time, bashio defaults to "%T" (time only)
+ENV LOG_TIMESTAMP="%Y-%m-%d %H:%M:%S"
+
 # setup base
 # certbot-dns-multi replaces most individual DNS plugins using lego
 # Only legacy plugins are kept for providers not supported by lego: gehirn, eurodns, noris

--- a/letsencrypt/rootfs/etc/services.d/lets-encrypt/run
+++ b/letsencrypt/rootfs/etc/services.d/lets-encrypt/run
@@ -35,6 +35,9 @@ timestamped() {
     "$@" 2>&1 | while IFS= read -r line; do
         printf '[%s] %s\n' "$(date +"${LOG_TIMESTAMP:-%Y-%m-%d %H:%M:%S}")" "${line}"
     done
+    # The while loop always succeeds, so report the wrapped command's status instead.
+    local status="${PIPESTATUS[0]}"
+    return "${status}"
 }
 
 # Legacy providers not supported by lego/certbot-dns-multi

--- a/letsencrypt/rootfs/etc/services.d/lets-encrypt/run
+++ b/letsencrypt/rootfs/etc/services.d/lets-encrypt/run
@@ -28,6 +28,15 @@ TEST_CERT=$(bashio::config 'test_cert')
 VERBOSE=$(bashio::config 'verbose')
 FORCE_RENEW=$(bashio::config 'force_renew')
 
+# Prefix each line of a command's output with a timestamp, so certbot's output
+# is dated like the bashio::log messages around it. bashio writes to $LOG_FD,
+# a dup of the original stdout, so this only wraps the given command.
+timestamped() {
+    "$@" 2>&1 | while IFS= read -r line; do
+        printf '[%s] %s\n' "$(date +"${LOG_TIMESTAMP:-%Y-%m-%d %H:%M:%S}")" "${line}"
+    done
+}
+
 # Legacy providers not supported by lego/certbot-dns-multi
 LEGACY_PROVIDERS="dns-eurodns dns-gehirn dns-noris"
 
@@ -636,7 +645,7 @@ if bashio::config.has_value 'eab_kid' ; then
 fi
 
 # Generate a new certificate if necessary or expand a previous certificate if domains has changed
-certbot certonly --non-interactive --keep-until-expiring --expand \
+timestamped certbot certonly --non-interactive --keep-until-expiring --expand \
     --email "$EMAIL" --agree-tos \
     "${KEY_ARGUMENTS[@]}" \
     "${ADDITIONAL_ARGS[@]}" \


### PR DESCRIPTION
This pull request improves logging in the Let's Encrypt service by adding timestamped log lines to Certbot output. The main changes include introducing a new `timestamped` function to prefix command output with a date and time, updating the Dockerfile to set a log timestamp format, and wrapping the Certbot invocation to use this new logging.

**Logging improvements:**

* Added a `timestamped` shell function in `letsencrypt/rootfs/etc/services.d/lets-encrypt/run` that prefixes each line of a command’s output with a timestamp, ensuring Certbot output is dated like other log messages.
* Updated the Certbot command invocation to use the `timestamped` function, so all Certbot logs include timestamps.
* Set a new `LOG_TIMESTAMP` environment variable in `letsencrypt/Dockerfile` to control the timestamp format for logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Container logs now include complete date and time information for clearer event tracking.
  * Certificate management command output is timestamped on every line, making activity easier to follow and troubleshooting more efficient.
  * Command results continue to report their original success or failure status while providing improved timestamped output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->