### PR TITLE
openthread_border_router: Retry unavailable network RCPs

### DIFF
--- a/openthread_border_router/CHANGELOG.md
+++ b/openthread_border_router/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.1.2
+
+- Keep retrying unavailable network RCPs without crashing the app
+
 ## 3.1.1
 
 - Bump beta to OTBR POSIX version d83ddc62 to test ePSKc / Thread 1.4 Credentials Sharing support ahead of the upstream `release-v2026.09.0` tag

--- a/openthread_border_router/config.yaml
+++ b/openthread_border_router/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 3.1.1
+version: 3.1.2
 breaking_versions: [3.0.0]
 slug: openthread_border_router
 name: OpenThread Border Router

--- a/openthread_border_router/rootfs/etc/s6-overlay/s6-rc.d/socat-otbr-tcp/run
+++ b/openthread_border_router/rootfs/etc/s6-overlay/s6-rc.d/socat-otbr-tcp/run
@@ -14,5 +14,6 @@ bashio::log.info "Starting socat TCP client for OTBR daemon..."
 # network RCP is reachable. Keep both connection attempts and readiness checks
 # running during an outage.
 exec s6-notifyoncheck -d -s 300 -w 300 -n 0 \
-    "/usr/bin/socat" -d "tcp:${network_device},forever,interval=10" \
+    "/usr/bin/socat" -d \
+    "tcp:${network_device},connect-timeout=10,forever,interval=10" \
     pty,raw,echo=0,link=/tmp/ttyOTBR,ignoreeof

--- a/openthread_border_router/rootfs/etc/s6-overlay/s6-rc.d/socat-otbr-tcp/run
+++ b/openthread_border_router/rootfs/etc/s6-overlay/s6-rc.d/socat-otbr-tcp/run
@@ -10,6 +10,9 @@ declare network_device
 network_device=$(bashio::config 'network_device')
 
 bashio::log.info "Starting socat TCP client for OTBR daemon..."
-exec s6-notifyoncheck -d -s 300 -w 300 \
-    "/usr/bin/socat" -d pty,raw,echo=0,link=/tmp/ttyOTBR,ignoreeof \
-    "tcp:${network_device}"
+# Connect before creating the PTY so readiness is only reported when the
+# network RCP is reachable. Keep both connection attempts and readiness checks
+# running during an outage.
+exec s6-notifyoncheck -d -s 300 -w 300 -n 0 \
+    "/usr/bin/socat" -d "tcp:${network_device},forever,interval=10" \
+    pty,raw,echo=0,link=/tmp/ttyOTBR,ignoreeof


### PR DESCRIPTION
## Summary

- Open the network RCP TCP connection before creating the pseudo-terminal.
- Retry TCP connection attempts and s6 readiness checks indefinitely during an outage.
- Bump the app version to 3.1.2 and add a changelog entry.

## Problem

For a configured network_device, socat currently creates /tmp/ttyOTBR before attempting the TCP connection. The readiness check therefore succeeds even when the remote RCP is unavailable. OTBR startup continues, the settings migration probes the disconnected pseudo-terminal, and the app exits. Repeated watchdog restarts can then exhaust the Supervisor restart limit before the network endpoint recovers.

Socat opens its addresses in order. Opening TCP first and retrying there keeps the pseudo-terminal absent until the RCP endpoint is reachable. The unlimited readiness check allows the dependent otbr-agent service to start after connectivity returns without restarting the container repeatedly.

## Validation

- ShellCheck passed for the changed run script.
- YAML parsing and git diff checks passed.
- An isolated A/B test using the official OTBR 3.1.1 image confirmed that the old address order exposes the pseudo-terminal before TCP connects, while the updated order withholds it during an outage and creates it after a delayed endpoint becomes reachable.

Fixes #4612.
Addresses the endpoint-unavailable case in #4784.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when the network RCP is unavailable by retrying the connection every 10 seconds instead of stopping.
  * Prevented the add-on from crashing during temporary RCP outages.

* **Chores**
  * Updated the OpenThread Border Router add-on to version 3.1.2.
  * Documented the reliability improvement in the changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->