### PR TITLE
Fix backup process in git_pull to include hidden files

### DIFF
--- a/git_pull/CHANGELOG.md
+++ b/git_pull/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 9.0.2
+
+- Fix `.storage/` and other hidden files/directories being silently dropped from
+  the pre-clone backup (they were never restored after the initial clone into
+  an existing `/config`, because `cp -rf /config/*` does **not** match dotfiles).
+  Use `cp -rf /config/.` instead, which copies directory contents including
+  hidden entries.
+
 ## 9.0.1
 
 - Replace eval+extglob with find for restoring non-YAML files after clone

--- a/git_pull/config.yaml
+++ b/git_pull/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 9.0.1
+version: 9.0.2
 slug: git_pull
 name: Git pull
 description: Simple git pull to update the local configuration

--- a/git_pull/data/run.sh
+++ b/git_pull/data/run.sh
@@ -47,7 +47,7 @@ function git-clone {
     bashio::log.info "[Info] Backup configuration to $BACKUP_LOCATION"
 
     mkdir "${BACKUP_LOCATION}" || bashio::exit.nok "[Error] Creation of backup directory failed"
-    cp -rf /config/* "${BACKUP_LOCATION}" || bashio::exit.nok "[Error] Copy files to backup directory failed"
+    cp -rf /config/. "${BACKUP_LOCATION}/" || bashio::exit.nok "[Error] Copy files to backup directory failed"
 
     # remove config folder content
     rm -rf /config/{,.[!.],..?}* || bashio::exit.nok "[Error] Clearing /config failed"


### PR DESCRIPTION
## Summary

The pre-clone backup in `git-clone` (used on the *first* run, when `/config`
isn't a git repo yet) silently drops hidden files and directories, most
importantly **`.storage/`**, which holds auth/refresh tokens, the entity/device/
area registries, and any Lovelace dashboards or helpers created through the
UI. On a fresh clone into an existing `/config`, those are wiped and never
restored, because the backup step never captured them in the first place.

## Root cause

```sh
cp -rf /config/* "${BACKUP_LOCATION}" || ...
```

`/config/*` is a shell glob and does **not** match dotfiles/dot-directories
(no `dotglob` is set). The very next step,

```sh
rm -rf /config/{,.[!.],..?}* || ...
```

*does* match dotfiles — so `.storage/`, `.cloud/`, `.cache/`, etc. get
deleted from `/config` without ever having been copied to
`$BACKUP_LOCATION`. The later restore step (`find "${BACKUP_LOCATION}" ...`)
can't bring back what was never backed up.

## Prior history

This was reported in #3547 and believed fixed by #4356 ("Fix data loss of
`.storage` and unrelated local files on fresh clone"), whose description
says it "Enables dotglob to preserve hidden directories like `.storage/`".
Looking at the diff that actually merged, though, #4356 only fixed the
restore-side line (which had a genuine, separate, and previously
completely broken syntax — `cp "${BACKUP_LOCATION}" "!(*.yaml)"` — so
*nothing* was restored before that fix, not even regular files) and an
unrelated `OLD_COMMIT` unbound-variable bug. The backup-side line was never
touched, so the dotfile data-loss the title/description describe is still
present on `master` today.

## Fix

```diff
-    cp -rf /config/* "${BACKUP_LOCATION}" || bashio::exit.nok "[Error] Copy files to backup directory failed"
+    cp -rf /config/. "${BACKUP_LOCATION}/" || bashio::exit.nok "[Error] Copy files to backup directory failed"
```

`cp -rf src/. dest/` copies a directory's contents, hidden entries
included, without relying on a shell glob or an extglob/dotglob shell
option — intentionally avoiding the kind of shell-option-dependent
approach that seems to have gotten lost in #4356's revisions. The restore
step (`find ... -mindepth 1 ...`) already handles dotfiles correctly once
they're actually present in the backup, so no change is needed there.

Bumped to 9.0.2 with a changelog entry, following this add-on's existing
convention.

## Testing

Verified manually: with the original line, backing up a directory
containing a `.storage/` subdirectory produces a backup missing
`.storage/`; with the fix, `.storage/` (and its contents) is present in
the backup.

---

**Disclaimer:** This PR is Co-Authored-By Claude Sonnet 5 but fully reviewed and approved by me, and I take full responsibility for the changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pre-clone backups silently excluding hidden files and directories, such as `.storage/`.
  * Existing configuration contents, including hidden entries, are now fully restored after cloning.

* **Chores**
  * Updated the add-on version to 9.0.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->