### PR TITLE
speech_to_phrase: Pin onnxruntime and disable its telemetry

### DIFF
--- a/speech_to_phrase/CHANGELOG.md
+++ b/speech_to_phrase/CHANGELOG.md
@@ -2,11 +2,9 @@
 
 ## 1.4.4
 
-- Update and pin `onnxruntime` to 1.29.0 (from 1.24.4) and `pysilero-vad` to
-  2.1.1, so rebuilds no longer silently change runtime behavior
-- Set `ORT_DISABLE_TELEMETRY=1`: onnxruntime 1.29.0 introduced telemetry on
-  Linux which uploads usage events and a persistent device identifier to a
-  Microsoft endpoint by default; it is disabled in this add-on
+- Update speech recognition components to their latest versions
+- Disable ONNX Runtime telemetry: newer versions send usage data to a
+  Microsoft server by default, this app keeps it turned off
 
 ## 1.4.3
 

--- a/speech_to_phrase/CHANGELOG.md
+++ b/speech_to_phrase/CHANGELOG.md
@@ -2,12 +2,11 @@
 
 ## 1.4.4
 
-- Pin `onnxruntime` and `pysilero-vad` to the versions shipped in 1.4.3, so
-  rebuilds no longer silently change runtime behavior
-- Set `ORT_DISABLE_TELEMETRY=1` preventively: onnxruntime 1.29.0 introduced
-  telemetry on Linux which uploads usage events and a persistent device
-  identifier to a Microsoft endpoint by default (this add-on ships 1.24.4,
-  which is not affected)
+- Update and pin `onnxruntime` to 1.29.0 (from 1.24.4) and `pysilero-vad` to
+  2.1.1, so rebuilds no longer silently change runtime behavior
+- Set `ORT_DISABLE_TELEMETRY=1`: onnxruntime 1.29.0 introduced telemetry on
+  Linux which uploads usage events and a persistent device identifier to a
+  Microsoft endpoint by default; it is disabled in this add-on
 
 ## 1.4.3
 

--- a/speech_to_phrase/CHANGELOG.md
+++ b/speech_to_phrase/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.4.4
+
+- Pin `onnxruntime` and `pysilero-vad` to the versions shipped in 1.4.3, so
+  rebuilds no longer silently change runtime behavior
+- Set `ORT_DISABLE_TELEMETRY=1` preventively: onnxruntime 1.29.0 introduced
+  telemetry on Linux which uploads usage events and a persistent device
+  identifier to a Microsoft endpoint by default (this add-on ships 1.24.4,
+  which is not affected)
+
 ## 1.4.3
 
 - Fix for empty names in HA 2026.4

--- a/speech_to_phrase/CHANGELOG.md
+++ b/speech_to_phrase/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.4.4
 
+- Upgrade base image to trixie
 - Update speech recognition components to their latest versions
 - Disable ONNX Runtime telemetry: newer versions send usage data to a
   Microsoft server by default, this app keeps it turned off

--- a/speech_to_phrase/Dockerfile
+++ b/speech_to_phrase/Dockerfile
@@ -41,8 +41,6 @@ RUN \
     && apt-get purge \
     && rm -rf /var/lib/apt/lists/*
 
-# ONNX Runtime 1.29.0 introduced telemetry on Linux, uploading usage events and
-# a persistent device identifier to a Microsoft endpoint by default. Opt out.
 ENV ORT_DISABLE_TELEMETRY=1
 
 WORKDIR /

--- a/speech_to_phrase/Dockerfile
+++ b/speech_to_phrase/Dockerfile
@@ -31,10 +31,17 @@ RUN \
     && python3 -m venv .venv \
     && .venv/bin/pip3 install --no-cache-dir \
         "speech-to-phrase @ https://github.com/OHF-Voice/speech-to-phrase/archive/refs/tags/v${SPEECH_TO_PHRASE_VERSION}.tar.gz" \
+        'onnxruntime==1.24.4' \
+        'pysilero-vad==2.1.1' \
     && apt-get remove --yes build-essential \
     && apt-get autoclean \
     && apt-get purge \
     && rm -rf /var/lib/apt/lists/*
+
+# ONNX Runtime 1.29.0 introduced telemetry on Linux, uploading usage events and
+# a persistent device identifier to a Microsoft endpoint by default. The pinned
+# 1.24.4 does not have it; keep the opt-out in place for future upgrades.
+ENV ORT_DISABLE_TELEMETRY=1
 
 WORKDIR /
 COPY rootfs /

--- a/speech_to_phrase/Dockerfile
+++ b/speech_to_phrase/Dockerfile
@@ -6,7 +6,10 @@ ARG BUILD_ARCH
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Install speech-to-phrase
-ARG SPEECH_TO_PHRASE_VERSION
+ARG \
+    SPEECH_TO_PHRASE_VERSION \
+    ONNXRUNTIME_VERSION \
+    PYSILERO_VAD_VERSION
 WORKDIR /usr/src
 
 RUN mkdir -p ./tools
@@ -31,8 +34,8 @@ RUN \
     && python3 -m venv .venv \
     && .venv/bin/pip3 install --no-cache-dir \
         "speech-to-phrase @ https://github.com/OHF-Voice/speech-to-phrase/archive/refs/tags/v${SPEECH_TO_PHRASE_VERSION}.tar.gz" \
-        'onnxruntime==1.29.0' \
-        'pysilero-vad==2.1.1' \
+        "onnxruntime==${ONNXRUNTIME_VERSION}" \
+        "pysilero-vad==${PYSILERO_VAD_VERSION}" \
     && apt-get remove --yes build-essential \
     && apt-get autoclean \
     && apt-get purge \

--- a/speech_to_phrase/Dockerfile
+++ b/speech_to_phrase/Dockerfile
@@ -31,7 +31,7 @@ RUN \
     && python3 -m venv .venv \
     && .venv/bin/pip3 install --no-cache-dir \
         "speech-to-phrase @ https://github.com/OHF-Voice/speech-to-phrase/archive/refs/tags/v${SPEECH_TO_PHRASE_VERSION}.tar.gz" \
-        'onnxruntime==1.24.4' \
+        'onnxruntime==1.29.0' \
         'pysilero-vad==2.1.1' \
     && apt-get remove --yes build-essential \
     && apt-get autoclean \
@@ -39,8 +39,7 @@ RUN \
     && rm -rf /var/lib/apt/lists/*
 
 # ONNX Runtime 1.29.0 introduced telemetry on Linux, uploading usage events and
-# a persistent device identifier to a Microsoft endpoint by default. The pinned
-# 1.24.4 does not have it; keep the opt-out in place for future upgrades.
+# a persistent device identifier to a Microsoft endpoint by default. Opt out.
 ENV ORT_DISABLE_TELEMETRY=1
 
 WORKDIR /

--- a/speech_to_phrase/build.yaml
+++ b/speech_to_phrase/build.yaml
@@ -4,3 +4,5 @@ build_from:
   aarch64: ghcr.io/home-assistant/aarch64-base-debian:bookworm
 args:
   SPEECH_TO_PHRASE_VERSION: 1.4.3
+  ONNXRUNTIME_VERSION: 1.29.0
+  PYSILERO_VAD_VERSION: 2.1.1

--- a/speech_to_phrase/build.yaml
+++ b/speech_to_phrase/build.yaml
@@ -1,7 +1,7 @@
 ---
 build_from:
-  amd64: ghcr.io/home-assistant/amd64-base-debian:bookworm
-  aarch64: ghcr.io/home-assistant/aarch64-base-debian:bookworm
+  amd64: ghcr.io/home-assistant/amd64-base-debian:trixie
+  aarch64: ghcr.io/home-assistant/aarch64-base-debian:trixie
 args:
   SPEECH_TO_PHRASE_VERSION: 1.4.3
   ONNXRUNTIME_VERSION: 1.29.0

--- a/speech_to_phrase/config.yaml
+++ b/speech_to_phrase/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 1.4.3
+version: 1.4.4
 slug: speech-to-phrase
 name: Speech-to-Phrase
 description: Fast and personalized local speech-to-text


### PR DESCRIPTION
## What this PR changes

- Pins `onnxruntime==1.29.0` (updated from the 1.24.4 in the current image — latest release) and `pysilero-vad==2.1.1` (already the latest 2.x allowed by speech-to-phrase's `<3` constraint). Both were previously unpinned transitive dependencies, so every rebuild could silently change them.
- Sets `ORT_DISABLE_TELEMETRY=1`, the documented opt-out for ONNX Runtime telemetry.
- Bumps the app to 1.4.4 with a changelog entry.

## Background

Follow-up to #4791 (Piper). ONNX Runtime 1.29.0 introduced telemetry on Linux: a POSIX 1DS provider that uploads usage events and a persistent device identifier to `mobile.events.data.microsoft.com` by default.

**The currently released 1.4.3 image is *not* affected** — verified both the amd64 and aarch64 images ship onnxruntime 1.24.4, whose binaries contain no telemetry implementation, Microsoft 1DS SDK symbols, or telemetry endpoint (the POSIX telemetry code first appears in 1.29.0). However, because onnxruntime was unpinned, the next rebuild would have jumped straight to 1.29+ and silently started phoning home, exactly as happened to Piper in 2.3.3 (#4767). With `ORT_DISABLE_TELEMETRY=1` in place there is no reason to hold onnxruntime back, so this PR takes the upgrade to 1.29.0 deliberately, with telemetry disabled, and pins it so future changes are explicit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Updated the add-on to version 1.4.4.
  * Updated speech recognition components, including ONNX Runtime and Silero VAD.
  * Improved version configuration during add-on builds.
  * Continued disabling ONNX Runtime telemetry by default.

* **Documentation**
  * Refreshed changelog information to reflect speech recognition updates and telemetry settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
