### PR TITLE
whisper: Pin inference stack and disable ONNX Runtime telemetry

### DIFF
--- a/whisper/CHANGELOG.md
+++ b/whisper/CHANGELOG.md
@@ -2,13 +2,12 @@
 
 ## 3.5.2
 
-- Pin the inference stack (`onnxruntime`, `faster-whisper`, `ctranslate2`,
-  `sherpa-onnx`) to the versions shipped in 3.5.1, so rebuilds no longer
+- Update and pin the inference stack: `onnxruntime` 1.29.0, `sherpa-onnx`
+  1.13.6, `faster-whisper` 1.2.1, `ctranslate2` 4.8.1 — rebuilds no longer
   silently change runtime behavior
-- Set `ORT_DISABLE_TELEMETRY=1` preventively: onnxruntime 1.29.0 introduced
-  telemetry on Linux which uploads usage events and a persistent device
-  identifier to a Microsoft endpoint by default (this add-on ships 1.28.0,
-  which is not affected)
+- Set `ORT_DISABLE_TELEMETRY=1`: onnxruntime 1.29.0 introduced telemetry on
+  Linux which uploads usage events and a persistent device identifier to a
+  Microsoft endpoint by default; it is disabled in this add-on
 
 ## 3.5.1.
 

--- a/whisper/CHANGELOG.md
+++ b/whisper/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 3.5.2
+
+- Pin the inference stack (`onnxruntime`, `faster-whisper`, `ctranslate2`,
+  `sherpa-onnx`) to the versions shipped in 3.5.1, so rebuilds no longer
+  silently change runtime behavior
+- Set `ORT_DISABLE_TELEMETRY=1` preventively: onnxruntime 1.29.0 introduced
+  telemetry on Linux which uploads usage events and a persistent device
+  identifier to a Microsoft endpoint by default (this add-on ships 1.28.0,
+  which is not affected)
+
 ## 3.5.1.
 
 - Upgrade base image to trixie

--- a/whisper/CHANGELOG.md
+++ b/whisper/CHANGELOG.md
@@ -2,12 +2,9 @@
 
 ## 3.5.2
 
-- Update and pin the inference stack: `onnxruntime` 1.29.0, `sherpa-onnx`
-  1.13.6, `faster-whisper` 1.2.1, `ctranslate2` 4.8.1 — rebuilds no longer
-  silently change runtime behavior
-- Set `ORT_DISABLE_TELEMETRY=1`: onnxruntime 1.29.0 introduced telemetry on
-  Linux which uploads usage events and a persistent device identifier to a
-  Microsoft endpoint by default; it is disabled in this add-on
+- Update speech recognition components to their latest versions
+- Disable ONNX Runtime telemetry: newer versions send usage data to a
+  Microsoft server by default, this app keeps it turned off
 
 ## 3.5.1.
 

--- a/whisper/Dockerfile
+++ b/whisper/Dockerfile
@@ -3,7 +3,16 @@ FROM ${BUILD_FROM}
 
 # Install Whisper
 WORKDIR /usr/src
-ARG WYOMING_WHISPER_VERSION
+ARG \
+    WYOMING_WHISPER_VERSION \
+    WYOMING_VERSION \
+    TRANSFORMERS_VERSION \
+    ONNX_ASR_VERSION \
+    ONNXRUNTIME_VERSION \
+    FASTER_WHISPER_VERSION \
+    CTRANSLATE2_VERSION \
+    SHERPA_ONNX_VERSION \
+    TORCH_VERSION
 
 RUN \
     apt-get update \
@@ -21,20 +30,20 @@ RUN \
         setuptools \
         wheel \
     && .venv/bin/pip3 install --no-cache-dir \
-        "wyoming[zeroconf]==1.9.0" \
+        "wyoming[zeroconf]==${WYOMING_VERSION}" \
         "wyoming-faster-whisper[sherpa] @ https://github.com/rhasspy/wyoming-faster-whisper/archive/refs/tags/v${WYOMING_WHISPER_VERSION}.tar.gz" \
-        'transformers==4.52.4' \
-        'onnx-asr[cpu,hub]==0.11.0' \
+        "transformers==${TRANSFORMERS_VERSION}" \
+        "onnx-asr[cpu,hub]==${ONNX_ASR_VERSION}" \
         'funasr>=1.1.0,<2' \
-        'onnxruntime==1.29.0' \
-        'faster-whisper==1.2.1' \
-        'ctranslate2==4.8.1' \
-        'sherpa-onnx==1.13.6' \
+        "onnxruntime==${ONNXRUNTIME_VERSION}" \
+        "faster-whisper==${FASTER_WHISPER_VERSION}" \
+        "ctranslate2==${CTRANSLATE2_VERSION}" \
+        "sherpa-onnx==${SHERPA_ONNX_VERSION}" \
     \
     && .venv/bin/pip3 install --no-cache-dir \
         --index-url 'https://download.pytorch.org/whl/cpu' \
-        'torch==2.7.1' \
-        'torchaudio==2.7.1' \
+        "torch==${TORCH_VERSION}" \
+        "torchaudio==${TORCH_VERSION}" \
     \
     && apt-get purge -y --auto-remove \
         build-essential \

--- a/whisper/Dockerfile
+++ b/whisper/Dockerfile
@@ -26,6 +26,10 @@ RUN \
         'transformers==4.52.4' \
         'onnx-asr[cpu,hub]==0.11.0' \
         'funasr>=1.1.0,<2' \
+        'onnxruntime==1.28.0' \
+        'faster-whisper==1.2.1' \
+        'ctranslate2==4.8.1' \
+        'sherpa-onnx==1.13.4' \
     \
     && .venv/bin/pip3 install --no-cache-dir \
         --index-url 'https://download.pytorch.org/whl/cpu' \
@@ -38,6 +42,11 @@ RUN \
     && rm -rf /var/lib/apt/lists/*
 
 ENV PATH="/usr/src/.venv/bin:$PATH"
+
+# ONNX Runtime 1.29.0 introduced telemetry on Linux, uploading usage events and
+# a persistent device identifier to a Microsoft endpoint by default. The pinned
+# 1.28.0 does not have it; keep the opt-out in place for future upgrades.
+ENV ORT_DISABLE_TELEMETRY=1
 WORKDIR /
 COPY rootfs /
 

--- a/whisper/Dockerfile
+++ b/whisper/Dockerfile
@@ -26,10 +26,10 @@ RUN \
         'transformers==4.52.4' \
         'onnx-asr[cpu,hub]==0.11.0' \
         'funasr>=1.1.0,<2' \
-        'onnxruntime==1.28.0' \
+        'onnxruntime==1.29.0' \
         'faster-whisper==1.2.1' \
         'ctranslate2==4.8.1' \
-        'sherpa-onnx==1.13.4' \
+        'sherpa-onnx==1.13.6' \
     \
     && .venv/bin/pip3 install --no-cache-dir \
         --index-url 'https://download.pytorch.org/whl/cpu' \
@@ -44,8 +44,7 @@ RUN \
 ENV PATH="/usr/src/.venv/bin:$PATH"
 
 # ONNX Runtime 1.29.0 introduced telemetry on Linux, uploading usage events and
-# a persistent device identifier to a Microsoft endpoint by default. The pinned
-# 1.28.0 does not have it; keep the opt-out in place for future upgrades.
+# a persistent device identifier to a Microsoft endpoint by default. Opt out.
 ENV ORT_DISABLE_TELEMETRY=1
 WORKDIR /
 COPY rootfs /

--- a/whisper/Dockerfile
+++ b/whisper/Dockerfile
@@ -52,8 +52,6 @@ RUN \
 
 ENV PATH="/usr/src/.venv/bin:$PATH"
 
-# ONNX Runtime 1.29.0 introduced telemetry on Linux, uploading usage events and
-# a persistent device identifier to a Microsoft endpoint by default. Opt out.
 ENV ORT_DISABLE_TELEMETRY=1
 WORKDIR /
 COPY rootfs /

--- a/whisper/Dockerfile
+++ b/whisper/Dockerfile
@@ -8,6 +8,7 @@ ARG \
     WYOMING_VERSION \
     TRANSFORMERS_VERSION \
     ONNX_ASR_VERSION \
+    FUNASR_VERSION \
     ONNXRUNTIME_VERSION \
     FASTER_WHISPER_VERSION \
     CTRANSLATE2_VERSION \
@@ -34,7 +35,7 @@ RUN \
         "wyoming-faster-whisper[sherpa] @ https://github.com/rhasspy/wyoming-faster-whisper/archive/refs/tags/v${WYOMING_WHISPER_VERSION}.tar.gz" \
         "transformers==${TRANSFORMERS_VERSION}" \
         "onnx-asr[cpu,hub]==${ONNX_ASR_VERSION}" \
-        'funasr>=1.1.0,<2' \
+        "funasr==${FUNASR_VERSION}" \
         "onnxruntime==${ONNXRUNTIME_VERSION}" \
         "faster-whisper==${FASTER_WHISPER_VERSION}" \
         "ctranslate2==${CTRANSLATE2_VERSION}" \

--- a/whisper/build.yaml
+++ b/whisper/build.yaml
@@ -8,6 +8,7 @@ args:
   # Must match the exact pins of wyoming-faster-whisper
   TRANSFORMERS_VERSION: 4.52.4
   ONNX_ASR_VERSION: 0.11.0
+  FUNASR_VERSION: 1.4.3
   ONNXRUNTIME_VERSION: 1.29.0
   FASTER_WHISPER_VERSION: 1.2.1
   CTRANSLATE2_VERSION: 4.8.1

--- a/whisper/build.yaml
+++ b/whisper/build.yaml
@@ -4,3 +4,12 @@ build_from:
   aarch64: ghcr.io/home-assistant/aarch64-base-debian:trixie
 args:
   WYOMING_WHISPER_VERSION: 3.5.0
+  WYOMING_VERSION: 1.9.0
+  # Must match the exact pins of wyoming-faster-whisper
+  TRANSFORMERS_VERSION: 4.52.4
+  ONNX_ASR_VERSION: 0.11.0
+  ONNXRUNTIME_VERSION: 1.29.0
+  FASTER_WHISPER_VERSION: 1.2.1
+  CTRANSLATE2_VERSION: 4.8.1
+  SHERPA_ONNX_VERSION: 1.13.6
+  TORCH_VERSION: 2.7.1

--- a/whisper/config.yaml
+++ b/whisper/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 3.5.1
+version: 3.5.2
 slug: whisper
 name: Whisper
 description: Speech-to-text with Whisper


### PR DESCRIPTION
## What this PR changes

- Pins the inference stack, updated to the latest releases: `onnxruntime==1.29.0`, `sherpa-onnx==1.13.6`, `faster-whisper==1.2.1`, `ctranslate2==4.8.1` (the latter two were already latest). These were previously unpinned transitive dependencies (via `onnx-asr[cpu]`, `wyoming-faster-whisper`), so every rebuild could silently change them.
- Sets `ORT_DISABLE_TELEMETRY=1`, the documented opt-out for ONNX Runtime telemetry.
- Bumps the app to 3.5.2 with a changelog entry.

## Background

Follow-up to #4791 (Piper). ONNX Runtime 1.29.0 introduced telemetry on Linux: a POSIX 1DS provider that uploads usage events and a persistent device identifier to `mobile.events.data.microsoft.com` by default.

**The currently released 3.5.1 image is *not* affected** — it ships onnxruntime 1.28.0, whose binaries contain no telemetry implementation or endpoint. However, because onnxruntime was unpinned, the next rebuild would have pulled in 1.29+ and silently started phoning home, exactly as happened to Piper in 2.3.3 (#4767). With `ORT_DISABLE_TELEMETRY=1` in place there is no reason to hold onnxruntime back, so this PR takes the upgrade to 1.29.0 deliberately, with telemetry disabled, and pins everything so future changes are explicit.

Notes:
- `transformers==4.52.4` and `onnx-asr==0.11.0` are exact pins required by upstream wyoming-faster-whisper 3.5.0, so they stay as-is.
- `sherpa-onnx` bundles its own statically-built ONNX Runtime copy; verified it contains no telemetry endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Released Whisper add-on version 3.5.2.
  - Updated speech-processing components to use compatible, configurable version settings.
  - Continued disabling ONNX Runtime telemetry by default.

- **Documentation**
  - Updated release notes to reference the latest inference-stack versions.
  - Simplified guidance about ONNX Runtime telemetry behavior and settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
