### PR TITLE
ssh: update HA CLI to v5.3.1 and Alpine 3.24

### DIFF
--- a/ssh/CHANGELOG.md
+++ b/ssh/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 10.4.0
+
+- Update to Alpine 3.24
+- Update Home Assistant CLI to 5.3.1
+
 ## 10.3.0
 
 - Update Home Assistant CLI to 5.2.0

--- a/ssh/build.yaml
+++ b/ssh/build.yaml
@@ -1,6 +1,6 @@
 ---
 build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-base:3.23-2026.04.0
-  amd64: ghcr.io/home-assistant/amd64-base:3.23-2026.04.0
+  aarch64: ghcr.io/home-assistant/aarch64-base:3.24-2026.08.0
+  amd64: ghcr.io/home-assistant/amd64-base:3.24-2026.08.0
 args:
-  CLI_VERSION: 5.2.0
+  CLI_VERSION: 5.3.1

--- a/ssh/config.yaml
+++ b/ssh/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 10.3.0
+version: 10.4.0
 slug: ssh
 name: Terminal & SSH
 description: Allow logging in remotely to Home Assistant using SSH


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the SSH add-on to version 10.4.0.
  - Added support for Alpine 3.24.
  - Updated the Home Assistant CLI to version 5.3.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->