### PR TITLE
NGINX proxy: Fix template crash with client_max_body_size option

### DIFF
--- a/nginx_proxy/CHANGELOG.md
+++ b/nginx_proxy/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.5.1
+
+- Fix nginx failing to start when the client max body size option is set (`incompatible types for comparison` in the config template)
+
 ## 4.5.0
 
 - Allow setting the client max request body size from the UI (to be able to upload large files, such as a KNX project file through the proxy)

--- a/nginx_proxy/CHANGELOG.md
+++ b/nginx_proxy/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 4.5.1
 
-- Fix nginx failing to start when the client max body size option is set (`incompatible types for comparison` in the config template)
+- Fix nginx failing to start when the client max body size option is present (`incompatible types for comparison` in the config template)
 
 ## 4.5.0
 

--- a/nginx_proxy/config.yaml
+++ b/nginx_proxy/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 4.5.0
+version: 4.5.1
 hassio_api: true
 slug: nginx_proxy
 name: NGINX Home Assistant SSL proxy

--- a/nginx_proxy/rootfs/etc/nginx/nginx.conf.gtpl
+++ b/nginx_proxy/rootfs/etc/nginx/nginx.conf.gtpl
@@ -115,11 +115,7 @@ http {
         proxy_buffering off;
 
         {{- if ne .options.client_max_body_size_megabytes nil }}
-        {{- if eq .options.client_max_body_size_megabytes 0 }}
-        client_max_body_size 0;
-        {{- else }}
         client_max_body_size {{ .options.client_max_body_size_megabytes }}m;
-        {{- end }}
         {{- end }}
 
         {{- if .options.customize.active }}


### PR DESCRIPTION
## The problem

The `client_max_body_size_megabytes` option added in #4741 (4.5.0) causes nginx to fail to start on every install, regardless of the configured value:

```
[INFO] Generating nginx.conf from template in /etc/nginx/nginx.conf.gtpl
template: tempIO:118:15: executing "tempIO" at <eq .options.client_max_body_size_megabytes 0>: error calling eq: incompatible types for comparison
[INFO] Service nginx exited with code 1 (by signal 0)
```

(reported in #4741 by @LennyM8472 and @mike10010100)

## Root cause

`tempio` decodes the add-on options from JSON, so `client_max_body_size_megabytes` is a **float64**, not an `int`. Go's `text/template` `eq` refuses to compare a float against the integer literal `0` — `incompatible types for comparison: float64 and int` — which aborts config generation before nginx can start.

## The fix

Drop the special-case `eq … 0` branch and always render the value with an `m` suffix. `client_max_body_size 0m;` is equivalent to `client_max_body_size 0;` in nginx — a value of `0` disables the body-size check — so unlimited uploads still work, and the fix is agnostic to whether tempio yields a `float64` or a `json.Number`.

Verified by rendering the template with a JSON-decoded (float64) value:
- `1` → `client_max_body_size 1m;`
- `0` → `client_max_body_size 0m;`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an nginx startup failure when configuring the client maximum body size.
  - Explicit `0m` values are now handled correctly in nginx configuration.

- **Release**
  - Updated the add-on version to 4.5.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->