### PR TITLE
Git pull fix gitdir from being restored

### DIFF
--- a/git_pull/CHANGELOG.md
+++ b/git_pull/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 9.0.3
+
+- Fix `git-clone`'s restore-after-clone step copying a stale/corrupt `.git`
+  directory from the pre-clone backup into the freshly cloned repository,
+  which could corrupt the new clone's git metadata. `.git` is now excluded
+  from that restore step, same as `*.yaml`/`*.yml`.
+
 ## 9.0.2
 
 - Fix `.storage/` and other hidden files/directories being silently dropped from

--- a/git_pull/config.yaml
+++ b/git_pull/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 9.0.2
+version: 9.0.3
 slug: git_pull
 name: Git pull
 description: Simple git pull to update the local configuration

--- a/git_pull/data/run.sh
+++ b/git_pull/data/run.sh
@@ -56,8 +56,8 @@ function git-clone {
     bashio::log.info "[Info] Start git clone"
     git clone "$REPOSITORY" /config || bashio::exit.nok "[Error] Git clone failed"
 
-    # try to copy non-yaml files back
-    find "${BACKUP_LOCATION}" -maxdepth 1 -mindepth 1 ! -name "*.yaml" ! -name "*.yml" -exec cp -r {} /config/ \; 2>/dev/null || true
+    # try to copy non-yaml files back (also excluding '.git' as it can corrupt the new repository)
+    find "${BACKUP_LOCATION}" -maxdepth 1 -mindepth 1 ! -name "*.yaml" ! -name "*.yml" ! -name ".git" -exec cp -r {} /config/ \; 2>/dev/null || true
 
     # try to copy secrets file back
     cp "${BACKUP_LOCATION}/secrets.yaml" /config 2>/dev/null || true


### PR DESCRIPTION
## Summary

Follow-up to #4797 (merged as 9.0.2). `git-clone`'s restore-after-clone step
can copy a stale/corrupt top-level `.git` directory from the pre-clone
backup into the freshly cloned repository, merging garbage refs/objects/
index state into the new clone's git metadata.

## Root cause

`git-clone` only runs when `git rev-parse --is-inside-work-tree` already
rejects `/config` — i.e. `/config` may contain a leftover, stale, or
corrupt `.git` directory from a previous failed/interrupted run. The
pre-clone backup copies all of `/config`, dotfiles included (that's the
fix from #4797):

```sh
cp -rf /config/. "${BACKUP_LOCATION}/" || ...
```

...so that stale `.git` ends up in `$BACKUP_LOCATION` too. After the fresh
`git clone`, the restore step brings non-YAML files back:

```sh
find "${BACKUP_LOCATION}" -maxdepth 1 -mindepth 1 ! -name "*.yaml" ! -name "*.yml" -exec cp -r {} /config/ \;
```

`find` lists dotfiles by default (unlike a shell glob), and `.git` isn't
excluded — so it matches, and `cp -r` merges the old `.git`'s contents
straight into the newly cloned repository's `.git`, potentially corrupting
it (e.g. stale `HEAD`/refs, mismatched index, leftover objects from a
different remote/history).

## Fix

```diff
-    find "${BACKUP_LOCATION}" -maxdepth 1 -mindepth 1 ! -name "*.yaml" ! -name "*.yml" -exec cp -r {} /config/ \; 2>/dev/null || true
+    find "${BACKUP_LOCATION}" -maxdepth 1 -mindepth 1 ! -name "*.yaml" ! -name "*.yml" ! -name ".git" -exec cp -r {} /config/ \; 2>/dev/null || true
```

Excludes `.git` from the restore step, the same way `*.yaml`/`*.yml` are
already excluded. Every other hidden entry (`.storage/`, `.HA_VERSION`,
etc.) is still restored as before — only the old repository metadata is
now skipped, letting the fresh `git clone` own `.git` entirely.

Bumped to 9.0.3 with a changelog entry, following this add-on's existing
convention.

## Testing

Verified manually: populated `$BACKUP_LOCATION` with a `.git` directory
containing a different ref/object than the freshly cloned repo; with the
original line, the restore step overwrote/merged files into the new
`.git`; with the fix, `.git` is skipped and the freshly cloned repository
is left untouched. All other dotfiles (e.g. a test `.storage/`) are still
restored correctly.

---

**Disclaimer:** This PR is Co-Authored-By Claude Sonnet 5 but fully reviewed and approved by me, and I take full responsibility for the changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented previous Git metadata from being restored during repository cloning.
  - Ensures fresh clones retain their own valid Git history and configuration.

- **Chores**
  - Updated the Git pull add-on version to 9.0.3.
  - Added release notes documenting the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->