### PR TITLE
letsencrypt: update certbot-dns-multi to 5.3.1

### DIFF
--- a/letsencrypt/CHANGELOG.md
+++ b/letsencrypt/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 6.5.0
+
 - Update certbot-dns-multi to 5.3.1, bug fixes and new DNS provider (see [lego's changelog](https://github.com/go-acme/lego/blob/v5.3.1/CHANGELOG.md) for details). 
 
 ## 6.4.0

--- a/letsencrypt/CHANGELOG.md
+++ b/letsencrypt/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 6.4.1
+## 6.5.0
 - Update certbot-dns-multi to 5.3.1, bug fixes and new DNS provider (see [lego's changelog](https://github.com/go-acme/lego/blob/v5.3.1/CHANGELOG.md) for details). 
 
 ## 6.4.0

--- a/letsencrypt/CHANGELOG.md
+++ b/letsencrypt/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 6.4.1
+- Update certbot-dns-multi to 5.3.1, bug fixes and new DNS provider (see [lego's changelog](https://github.com/go-acme/lego/blob/v5.3.1/CHANGELOG.md) for details). 
+
 ## 6.4.0
 
 - Update certbot-dns-multi to 5.2.2, adding several DNS providers (see [lego's changelog](https://github.com/go-acme/lego/blob/v5.2.2/CHANGELOG.md) for details). The following deprecated DNS providers have been removed: `googledomains`, `azure` (replaced by `azuredns`), `cloudxns`, `dnspod`, `brandit`, `iwantmyname`, `iij` (replaced by `iijdpf`).

--- a/letsencrypt/build.yaml
+++ b/letsencrypt/build.yaml
@@ -5,7 +5,7 @@ build_from:
 args:
   ACME_VERSION: 3.3.0
   # certbot-dns-multi replaces most individual DNS plugins using lego
-  CERTBOT_DNS_MULTI_VERSION: 5.2.2
+  CERTBOT_DNS_MULTI_VERSION: 5.3.1
   # Only legacy plugins are kept for providers not supported by lego:
   # gehirn, eurodns, noris
   CERTBOT_DNS_EURODNS_VERSION: 1.8.1

--- a/letsencrypt/config.yaml
+++ b/letsencrypt/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 6.4.0
+version: 6.4.1
 breaking_versions: [5.3.0, 6.0.0]
 slug: letsencrypt
 name: Let's Encrypt

--- a/letsencrypt/config.yaml
+++ b/letsencrypt/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 6.4.1
+version: 6.5.0
 breaking_versions: [5.3.0, 6.0.0]
 slug: letsencrypt
 name: Let's Encrypt


### PR DESCRIPTION
Lego fixed a bug relating to my DNS provider, hence the version update.

There are mostly minor bug fixes and the addition of a new dns provider since v5.2.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the DNS provider integration to version 5.3.1, adding support for a new provider.

* **Bug Fixes**
  * Included fixes delivered in the updated DNS provider integration.

* **Chores**
  * Released the Let’s Encrypt add-on as version 6.5.0.
  * Updated the documented release information to reflect the new version and integration updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->