### PR TITLE
piper: Disable ONNX Runtime telemetry

### DIFF
--- a/piper/CHANGELOG.md
+++ b/piper/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.3.4
+
+- Disable ONNX Runtime telemetry: onnxruntime 1.29.0 (pulled in by the 2.3.3
+  rebuild) introduced telemetry on Linux which uploads usage events and a
+  persistent device identifier to a Microsoft endpoint by default
+
 ## 2.3.3
 
 - Add 2 new Italian voices (`it_IT-serena-high`, `it_IT-serena-medium`)

--- a/piper/Dockerfile
+++ b/piper/Dockerfile
@@ -29,8 +29,6 @@ RUN \
 
 ENV PATH="/usr/src/.venv/bin:$PATH"
 
-# ONNX Runtime 1.29.0 introduced telemetry on Linux, uploading usage events and
-# a persistent device identifier to a Microsoft endpoint by default. Opt out.
 ENV ORT_DISABLE_TELEMETRY=1
 WORKDIR /
 COPY rootfs /

--- a/piper/Dockerfile
+++ b/piper/Dockerfile
@@ -28,6 +28,10 @@ RUN \
     && rm -rf /var/lib/apt/lists/*
 
 ENV PATH="/usr/src/.venv/bin:$PATH"
+
+# ONNX Runtime 1.29.0 introduced telemetry on Linux, uploading usage events and
+# a persistent device identifier to a Microsoft endpoint by default. Opt out.
+ENV ORT_DISABLE_TELEMETRY=1
 WORKDIR /
 COPY rootfs /
 

--- a/piper/config.yaml
+++ b/piper/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 2.3.3
+version: 2.3.4
 slug: piper
 name: Piper
 description: Text-to-speech with Piper


### PR DESCRIPTION
## What this PR changes

Sets `ORT_DISABLE_TELEMETRY=1` in the Piper add-on image and bumps the version to 2.3.4.

## Background

As reported in #4767, upgrading the add-on from 2.3.2 to 2.3.3 caused a flood of DNS queries for `mobile.events.data.microsoft.com` on installations that block that domain (e.g. via Pi-hole), stopping again on downgrade.

The 2.3.3 source change was data-only, but the version bump triggered an image rebuild with unpinned Python dependencies, which moved `onnxruntime` from 1.28.0 to 1.29.0 (among others). ONNX Runtime 1.29.0 introduced telemetry on Linux (previously Windows-only ETW): a new `PosixTelemetry` provider built on Microsoft's 1DS SDK that uploads usage events and a **persistent device identifier** to `https://mobile.events.data.microsoft.com/OneCollector/1.0` by default. This is verifiable by comparing the published images: the endpoint string is present in `libonnxruntime.so.1.29.0` in the 2.3.3 image and absent from the 2.3.2 image. The observed "flood" is the 1DS uploader retrying against the blocked domain.

## Fix

`ORT_DISABLE_TELEMETRY=1` is the opt-out documented in ONNX Runtime's [Privacy.md](https://github.com/microsoft/onnxruntime/blob/v1.29.0/docs/Privacy.md): set before ONNX Runtime initializes, it prevents the uploader, events, and persistent device identifier from being created for the process lifetime.

## Follow-ups to consider (not in this PR)

- Pin `onnxruntime` (and other dependencies) so rebuilds stop silently pulling in behavior changes.
- Audit other add-ons/images bundling `onnxruntime` — any of them will gain the same phone-home behavior once rebuilt against ≥ 1.29.0. Setting `ORT_DISABLE_TELEMETRY=1` in the base images may be the more durable answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Privacy**
  * Disabled ONNX Runtime telemetry, preventing usage events and persistent device identifiers from being sent externally.
* **Documentation**
  * Added release notes documenting the telemetry change.
* **Chores**
  * Updated the Piper add-on version to 2.3.4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->