### PR TITLE
openthread_border_router: Fix upstream DNS resolution for Thread devices

### DIFF
--- a/openthread_border_router/CHANGELOG.md
+++ b/openthread_border_router/CHANGELOG.md
@@ -2,10 +2,7 @@
 
 ## 3.1.2
 
-- Fix upstream DNS resolution (and thus DNS64 name resolution) for Thread
-  devices: no longer bind the upstream DNS resolver socket to the infra
-  interface, so queries can reach the Supervisor DNS again (fixes #3947,
-  regression introduced in 2.12.0)
+- Fix upstream DNS/DNS64 resolution for Thread devices by not binding the upstream DNS resolver socket to the infra interface (fixes #3947, regression since 2.12.0)
 
 ## 3.1.1
 

--- a/openthread_border_router/CHANGELOG.md
+++ b/openthread_border_router/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 3.1.2
+
+- Fix upstream DNS resolution (and thus DNS64 name resolution) for Thread
+  devices: no longer bind the upstream DNS resolver socket to the infra
+  interface, so queries can reach the Supervisor DNS again (fixes #3947,
+  regression introduced in 2.12.0)
+
 ## 3.1.1
 
 - Bump beta to OTBR POSIX version d83ddc62 to test ePSKc / Thread 1.4 Credentials Sharing support ahead of the upstream `release-v2026.09.0` tag

--- a/openthread_border_router/config.yaml
+++ b/openthread_border_router/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 3.1.1
+version: 3.1.2
 breaking_versions: [3.0.0]
 slug: openthread_border_router
 name: OpenThread Border Router

--- a/openthread_border_router/openthread-core-ha-config-posix.h
+++ b/openthread_border_router/openthread-core-ha-config-posix.h
@@ -83,4 +83,18 @@
  */
 #define OPENTHREAD_CONFIG_MULTICAST_DNS_AUTO_ENABLE_ON_INFRA_IF 0
 
+/**
+ * @def OPENTHREAD_POSIX_CONFIG_UPSTREAM_DNS_BIND_TO_INFRA_NETIF
+ *
+ * The app runs with host networking; the upstream DNS server from
+ * /etc/resolv.conf (Supervisor CoreDNS, 172.30.32.3) is only reachable
+ * through the hassio bridge, not through the infra interface. Binding the
+ * upstream DNS resolver socket to the infra interface (OpenThread default
+ * since commit d88b63d19, first shipped in app 2.12.0) misroutes those
+ * queries out the physical interface, breaking upstream DNS/DNS64 for
+ * Thread devices. Disable the bind so queries follow the host routing
+ * table (see home-assistant/addons#3947).
+ */
+#define OPENTHREAD_POSIX_CONFIG_UPSTREAM_DNS_BIND_TO_INFRA_NETIF 0
+
 #endif /* OPENTHREAD_CORE_HA_CONFIG_POSIX_H_ */


### PR DESCRIPTION
## Summary

Fixes upstream DNS resolution (and with it NAT64/DNS64 name resolution) for Thread devices, broken since add-on **2.12.0**. Fixes #3947.

## Root cause

The 2.12.0 OTBR bump (`ff7227ea` → `b041fa52`) pulled in OpenThread commit `d88b63d19` (openthread/openthread#10864), which binds the upstream DNS resolver's UDP sockets to the infrastructure interface via `SO_BINDTODEVICE`. The add-on runs with host networking, and its `/etc/resolv.conf` points at the Supervisor DNS (`172.30.32.3`) — reachable only through the `hassio` bridge, not through the infra interface (`end0`/`eth0`). With the socket bound, the kernel routes the query out the physical interface via the default route, where it goes unanswered. Result: `DnssdServer: Upstream query transaction N closed: ResponseTimeout.` for every upstream query from a Thread device.

## Fix

Set `OPENTHREAD_POSIX_CONFIG_UPSTREAM_DNS_BIND_TO_INFRA_NETIF 0` in the project config header, restoring the pre-2.12.0 behavior (queries follow the host routing table and reach the Supervisor DNS on the bridge). A behavioral fix has been proposed upstream in openthread/openthread#13545 (bind only RDNSS-discovered on-link servers, never host-scoped resolv.conf servers); once merged and picked up, this define can be dropped.

Verified on a Home Assistant Yellow: a Thread client resolving `example.com` via the border router now gets DNS64-synthesized answers again; the query and response are visible on the `hassio` bridge toward `172.30.32.3`.

## Wrinkles worth knowing (why this was hard to reproduce)

- **RDNSS masks the bug on recent versions:** since OpenThread #11342 (March 2025, in current add-on versions) the resolver also queries RDNSS servers learned from router advertisements on the infra link. Those are on-link and work despite the binding — so on networks whose router advertises RDNSS (check with `ot-ctl br rdnsstable`), upstream DNS appears healthy even unpatched. IPv4-only networks (no RDNSS) are always affected, which matches the reporters in #3947.
- **Testing from the BR console is not valid:** `ot-ctl dns resolve4` on the border router itself never reached the BR's own DNS-SD server in our testing, independent of this bug (it failed the same way on known-good 2.11.x, see https://github.com/orgs/openthread/discussions/9782). Only queries from an actual Thread device (or a TREL-connected OT CLI node) exercise the fixed path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed upstream DNS resolution for Thread devices using DNS64.
  * DNS queries can now reach Supervisor DNS correctly in host-networked deployments.

* **Chores**
  * Updated the OpenThread Border Router add-on to version 3.1.2.
  * Added release notes documenting the DNS resolution fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->